### PR TITLE
Build iOS fat static library for Unity and Xamarin

### DIFF
--- a/csharp/BUCK
+++ b/csharp/BUCK
@@ -33,3 +33,27 @@ cxx_library(
   deps = [yoga_dep(':yoga')],
   visibility = ['PUBLIC'],
 )
+
+yoganet_ios_srcs = []
+for arch in ['iphonesimulator-x86_64', 'iphoneos-arm64', 'iphoneos-armv7']:
+  name = 'yoganet-' + arch
+  yoganet_ios_srcs.append(':' + name)
+  genrule(
+    name = name,
+    srcs = [
+      yoga_dep(':yoga#%s,static' % arch),
+      yoga_dep('YogaKit:YogaKit#%s,static' % arch),
+      yoga_dep('csharp:yoganet#%s,static' % arch),
+    ],
+    out = 'libyoga-%s.a' % arch,
+    cmd = 'libtool -static -o $OUT $SRCS',
+    visibility = [yoga_dep('csharp:yoganet-ios')],
+  )
+
+genrule(
+  name = 'yoganet-ios',
+  srcs = yoganet_ios_srcs,
+  out = 'libyoga.a',
+  cmd = 'lipo $SRCS -create -output $OUT',
+  visibility = ['PUBLIC'],
+)


### PR DESCRIPTION
    $ buck build //csharp:yoganet-ios
    $ buck targets --show-output //csharp:yoganet-ios
    //csharp:yoganet-ios buck-out/gen/csharp/yoganet-ios/libyoga.a

    $ lipo -info buck-out/gen/csharp/yoganet-ios/libyoga.a
    Architectures in the fat file: buck-out/gen/csharp/yoganet-ios/libyoga.a are: armv7 x86_64 arm64

    $ nm buck-out/gen/csharp/yoganet-ios/libyoga.a|grep -e 'T _YGNodeNew' -e 'ygNode' -e 'T _YGInteropSetLogger'
    0000000000000000 T _YGNodeNew
    0000000000001070 t -[UIView(Yoga) ygNode]
    0000000000000000 T _YGInteropSetLogger