### PR TITLE
explicit default justifyContent value

### DIFF
--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -197,6 +197,7 @@ static void YGNodeInit(const YGNodeRef node) {
   node->style.flexBasis = YGUndefined;
 
   node->style.alignItems = YGAlignStretch;
+  node->style.justifyContent = YGJustifyFlexStart;
   node->style.alignContent = YGAlignFlexStart;
 
   node->style.direction = YGDirectionInherit;


### PR DESCRIPTION
make default justifyContent value explicit like alignItems

https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content

https://developer.mozilla.org/en-US/docs/Web/CSS/align-items

https://developer.mozilla.org/en-US/docs/Web/CSS/align-content