### PR TITLE
Add yg_isLeaf readonly property.

### DIFF
--- a/YogaKit/UIView+Yoga.h
+++ b/YogaKit/UIView+Yoga.h
@@ -21,6 +21,7 @@
  The property that decides during layout/sizing whether or not yg_* properties should be applied. Defaults to NO.
  */
 @property (nonatomic, readwrite, assign, setter=yg_setUsesYoga:) BOOL yg_usesYoga;
+@property (nonatomic, readonly) BOOL yg_isLeaf;
 
 - (void)yg_setDirection:(YGDirection)direction;
 - (void)yg_setFlexDirection:(YGFlexDirection)flexDirection;

--- a/YogaKit/UIView+Yoga.h
+++ b/YogaKit/UIView+Yoga.h
@@ -21,7 +21,7 @@
  The property that decides during layout/sizing whether or not yg_* properties should be applied. Defaults to NO.
  */
 @property (nonatomic, readwrite, assign, setter=yg_setUsesYoga:) BOOL yg_usesYoga;
-@property (nonatomic, readonly) BOOL yg_isLeaf;
+@property (nonatomic, readwrite, assign, setter=yg_setLeaf:) BOOL yg_isLeaf;
 
 - (void)yg_setDirection:(YGDirection)direction;
 - (void)yg_setFlexDirection:(YGFlexDirection)flexDirection;


### PR DESCRIPTION
This fixes #290. It is not clear to me if there a programatic way of deciding if a view is a "composite" view or not. Because if there is that would be much better than having to add a category for each view that is a composite view overwriting the `yg_isLeaf` method.