### PR TITLE
Use https when we can.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ baseurl: "/yoga"
 # This was also be set to the right thing automatically for local development
 # https://github.com/blog/2277-what-s-new-in-github-pages-with-jekyll-3-3
 # http://jekyllrb.com/news/2016/10/06/jekyll-3-3-is-here/
-url: "http://facebook.github.io"
+url: "https://facebook.github.io"
 
 # Note: There are new filters in Jekyll 3.3 to help with absolute and relative urls
 # absolute_url

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -3,7 +3,7 @@
   category: api
 
 - title: GitHub
-  href: http://github.com/facebook/yoga
+  href: https://github.com/facebook/yoga
   category: external
 
 # Use external for external links not associated with the paths of the current site.


### PR DESCRIPTION
Not sure if the _config one really matters but the other is in the nav and makes sure we avoid a redirect (GitHub is all https anyway).

There are a few others but it looks like those were just copypasta and don't actually get used, so I skipped them.

cc @JoelMarcey 