### PR TITLE
Support Xamarin.iOS

### DIFF
--- a/csharp/Facebook.Yoga/Native.cs
+++ b/csharp/Facebook.Yoga/Native.cs
@@ -14,7 +14,7 @@ namespace Facebook.Yoga
 {
     internal static class Native
     {
-#if UNITY_IOS && !UNITY_EDITOR
+#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
         private const string DllName = "__Internal";
 #else
         private const string DllName = "yoga";


### PR DESCRIPTION
- `__Internal`

https://developer.xamarin.com/guides/ios/advanced_topics/native_interop/#Static_Libraries

 > Since you can only use static libraries on iOS, there is no external shared library to link with, so the path parameter in the DllImport attribute needs to use the special name __Internal (note the double underscore characters at the start of the name) as opposed to the path name.

- `__IOS__`

https://developer.xamarin.com/guides/cross-platform/application_fundamentals/building_cross_platform_applications/part_4_-_platform_divergence_abstraction_divergent_implementation/#iOS

 > Xamarin.iOS defines __IOS__ which you can use to detect iOS devices.