### PR TITLE
Build native library with BUCK for .NET (Mono, Xamarin)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -7,14 +7,6 @@
 
 include_defs('//YOGA_DEFS')
 
-BASE_COMPILER_FLAGS = [
-  '-fno-omit-frame-pointer',
-  '-fexceptions',
-  '-Wall',
-  '-Werror',
-  '-O3',
-]
-
 GMOCK_OVERRIDE_FLAGS = [
   # gmock does not mark mocked methods as override, ignore the warnings in tests
   '-Wno-inconsistent-missing-override',

--- a/YOGA_DEFS
+++ b/YOGA_DEFS
@@ -17,6 +17,14 @@ CXX_LIBRARY_WHITELIST = [
   '//java:jni',
 ]
 
+BASE_COMPILER_FLAGS = [
+  '-fno-omit-frame-pointer',
+  '-fexceptions',
+  '-Wall',
+  '-Werror',
+  '-O3',
+]
+
 def yoga_dep(dep):
   return '//' + dep
 

--- a/csharp/BUCK
+++ b/csharp/BUCK
@@ -5,6 +5,10 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
+include_defs('//YOGA_DEFS')
+
+COMPILER_FLAGS = BASE_COMPILER_FLAGS + ['-std=c++11']
+
 csharp_library(
   name = 'yogalibnet46',
   dll_name = 'Facebook.Yoga.dll',
@@ -17,4 +21,15 @@ csharp_library(
   dll_name = 'Facebook.Yoga.dll',
   framework_ver = 'net45',
   srcs = glob(['**/*.cs']),
+)
+
+cxx_library(
+  name = 'yoganet',
+  soname = 'libyoga.$(ext)',
+  srcs = glob(['Yoga/YGInterop.cpp']),
+  compiler_flags = COMPILER_FLAGS,
+  link_style = 'static',
+  link_whole = True,
+  deps = [yoga_dep(':yoga')],
+  visibility = ['PUBLIC'],
 )

--- a/csharp/tests/Facebook.Yoga/test_macos.sh
+++ b/csharp/tests/Facebook.Yoga/test_macos.sh
@@ -1,16 +1,6 @@
 #!/bin/sh
-if clang --version >/dev/null 2>&1; then true; else
-  echo "ERROR: Can't execute clang. You need to install Xcode and command line tools."
-  exit 1
-fi
-
-if mcs --version >/dev/null 2>&1; then true; else
-  echo "ERROR: Can't execute mcs. You need to install Mono from http://www.mono-project.com/download/ and re-login to apply PATH environment."
-  exit 1
-fi
-
-if mono --version >/dev/null 2>&1; then true; else
-  echo "ERROR: Can't execute mono64. You need to install Mono from http://www.mono-project.com/download/ and re-login to apply PATH environment."
+if mcs --version >/dev/null 2>&1 && mono --version >/dev/null 2>&1; then true; else
+  echo "ERROR: Need to install Mono (brew install mono, or http://www.mono-project.com/download/)"
   exit 1
 fi
 
@@ -28,6 +18,11 @@ if [ -d $NUNIT \
   rm NUnit-2.6.4.zip
 fi
 
-clang -g -Wall -Wextra -dynamiclib -o libyoga.dylib -I../../.. ../../../yoga/*.c ../../Yoga/YGInterop.cpp
+TARGET=//csharp:yoganet#default,shared
+buck build $TARGET
+ROOT=`buck root|tail -1`
+DYLIB=`buck targets --show-output $TARGET|tail -1|awk '{print $2}'`
+cp $ROOT/$DYLIB .
+
 mcs -debug -t:library -r:$NUNIT/nunit.framework.dll -out:YogaTest.dll *.cs ../../../csharp/Facebook.Yoga/*cs
 MONO_PATH=$NUNIT mono --arch=64 --debug $NUNIT/nunit-console.exe YogaTest.dll


### PR DESCRIPTION
Examples:

- macOS on macOS (Mono, Xamarin.Mac, Unity)
  - `buck build //csharp:yoganet#shared,default` -> `libyoga.dylib`
- Android (Xamarin.Android, Unity)
  - `buck build //csharp:yoganet#shared,android-armv7` -> `libyoga.so`
- iOS (Xamarin.iOS, Unity)
  - `buck build //:yoga#static,iphoneos-arm64` -> `libyoga.a`
  - `buck build //csharp:yoganet#static,iphoneos-arm64` -> `libyoganet.a`