### PR TITLE
Fix "Learn More about Aspect Ratio" link

### DIFF
--- a/_docs/learn-more.md
+++ b/_docs/learn-more.md
@@ -37,6 +37,6 @@ The goal of Yoga is to be a library which makes layout easy. Of course, implemen
 <div class="pluginWrapper buttonWrapper">
   <a
     class="button"
-    href="/yoga/docs/rtl/"
+    href="/yoga/docs/aspect-ratio/"
   >Learn More about Aspect Ratio</a>
 </div>


### PR DESCRIPTION
Original link was pointing to `/yoga/docs/rtl/`. Thanks :beers: