### PR TITLE
C# use YogaSize throughout the measure call chain

### DIFF
--- a/csharp/Facebook.Yoga/MeasureFunction.cs
+++ b/csharp/Facebook.Yoga/MeasureFunction.cs
@@ -9,7 +9,7 @@
 
 namespace Facebook.Yoga
 {
-    public delegate long MeasureFunction(
+    public delegate YogaSize MeasureFunction(
         YogaNode node,
         float width,
         YogaMeasureMode widthMode,

--- a/csharp/Facebook.Yoga/MeasureOutput.cs
+++ b/csharp/Facebook.Yoga/MeasureOutput.cs
@@ -11,24 +11,9 @@ namespace Facebook.Yoga
 {
     public class MeasureOutput
     {
-        public static long Make(double width, double height)
+        public static YogaSize Make(float width, float height)
         {
-            return Make((int) width, (int) height);
-        }
-
-        public static long Make(int width, int height)
-        {
-            return (long)(((ulong) width) << 32 | ((uint) height));
-        }
-
-        public static int GetWidth(long measureOutput)
-        {
-            return (int) (0xFFFFFFFF & (measureOutput >> 32));
-        }
-
-        public static int GetHeight(long measureOutput)
-        {
-            return (int) (0xFFFFFFFF & measureOutput);
+            return new YogaSize { width = width, height = height};
         }
     }
 }

--- a/csharp/Facebook.Yoga/YogaNode.cs
+++ b/csharp/Facebook.Yoga/YogaNode.cs
@@ -532,8 +532,7 @@ namespace Facebook.Yoga
                 throw new InvalidOperationException("Measure function is not defined.");
             }
 
-            long output = _measureFunction(this, width, widthMode, height, heightMode);
-            return new YogaSize { width = MeasureOutput.GetWidth(output), height = MeasureOutput.GetHeight(output) };
+            return _measureFunction(this, width, widthMode, height, heightMode);
         }
 
         public string Print(YogaPrintOptions options =

--- a/csharp/tests/Facebook.Yoga/YogaNodeTest.cs
+++ b/csharp/tests/Facebook.Yoga/YogaNodeTest.cs
@@ -169,8 +169,8 @@ namespace Facebook.Yoga
                 return MeasureOutput.Make(123.4f, 81.7f);
             });
             node.CalculateLayout();
-            Assert.AreEqual(123, node.LayoutWidth);
-            Assert.AreEqual(81, node.LayoutHeight);
+            Assert.AreEqual(123.4f, node.LayoutWidth);
+            Assert.AreEqual(81.7f, node.LayoutHeight);
         }
 
         [Test]


### PR DESCRIPTION
#296 hint me to taking a deeper look. We already have ```YogaSize``` struct in c# an convert into a ```long``` into the meantime. We loose some precission here and could get a wrong result with very hugh values.

Java still has the same problem (see #296)

Also there is no need to have double in the method signature as we only use float internally, which could confuse some.