### PR TITLE
Use float instead of double for test values

### DIFF
--- a/tests/YGRoundingMeasureFuncTest.cpp
+++ b/tests/YGRoundingMeasureFuncTest.cpp
@@ -17,8 +17,8 @@ static YGSize _measureFloor(YGNodeRef node,
   YGMeasureMode heightMode) {
 
   return YGSize{
-    width = 10.2,
-    height = 10.2,
+    width = 10.2f,
+    height = 10.2f,
   };
 }
 


### PR DESCRIPTION
Use explicit float values to remove warning.