### PR TITLE
Add test that makes sure text consts are in sync

### DIFF
--- a/RunLayoutTests.html
+++ b/RunLayoutTests.html
@@ -18,5 +18,6 @@
 <body>
   <script type="text/javascript" src="src/Layout-test-utils.js"></script>
   <script type="text/javascript" src="src/__tests__/Layout-test.js"></script>
+  <script type="text/javascript" src="src/__tests__/Layout-consts-test.js"></script>
 </body>
 </html>

--- a/src/Layout-test-utils.js
+++ b/src/Layout-test-utils.js
@@ -269,15 +269,17 @@ var layoutTestUtils = (function() {
     big: 'loooooooooong with space',
   };
 
+  var preDefinedTextSizes = {
+    smallWidth: 34.671875,
+    smallHeight: 18,
+    bigWidth: 172.421875,
+    bigHeight: 36,
+    bigMinWidth: 100.453125
+  };
+
   var textSizes;
   if (typeof require === 'function') {
-    textSizes =  {
-      smallWidth: 34.671875,
-      smallHeight: 18,
-      bigWidth: 172.421875,
-      bigHeight: 36,
-      bigMinWidth: 100.453125
-    };
+    textSizes = preDefinedTextSizes;
   } else {
     textSizes = {
       smallWidth: measureTextSizes(texts.small, 0).width,
@@ -291,6 +293,7 @@ var layoutTestUtils = (function() {
   return {
     texts: texts,
     textSizes: textSizes,
+    preDefinedTextSizes: preDefinedTextSizes,
     testLayout: function(node, expectedLayout) {
       var layout = computeCSSLayout(node);
       var domLayout = computeDOMLayout(node);
@@ -333,7 +336,7 @@ var layoutTestUtils = (function() {
       fn.toString = function() { return text; };
       return fn;
     }
-  }
+  };
 })();
 
 if (typeof module !== 'undefined') {

--- a/src/__tests__/Layout-consts-test.js
+++ b/src/__tests__/Layout-consts-test.js
@@ -1,0 +1,14 @@
+/* globals layoutTestUtils */
+
+var textSizes = layoutTestUtils.textSizes;
+var preDefinedTextSizes = layoutTestUtils.preDefinedTextSizes;
+
+describe('Layout tests consts', function() {
+  it('keeps browser text measurements in sync with predefined consts', function() {
+    expect(preDefinedTextSizes).toEqual(
+      textSizes,
+      'Looks like browser has updated its text measurements functions. ' +
+      'You need to update `preDefinedTextSizes` in Layout-test-utils.js'
+    );
+  });
+});


### PR DESCRIPTION
RFC. This makes sure we are always in sync with the browser consts if we run tests in browser.

However I think we should use text measurements only for random tests generator and update consts when they change.
