### PR TITLE
[YogaKit] Set nodes dirty when sizeThatFits changes

### DIFF
--- a/YogaKit/Tests/YogaKitTests.m
+++ b/YogaKit/Tests/YogaKitTests.m
@@ -96,6 +96,27 @@
   XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(514,21), containerSize), @"Size is actually %@", NSStringFromCGSize(containerSize));
 }
 
+- (void)testThatModificationsInSizeThatFitsUpdatesLayout
+{
+  UIView *container = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 50)];
+  [container yg_setUsesYoga:YES];
+  [container yg_setFlexDirection:YGFlexDirectionRow];
+  [container yg_setAlignItems:YGAlignFlexStart];
+
+  UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
+  label.text = @"This is a short text.";
+  label.numberOfLines = 1;
+  [label yg_setUsesYoga:YES];
+  [container addSubview:label];
+
+  [container yg_applyLayout];
+  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(146,21), label.bounds.size), @"Size is actually %@", NSStringFromCGSize(label.bounds.size));
+
+  label.text = @"This is a slightly longer text.";
+  [container yg_applyLayout];
+  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(213,21), label.bounds.size), @"Size is actually %@", NSStringFromCGSize(label.bounds.size));
+}
+
 - (void)testFrameAndOriginPlacement
 {
   const CGSize containerSize = CGSizeMake(320, 50);

--- a/YogaKit/UIView+Yoga.m
+++ b/YogaKit/UIView+Yoga.m
@@ -13,6 +13,7 @@
 
 @interface YGNodeBridge : NSObject
 @property (nonatomic, assign, readonly) YGNodeRef cnode;
+@property (nonatomic, assign) YGSize cachedSize;
 @end
 
 @implementation YGNodeBridge
@@ -221,14 +222,19 @@
 
 - (YGNodeRef)ygNode
 {
-  YGNodeBridge *node = objc_getAssociatedObject(self, @selector(ygNode));
-  if (!node) {
-    node = [YGNodeBridge new];
-    YGNodeSetContext(node.cnode, (__bridge void *) self);
-    objc_setAssociatedObject(self, @selector(ygNode), node, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+  return self.ygBridge.cnode;
+}
+
+- (YGNodeBridge *)ygBridge
+{
+  YGNodeBridge *bridge = objc_getAssociatedObject(self, @selector(ygBridge));
+  if (!bridge) {
+    bridge = [YGNodeBridge new];
+    YGNodeSetContext(bridge.cnode, (__bridge void *) self);
+    objc_setAssociatedObject(self, @selector(ygBridge), bridge, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
   }
 
-  return node.cnode;
+  return bridge;
 }
 
 - (CGSize)calculateLayoutWithSize:(CGSize)size
@@ -236,7 +242,7 @@
   NSAssert([NSThread isMainThread], @"YG Layout calculation must be done on main.");
   NSAssert([self yg_usesYoga], @"YG Layout is not enabled for this view.");
 
-  YGAttachNodesFromViewHierachy(self);
+  YGUpdateNodesFromViewHierachy(self);
 
   const YGNodeRef node = [self ygNode];
   YGNodeCalculateLayout(
@@ -305,14 +311,23 @@ static BOOL YGNodeHasExactSameChildren(const YGNodeRef node, NSArray<UIView *> *
   return YES;
 }
 
-static void YGAttachNodesFromViewHierachy(UIView *const view)
+static void YGUpdateNodesFromViewHierachy(UIView *const view)
 {
   const YGNodeRef node = [view ygNode];
 
   // Only leaf nodes should have a measure function
   if (view.yg_isLeaf) {
     YGNodeSetMeasureFunc(node, YGMeasureView);
-    YGRemoveAllChildren(node);
+    YGRemoveAllChildren(node);    
+    
+    YGNodeBridge *bridge = [view ygBridge];
+    YGSize oldSize = bridge.cachedSize;
+    YGSize newSize = YGMeasureView(node, 0, YGMeasureModeUndefined, 0, YGMeasureModeUndefined);
+    bridge.cachedSize = newSize;
+      
+    if (!YGNodeIsDirty(node) && (oldSize.width != newSize.width || oldSize.height != newSize.height)) {
+      YGNodeMarkDirty(node);
+    }
   } else {
     YGNodeSetMeasureFunc(node, NULL);
 
@@ -331,7 +346,7 @@ static void YGAttachNodesFromViewHierachy(UIView *const view)
     }
 
     for (UIView *const subview in subviewsToInclude) {
-        YGAttachNodesFromViewHierachy(subview);
+        YGUpdateNodesFromViewHierachy(subview);
     }
   }
 }


### PR DESCRIPTION
In YogaKit, nodes are not dirtied when `sizeThatFits` of leaf nodes change. This makes it difficult to reuse views like `UILabel` when their content (text) changes. I wrote a failing test to prove it and wrote a fix by caching the latest value of `sizeThatFits` in `YGNodeBridge` and checking for changes in `YGAttachNodesFromViewHierachy` (renamed to `YGUpdateNodesFromViewHierachy` to make it clear it's not simply reattaching nodes anymore). When a new size is detected, I call `YGNodeMarkDirty` on the leaf node.

**Unfortunately**, this makes another test fail for no logical reason (`testThatViewNotIncludedInFirstLayoutPassAreIncludedInSecond`). Either there's something I don't understand or I've un-advertedly unearthed a bug in the C implementation, but in what case would setting a node dirty make the layout return a different size?