### PR TITLE
Update tests to expect align-items: stretch as default instead of flex-start

### DIFF
--- a/src/Layout.c
+++ b/src/Layout.c
@@ -18,7 +18,7 @@ static bool eq(float a, float b) {
 }
 
 void init_css_node(css_node_t *node) {
-  node->style.align_items = CSS_ALIGN_FLEX_START;
+  node->style.align_items = CSS_ALIGN_STRETCH;
 
   // Some of the fields default to undefined and not 0
   node->style.dimensions[CSS_WIDTH] = CSS_UNDEFINED;

--- a/src/__tests__/Layout-test.c
+++ b/src/__tests__/Layout-test.c
@@ -2752,7 +2752,7 @@ int main()
         node_1 = node_0->get_child(node_0->context, 0);
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
-        node_1->layout.dimensions[CSS_WIDTH] = 100.453125;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
         node_1->layout.dimensions[CSS_HEIGHT] = 36;
       }
     }
@@ -2800,7 +2800,7 @@ int main()
         node_1 = node_0->get_child(node_0->context, 0);
         node_1->layout.position[CSS_TOP] = 20;
         node_1->layout.position[CSS_LEFT] = 20;
-        node_1->layout.dimensions[CSS_WIDTH] = 100.453125;
+        node_1->layout.dimensions[CSS_WIDTH] = 60;
         node_1->layout.dimensions[CSS_HEIGHT] = 36;
         init_css_node_children(node_1, 1);
         {
@@ -2808,7 +2808,7 @@ int main()
           node_2 = node_1->get_child(node_1->context, 0);
           node_2->layout.position[CSS_TOP] = 0;
           node_2->layout.position[CSS_LEFT] = 0;
-          node_2->layout.dimensions[CSS_WIDTH] = 100.453125;
+          node_2->layout.dimensions[CSS_WIDTH] = 60;
           node_2->layout.dimensions[CSS_HEIGHT] = 36;
         }
       }
@@ -3069,12 +3069,12 @@ int main()
         node_1 = node_0->get_child(node_0->context, 0);
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
-        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
         node_1->layout.dimensions[CSS_HEIGHT] = 25;
         node_1 = node_0->get_child(node_0->context, 1);
         node_1->layout.position[CSS_TOP] = 25;
         node_1->layout.position[CSS_LEFT] = 0;
-        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
         node_1->layout.dimensions[CSS_HEIGHT] = 75;
       }
     }
@@ -3110,12 +3110,12 @@ int main()
         node_1 = node_0->get_child(node_0->context, 0);
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
-        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
         node_1->layout.dimensions[CSS_HEIGHT] = 0;
         node_1 = node_0->get_child(node_0->context, 1);
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
-        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
         node_1->layout.dimensions[CSS_HEIGHT] = 0;
       }
     }

--- a/src/__tests__/Layout-test.js
+++ b/src/__tests__/Layout-test.js
@@ -831,7 +831,7 @@ describe('Layout', function() {
         {style: {measure: text(texts.big)}}
       ]},
       {width: 100, height: textSizes.bigHeight, top: 0, left: 0, children: [
-        {width: textSizes.bigMinWidth, height: textSizes.bigHeight, top: 0, left: 0}
+        {width: 100, height: textSizes.bigHeight, top: 0, left: 0}
       ]}
     );
   });
@@ -844,8 +844,8 @@ describe('Layout', function() {
         ]}
       ]},
       {width: 100, height: 40 + textSizes.bigHeight, top: 0, left: 0, children: [
-        {width: textSizes.bigMinWidth, height: textSizes.bigHeight, top: 20, left: 20, children: [
-          {width: textSizes.bigMinWidth, height: textSizes.bigHeight, top: 0, left: 0}
+        {width: 60, height: textSizes.bigHeight, top: 20, left: 20, children: [
+          {width: 60, height: textSizes.bigHeight, top: 0, left: 0}
         ]}
       ]}
     );
@@ -923,8 +923,8 @@ describe('Layout', function() {
         {style: {flex: 7.5}}
       ]},
       {width: 100, height: 100, top: 0, left: 0, children: [
-        {width: 0, height: 25, top: 0, left: 0},
-        {width: 0, height: 75, top: 25, left: 0},
+        {width: 100, height: 25, top: 0, left: 0},
+        {width: 100, height: 75, top: 25, left: 0},
       ]}
     );
   });
@@ -936,8 +936,8 @@ describe('Layout', function() {
         {style: {flex: 0}}
       ]},
       {width: 100, height: 100, top: 0, left: 0, children: [
-        {width: 0, height: 0, top: 0, left: 0},
-        {width: 0, height: 0, top: 0, left: 0},
+        {width: 100, height: 0, top: 0, left: 0},
+        {width: 100, height: 0, top: 0, left: 0},
       ]}
     );
   });

--- a/src/java/src/com/facebook/csslayout/CSSStyle.java
+++ b/src/java/src/com/facebook/csslayout/CSSStyle.java
@@ -7,7 +7,7 @@ public class CSSStyle {
 
   public CSSFlexDirection flexDirection = CSSFlexDirection.COLUMN;
   public CSSJustify justifyContent = CSSJustify.FLEX_START;
-  public CSSAlign alignItems = CSSAlign.FLEX_START;
+  public CSSAlign alignItems = CSSAlign.STRETCH;
   public CSSAlign alignSelf = CSSAlign.AUTO;
   public CSSPositionType positionType = CSSPositionType.RELATIVE;
   public float flex;

--- a/src/java/tests/com/facebook/csslayout/LayoutEngineTest.java
+++ b/src/java/tests/com/facebook/csslayout/LayoutEngineTest.java
@@ -2967,7 +2967,7 @@ public class LayoutEngineTest {
         node_1 = node_0.getChildAt(0);
         node_1.layout.y = 0;
         node_1.layout.x = 0;
-        node_1.layout.width = 100.453125f;
+        node_1.layout.width = 100;
         node_1.layout.height = 36;
       }
     }
@@ -3017,7 +3017,7 @@ public class LayoutEngineTest {
         node_1 = node_0.getChildAt(0);
         node_1.layout.y = 20;
         node_1.layout.x = 20;
-        node_1.layout.width = 100.453125f;
+        node_1.layout.width = 60;
         node_1.layout.height = 36;
         addChildren(node_1, 1);
         {
@@ -3025,7 +3025,7 @@ public class LayoutEngineTest {
           node_2 = node_1.getChildAt(0);
           node_2.layout.y = 0;
           node_2.layout.x = 0;
-          node_2.layout.width = 100.453125f;
+          node_2.layout.width = 60;
           node_2.layout.height = 36;
         }
       }
@@ -3298,12 +3298,12 @@ public class LayoutEngineTest {
         node_1 = node_0.getChildAt(0);
         node_1.layout.y = 0;
         node_1.layout.x = 0;
-        node_1.layout.width = 0;
+        node_1.layout.width = 100;
         node_1.layout.height = 25;
         node_1 = node_0.getChildAt(1);
         node_1.layout.y = 25;
         node_1.layout.x = 0;
-        node_1.layout.width = 0;
+        node_1.layout.width = 100;
         node_1.layout.height = 75;
       }
     }
@@ -3341,12 +3341,12 @@ public class LayoutEngineTest {
         node_1 = node_0.getChildAt(0);
         node_1.layout.y = 0;
         node_1.layout.x = 0;
-        node_1.layout.width = 0;
+        node_1.layout.width = 100;
         node_1.layout.height = 0;
         node_1 = node_0.getChildAt(1);
         node_1.layout.y = 0;
         node_1.layout.x = 0;
-        node_1.layout.width = 0;
+        node_1.layout.width = 100;
         node_1.layout.height = 0;
       }
     }


### PR DESCRIPTION
I'm submitting this for review: it does not update the JS tests so it probably shouldn't go in. I just updated the tests that were failing when I changed the defaults based on reading http://css-tricks.com/snippets/css/a-guide-to-flexbox/ for expected behavior. I'm pretty sure I got the expected behavior right but I want to make sure we're not reducing test coverage by making these changes. I'm not sure how you all decided what tests to put in in the first place so I'd like to get your thoughts.

Re: JS tests, I'm really not sure what's going on there. Making this change causes 50 tests to fail:
![screen shot 2014-10-07 at 5 11 34 pm](https://cloud.githubusercontent.com/assets/594924/4554358/d5a38d5e-4eac-11e4-96ae-8275b03f472f.png)
