### PR TITLE
Optimized memory alignment

### DIFF
--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -94,16 +94,18 @@ typedef struct YGNode {
   YGStyle style;
   YGLayout layout;
   uint32_t lineIndex;
-  bool hasNewLayout;
+
   YGNodeRef parent;
   YGNodeListRef children;
-  bool isDirty;
 
   struct YGNode *nextChild;
 
   YGMeasureFunc measure;
   YGPrintFunc print;
   void *context;
+
+  bool isDirty;
+  bool hasNewLayout;
 } YGNode;
 
 #define YG_UNDEFINED_VALUES \


### PR DESCRIPTION
It's not much, but still 4 bytes saved here by moving the ```bool```s together. (on compilers where ```bool``` is a single byte)