### PR TITLE
Fix Unity build

### DIFF
--- a/csharp/Facebook.Yoga/YogaValue.cs
+++ b/csharp/Facebook.Yoga/YogaValue.cs
@@ -17,8 +17,21 @@ namespace Facebook.Yoga
         private float value;
         private YogaUnit unit;
 
-        public YogaUnit Unit => unit;
-        public float Value => value;
+        public YogaUnit Unit
+        {
+            get
+            {
+                return unit;
+            }
+        }
+
+        public float Value
+        {
+            get
+            {
+                return value;
+            }
+        }
 
         public static YogaValue Pixel(float value)
         {


### PR DESCRIPTION
    YogaValue.cs(20,30): error CS1644: Feature `expression bodied members' cannot be used because it is not part of the C# 4.0 language specification
    YogaValue.cs(21,28): error CS1644: Feature `expression bodied members' cannot be used because it is not part of the C# 4.0 language specification