### PR TITLE
[YogaKit] Fix crash when a non-leaf node becomes a leaf node

### DIFF
--- a/YogaKit/Tests/YogaKitTests.m
+++ b/YogaKit/Tests/YogaKitTests.m
@@ -343,4 +343,22 @@
     }
 }
 
+- (void)testThatANonLeafNodeCanBecomeALeafNode
+{
+    UIView *container = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 300, 50)];
+    [container yg_setUsesYoga:YES];
+
+    UIView *subview1 = [[UIView alloc] initWithFrame:CGRectZero];
+    [subview1 yg_setUsesYoga:YES];
+    [container addSubview:subview1];
+
+    UIView *subview2 = [[UIView alloc] initWithFrame:CGRectZero];
+    [subview2 yg_setUsesYoga:YES];
+    [subview1 addSubview:subview2];
+
+    [container yg_applyLayout];
+    [subview2 removeFromSuperview];
+    [container yg_applyLayout];
+}
+
 @end

--- a/YogaKit/UIView+Yoga.m
+++ b/YogaKit/UIView+Yoga.m
@@ -316,8 +316,8 @@ static void YGAttachNodesFromViewHierachy(UIView *const view)
 
   // Only leaf nodes should have a measure function
   if (view.yg_isLeaf) {
-    YGNodeSetMeasureFunc(node, YGMeasureView);
     YGRemoveAllChildren(node);
+    YGNodeSetMeasureFunc(node, YGMeasureView);
   } else {
     YGNodeSetMeasureFunc(node, NULL);
 


### PR DESCRIPTION
When a non-leaf node becomes a leaf node, `YGAttachNodesFromViewHierachy` calls `YGNodeSetMeasureFunc` before `YGRemoveAllChildren`, which causes a crash because that node has children. Fixed by swapping the order of the calls and have a unit-test to make sure it works.