### PR TITLE
Fix absolute position if align-item or justify-content is center or flex-end

### DIFF
--- a/csharp/tests/Facebook.Yoga/YGAbsolutePositionTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGAbsolutePositionTest.cs
@@ -434,5 +434,177 @@ namespace Facebook.Yoga
             Assert.AreEqual(40f, root_child0.LayoutHeight);
         }
 
+        [Test]
+        public void Test_absolute_layout_align_items_and_justify_content_center_and_top_position()
+        {
+            YogaNode root = new YogaNode();
+            root.JustifyContent = YogaJustify.Center;
+            root.AlignItems = YogaAlign.Center;
+            root.FlexGrow = 1;
+            root.Width = 110;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.SetPosition(YogaEdge.Top, 10);
+            root_child0.Width = 60;
+            root_child0.Height = 40;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child0.LayoutX);
+            Assert.AreEqual(10f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child0.LayoutX);
+            Assert.AreEqual(10f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_absolute_layout_align_items_and_justify_content_center_and_bottom_position()
+        {
+            YogaNode root = new YogaNode();
+            root.JustifyContent = YogaJustify.Center;
+            root.AlignItems = YogaAlign.Center;
+            root.FlexGrow = 1;
+            root.Width = 110;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.SetPosition(YogaEdge.Bottom, 10);
+            root_child0.Width = 60;
+            root_child0.Height = 40;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child0.LayoutX);
+            Assert.AreEqual(50f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child0.LayoutX);
+            Assert.AreEqual(50f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_absolute_layout_align_items_and_justify_content_center_and_left_position()
+        {
+            YogaNode root = new YogaNode();
+            root.JustifyContent = YogaJustify.Center;
+            root.AlignItems = YogaAlign.Center;
+            root.FlexGrow = 1;
+            root.Width = 110;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.SetPosition(YogaEdge.Left, 5);
+            root_child0.Width = 60;
+            root_child0.Height = 40;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(5f, root_child0.LayoutX);
+            Assert.AreEqual(30f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(5f, root_child0.LayoutX);
+            Assert.AreEqual(30f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_absolute_layout_align_items_and_justify_content_center_and_right_position()
+        {
+            YogaNode root = new YogaNode();
+            root.JustifyContent = YogaJustify.Center;
+            root.AlignItems = YogaAlign.Center;
+            root.FlexGrow = 1;
+            root.Width = 110;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.SetPosition(YogaEdge.Right, 5);
+            root_child0.Width = 60;
+            root_child0.Height = 40;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(45f, root_child0.LayoutX);
+            Assert.AreEqual(30f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(45f, root_child0.LayoutX);
+            Assert.AreEqual(30f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+        }
+
     }
 }

--- a/csharp/tests/Facebook.Yoga/YGAbsolutePositionTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGAbsolutePositionTest.cs
@@ -435,6 +435,47 @@ namespace Facebook.Yoga
         }
 
         [Test]
+        public void Test_absolute_layout_align_items_center_on_child_only()
+        {
+            YogaNode root = new YogaNode();
+            root.FlexGrow = 1;
+            root.Width = 110;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.AlignSelf = YogaAlign.Center;
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.Width = 60;
+            root_child0.Height = 40;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+        }
+
+        [Test]
         public void Test_absolute_layout_align_items_and_justify_content_center_and_top_position()
         {
             YogaNode root = new YogaNode();

--- a/csharp/tests/Facebook.Yoga/YGAbsolutePositionTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGAbsolutePositionTest.cs
@@ -353,6 +353,48 @@ namespace Facebook.Yoga
         }
 
         [Test]
+        public void Test_absolute_layout_align_items_and_justify_content_flex_end()
+        {
+            YogaNode root = new YogaNode();
+            root.JustifyContent = YogaJustify.FlexEnd;
+            root.AlignItems = YogaAlign.FlexEnd;
+            root.FlexGrow = 1;
+            root.Width = 110;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.Width = 60;
+            root_child0.Height = 40;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child0.LayoutX);
+            Assert.AreEqual(60f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(60f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+        }
+
+        [Test]
         public void Test_absolute_layout_justify_content_center()
         {
             YogaNode root = new YogaNode();

--- a/csharp/tests/Facebook.Yoga/YGAbsolutePositionTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGAbsolutePositionTest.cs
@@ -310,5 +310,129 @@ namespace Facebook.Yoga
             Assert.AreEqual(50f, root_child1.LayoutHeight);
         }
 
+        [Test]
+        public void Test_absolute_layout_align_items_and_justify_content_center()
+        {
+            YogaNode root = new YogaNode();
+            root.JustifyContent = YogaJustify.Center;
+            root.AlignItems = YogaAlign.Center;
+            root.FlexGrow = 1;
+            root.Width = 110;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.Width = 60;
+            root_child0.Height = 40;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child0.LayoutX);
+            Assert.AreEqual(30f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child0.LayoutX);
+            Assert.AreEqual(30f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_absolute_layout_justify_content_center()
+        {
+            YogaNode root = new YogaNode();
+            root.JustifyContent = YogaJustify.Center;
+            root.FlexGrow = 1;
+            root.Width = 110;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.Width = 60;
+            root_child0.Height = 40;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(30f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child0.LayoutX);
+            Assert.AreEqual(30f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_absolute_layout_align_items_center()
+        {
+            YogaNode root = new YogaNode();
+            root.AlignItems = YogaAlign.Center;
+            root.FlexGrow = 1;
+            root.Width = 110;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.Width = 60;
+            root_child0.Height = 40;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(110f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+        }
+
     }
 }

--- a/gentest/fixtures/YGAbsolutePositionTest.html
+++ b/gentest/fixtures/YGAbsolutePositionTest.html
@@ -36,3 +36,19 @@
 <div id="absolute_layout_align_items_center" style="height: 100px; width: 110px; flex-grow: 1; align-items: center;">
 	<div style="position: absolute; width: 60px; height: 40px;"></div>
 </div>
+
+<div id="absolute_layout_align_items_and_justify_content_center_and_top_position" style="height: 100px; width: 110px; flex-grow: 1; align-items: center; justify-content: center;">
+	<div style="position: absolute; width: 60px; height: 40px;top:10px;"></div>
+</div>
+
+<div id="absolute_layout_align_items_and_justify_content_center_and_bottom_position" style="height: 100px; width: 110px; flex-grow: 1; align-items: center; justify-content: center;">
+	<div style="position: absolute; width: 60px; height: 40px;bottom:10px;"></div>
+</div>
+
+<div id="absolute_layout_align_items_and_justify_content_center_and_left_position" style="height: 100px; width: 110px; flex-grow: 1; align-items: center; justify-content: center;">
+	<div style="position: absolute; width: 60px; height: 40px;left:5px;"></div>
+</div>
+
+<div id="absolute_layout_align_items_and_justify_content_center_and_right_position" style="height: 100px; width: 110px; flex-grow: 1; align-items: center; justify-content: center;">
+	<div style="position: absolute; width: 60px; height: 40px;right:5px;"></div>
+</div>

--- a/gentest/fixtures/YGAbsolutePositionTest.html
+++ b/gentest/fixtures/YGAbsolutePositionTest.html
@@ -29,6 +29,10 @@
 	<div style="position: absolute; width: 60px; height: 40px;"></div>
 </div>
 
+<div id="absolute_layout_align_items_and_justify_content_flex_end" style="height: 100px; width: 110px; flex-grow: 1; align-items: flex-end; justify-content: flex-end;">
+	<div style="position: absolute; width: 60px; height: 40px;"></div>
+</div>
+
 <div id="absolute_layout_justify_content_center" style="height: 100px; width: 110px; flex-grow: 1; justify-content: center;">
 	<div style="position: absolute; width: 60px; height: 40px;"></div>
 </div>

--- a/gentest/fixtures/YGAbsolutePositionTest.html
+++ b/gentest/fixtures/YGAbsolutePositionTest.html
@@ -24,3 +24,15 @@
   <div style="position: absolute; width: 50px; height: 50px; left: 0px; top: 0px;"></div>
   <div style="position: absolute; width: 50px; height: 50px; right: 0px; bottom: 0px;"></div>
 </div>
+
+<div id="absolute_layout_align_items_and_justify_content_center" style="height: 100px; width: 110px; flex-grow: 1; align-items: center; justify-content: center;">
+	<div style="position: absolute; width: 60px; height: 40px;"></div>
+</div>
+
+<div id="absolute_layout_justify_content_center" style="height: 100px; width: 110px; flex-grow: 1; justify-content: center;">
+	<div style="position: absolute; width: 60px; height: 40px;"></div>
+</div>
+
+<div id="absolute_layout_align_items_center" style="height: 100px; width: 110px; flex-grow: 1; align-items: center;">
+	<div style="position: absolute; width: 60px; height: 40px;"></div>
+</div>

--- a/gentest/fixtures/YGAbsolutePositionTest.html
+++ b/gentest/fixtures/YGAbsolutePositionTest.html
@@ -37,6 +37,10 @@
 	<div style="position: absolute; width: 60px; height: 40px;"></div>
 </div>
 
+<div id="absolute_layout_align_items_center_on_child_only" style="height: 100px; width: 110px; flex-grow: 1;">
+	<div style="position: absolute; width: 60px; height: 40px;align-self: center;"></div>
+</div>
+
 <div id="absolute_layout_align_items_and_justify_content_center_and_top_position" style="height: 100px; width: 110px; flex-grow: 1; align-items: center; justify-content: center;">
 	<div style="position: absolute; width: 60px; height: 40px;top:10px;"></div>
 </div>

--- a/java/tests/com/facebook/yoga/YGAbsolutePositionTest.java
+++ b/java/tests/com/facebook/yoga/YGAbsolutePositionTest.java
@@ -424,4 +424,172 @@ public class YGAbsolutePositionTest {
     assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
   }
 
+  @Test
+  public void test_absolute_layout_align_items_and_justify_content_center_and_top_position() {
+    final YogaNode root = new YogaNode();
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setAlignItems(YogaAlign.CENTER);
+    root.setFlexGrow(1f);
+    root.setWidth(110f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setPosition(YogaEdge.TOP, 10f);
+    root_child0.setWidth(60f);
+    root_child0.setHeight(40f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_absolute_layout_align_items_and_justify_content_center_and_bottom_position() {
+    final YogaNode root = new YogaNode();
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setAlignItems(YogaAlign.CENTER);
+    root.setFlexGrow(1f);
+    root.setWidth(110f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setPosition(YogaEdge.BOTTOM, 10f);
+    root_child0.setWidth(60f);
+    root_child0.setHeight(40f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_absolute_layout_align_items_and_justify_content_center_and_left_position() {
+    final YogaNode root = new YogaNode();
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setAlignItems(YogaAlign.CENTER);
+    root.setFlexGrow(1f);
+    root.setWidth(110f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setPosition(YogaEdge.LEFT, 5f);
+    root_child0.setWidth(60f);
+    root_child0.setHeight(40f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(5f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(5f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_absolute_layout_align_items_and_justify_content_center_and_right_position() {
+    final YogaNode root = new YogaNode();
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setAlignItems(YogaAlign.CENTER);
+    root.setFlexGrow(1f);
+    root.setWidth(110f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setPosition(YogaEdge.RIGHT, 5f);
+    root_child0.setWidth(60f);
+    root_child0.setHeight(40f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(45f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(45f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
 }

--- a/java/tests/com/facebook/yoga/YGAbsolutePositionTest.java
+++ b/java/tests/com/facebook/yoga/YGAbsolutePositionTest.java
@@ -425,6 +425,46 @@ public class YGAbsolutePositionTest {
   }
 
   @Test
+  public void test_absolute_layout_align_items_center_on_child_only() {
+    final YogaNode root = new YogaNode();
+    root.setFlexGrow(1f);
+    root.setWidth(110f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setAlignSelf(YogaAlign.CENTER);
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setWidth(60f);
+    root_child0.setHeight(40f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
   public void test_absolute_layout_align_items_and_justify_content_center_and_top_position() {
     final YogaNode root = new YogaNode();
     root.setJustifyContent(YogaJustify.CENTER);

--- a/java/tests/com/facebook/yoga/YGAbsolutePositionTest.java
+++ b/java/tests/com/facebook/yoga/YGAbsolutePositionTest.java
@@ -303,4 +303,125 @@ public class YGAbsolutePositionTest {
     assertEquals(50f, root_child1.getLayoutHeight(), 0.0f);
   }
 
+  @Test
+  public void test_absolute_layout_align_items_and_justify_content_center() {
+    final YogaNode root = new YogaNode();
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setAlignItems(YogaAlign.CENTER);
+    root.setFlexGrow(1f);
+    root.setWidth(110f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setWidth(60f);
+    root_child0.setHeight(40f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_absolute_layout_justify_content_center() {
+    final YogaNode root = new YogaNode();
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setFlexGrow(1f);
+    root.setWidth(110f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setWidth(60f);
+    root_child0.setHeight(40f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_absolute_layout_align_items_center() {
+    final YogaNode root = new YogaNode();
+    root.setAlignItems(YogaAlign.CENTER);
+    root.setFlexGrow(1f);
+    root.setWidth(110f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setWidth(60f);
+    root_child0.setHeight(40f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
 }

--- a/java/tests/com/facebook/yoga/YGAbsolutePositionTest.java
+++ b/java/tests/com/facebook/yoga/YGAbsolutePositionTest.java
@@ -345,6 +345,47 @@ public class YGAbsolutePositionTest {
   }
 
   @Test
+  public void test_absolute_layout_align_items_and_justify_content_flex_end() {
+    final YogaNode root = new YogaNode();
+    root.setJustifyContent(YogaJustify.FLEX_END);
+    root.setAlignItems(YogaAlign.FLEX_END);
+    root.setFlexGrow(1f);
+    root.setWidth(110f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setWidth(60f);
+    root_child0.setHeight(40f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout();
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(110f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
   public void test_absolute_layout_justify_content_center() {
     final YogaNode root = new YogaNode();
     root.setJustifyContent(YogaJustify.CENTER);

--- a/tests/YGAbsolutePositionTest.cpp
+++ b/tests/YGAbsolutePositionTest.cpp
@@ -411,6 +411,45 @@ TEST(YogaTest, absolute_layout_align_items_center) {
   YGNodeFreeRecursive(root);
 }
 
+TEST(YogaTest, absolute_layout_align_items_center_on_child_only) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetFlexGrow(root, 1);
+  YGNodeStyleSetWidth(root, 110);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetAlignSelf(root_child0, YGAlignCenter);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root_child0, 60);
+  YGNodeStyleSetHeight(root_child0, 40);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+}
+
 TEST(YogaTest, absolute_layout_align_items_and_justify_content_center_and_top_position) {
   const YGNodeRef root = YGNodeNew();
   YGNodeStyleSetJustifyContent(root, YGJustifyCenter);

--- a/tests/YGAbsolutePositionTest.cpp
+++ b/tests/YGAbsolutePositionTest.cpp
@@ -292,3 +292,121 @@ TEST(YogaTest, absolute_layout_within_border) {
 
   YGNodeFreeRecursive(root);
 }
+
+TEST(YogaTest, absolute_layout_align_items_and_justify_content_center) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetFlexGrow(root, 1);
+  YGNodeStyleSetWidth(root, 110);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root_child0, 60);
+  YGNodeStyleSetHeight(root_child0, 40);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, absolute_layout_justify_content_center) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetFlexGrow(root, 1);
+  YGNodeStyleSetWidth(root, 110);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root_child0, 60);
+  YGNodeStyleSetHeight(root_child0, 40);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, absolute_layout_align_items_center) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetFlexGrow(root, 1);
+  YGNodeStyleSetWidth(root, 110);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root_child0, 60);
+  YGNodeStyleSetHeight(root_child0, 40);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+}

--- a/tests/YGAbsolutePositionTest.cpp
+++ b/tests/YGAbsolutePositionTest.cpp
@@ -333,6 +333,46 @@ TEST(YogaTest, absolute_layout_align_items_and_justify_content_center) {
   YGNodeFreeRecursive(root);
 }
 
+TEST(YogaTest, absolute_layout_align_items_and_justify_content_flex_end) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetJustifyContent(root, YGJustifyFlexEnd);
+  YGNodeStyleSetAlignItems(root, YGAlignFlexEnd);
+  YGNodeStyleSetFlexGrow(root, 1);
+  YGNodeStyleSetWidth(root, 110);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root_child0, 60);
+  YGNodeStyleSetHeight(root_child0, 40);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+}
+
 TEST(YogaTest, absolute_layout_justify_content_center) {
   const YGNodeRef root = YGNodeNew();
   YGNodeStyleSetJustifyContent(root, YGJustifyCenter);

--- a/tests/YGAbsolutePositionTest.cpp
+++ b/tests/YGAbsolutePositionTest.cpp
@@ -410,3 +410,167 @@ TEST(YogaTest, absolute_layout_align_items_center) {
 
   YGNodeFreeRecursive(root);
 }
+
+TEST(YogaTest, absolute_layout_align_items_and_justify_content_center_and_top_position) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetFlexGrow(root, 1);
+  YGNodeStyleSetWidth(root, 110);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child0, YGEdgeTop, 10);
+  YGNodeStyleSetWidth(root_child0, 60);
+  YGNodeStyleSetHeight(root_child0, 40);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, absolute_layout_align_items_and_justify_content_center_and_bottom_position) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetFlexGrow(root, 1);
+  YGNodeStyleSetWidth(root, 110);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child0, YGEdgeBottom, 10);
+  YGNodeStyleSetWidth(root_child0, 60);
+  YGNodeStyleSetHeight(root_child0, 40);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, absolute_layout_align_items_and_justify_content_center_and_left_position) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetFlexGrow(root, 1);
+  YGNodeStyleSetWidth(root, 110);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child0, YGEdgeLeft, 5);
+  YGNodeStyleSetWidth(root_child0, 60);
+  YGNodeStyleSetHeight(root_child0, 40);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, absolute_layout_align_items_and_justify_content_center_and_right_position) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetFlexGrow(root, 1);
+  YGNodeStyleSetWidth(root, 110);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child0, YGEdgeRight, 5);
+  YGNodeStyleSetWidth(root_child0, 60);
+  YGNodeStyleSetHeight(root_child0, 40);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+}

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -1376,9 +1376,10 @@ static void YGNodeAbsoluteLayoutChild(const YGNodeRef node,
                                                 child->layout.measuredDimensions[dim[mainAxis]] -
                                                 YGNodeTrailingBorder(node, mainAxis) -
                                                 YGNodeTrailingPosition(child, mainAxis, width);
-  }else if (!YGNodeIsLeadingPosDefined(child, mainAxis) && node->style.justifyContent == YGJustifyCenter) {
+  }else if (!YGNodeIsLeadingPosDefined(child, mainAxis) && 
+      node->style.justifyContent == YGJustifyCenter) {
     child->layout.position[leading[mainAxis]] = (node->layout.measuredDimensions[dim[mainAxis]] -
-                                                   child->layout.measuredDimensions[dim[mainAxis]]) / 2.0f;
+                                                 child->layout.measuredDimensions[dim[mainAxis]]) / 2.0f;
   }
 
   if (YGNodeIsTrailingPosDefined(child, crossAxis) &&
@@ -1388,9 +1389,9 @@ static void YGNodeAbsoluteLayoutChild(const YGNodeRef node,
                                                  YGNodeTrailingBorder(node, crossAxis) -
                                                  YGNodeTrailingPosition(child, crossAxis, width);
   }else if (!YGNodeIsLeadingPosDefined(child, crossAxis) && 
-    node->style.alignItems == YGAlignCenter) {
+    YGNodeAlignItem(node, child) == YGAlignCenter) {
     child->layout.position[leading[crossAxis]] = (node->layout.measuredDimensions[dim[crossAxis]] -
-                                                   child->layout.measuredDimensions[dim[crossAxis]]) / 2.0f;
+                                                  child->layout.measuredDimensions[dim[crossAxis]]) / 2.0f;
   }
 }
 

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -1371,6 +1371,16 @@ static void YGNodeAbsoluteLayoutChild(const YGNodeRef node,
                        true,
                        "abs-layout");
 
+  if (node->style.alignItems == YGAlignCenter) {
+	  child->layout.position[leading[crossAxis]] = (node->layout.measuredDimensions[dim[crossAxis]] -
+		  child->layout.measuredDimensions[dim[crossAxis]]) / 2.0f;
+  }
+
+  if (node->style.justifyContent == YGJustifyCenter) {
+	  child->layout.position[leading[mainAxis]] = (node->layout.measuredDimensions[dim[mainAxis]] - 
+		  child->layout.measuredDimensions[dim[mainAxis]]) / 2.0f;
+  }
+
   if (YGNodeIsTrailingPosDefined(child, mainAxis) && !YGNodeIsLeadingPosDefined(child, mainAxis)) {
     child->layout.position[leading[mainAxis]] = node->layout.measuredDimensions[dim[mainAxis]] -
                                                 child->layout.measuredDimensions[dim[mainAxis]] -

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -1380,6 +1380,10 @@ static void YGNodeAbsoluteLayoutChild(const YGNodeRef node,
       node->style.justifyContent == YGJustifyCenter) {
     child->layout.position[leading[mainAxis]] = (node->layout.measuredDimensions[dim[mainAxis]] -
                                                  child->layout.measuredDimensions[dim[mainAxis]]) / 2.0f;
+  }else if (!YGNodeIsLeadingPosDefined(child, mainAxis) && 
+      node->style.justifyContent == YGJustifyFlexEnd) {
+    child->layout.position[leading[mainAxis]] = (node->layout.measuredDimensions[dim[mainAxis]] -
+                                                 child->layout.measuredDimensions[dim[mainAxis]]);
   }
 
   if (YGNodeIsTrailingPosDefined(child, crossAxis) &&
@@ -1392,6 +1396,10 @@ static void YGNodeAbsoluteLayoutChild(const YGNodeRef node,
     YGNodeAlignItem(node, child) == YGAlignCenter) {
     child->layout.position[leading[crossAxis]] = (node->layout.measuredDimensions[dim[crossAxis]] -
                                                   child->layout.measuredDimensions[dim[crossAxis]]) / 2.0f;
+  }else if (!YGNodeIsLeadingPosDefined(child, crossAxis) && 
+    YGNodeAlignItem(node, child) == YGAlignFlexEnd) {
+    child->layout.position[leading[crossAxis]] = (node->layout.measuredDimensions[dim[crossAxis]] -
+                                                  child->layout.measuredDimensions[dim[crossAxis]]);
   }
 }
 

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -1371,21 +1371,14 @@ static void YGNodeAbsoluteLayoutChild(const YGNodeRef node,
                        true,
                        "abs-layout");
 
-  if (node->style.alignItems == YGAlignCenter) {
-	  child->layout.position[leading[crossAxis]] = (node->layout.measuredDimensions[dim[crossAxis]] -
-		  child->layout.measuredDimensions[dim[crossAxis]]) / 2.0f;
-  }
-
-  if (node->style.justifyContent == YGJustifyCenter) {
-	  child->layout.position[leading[mainAxis]] = (node->layout.measuredDimensions[dim[mainAxis]] - 
-		  child->layout.measuredDimensions[dim[mainAxis]]) / 2.0f;
-  }
-
   if (YGNodeIsTrailingPosDefined(child, mainAxis) && !YGNodeIsLeadingPosDefined(child, mainAxis)) {
     child->layout.position[leading[mainAxis]] = node->layout.measuredDimensions[dim[mainAxis]] -
                                                 child->layout.measuredDimensions[dim[mainAxis]] -
                                                 YGNodeTrailingBorder(node, mainAxis) -
                                                 YGNodeTrailingPosition(child, mainAxis, width);
+  }else if (!YGNodeIsLeadingPosDefined(child, mainAxis) && node->style.justifyContent == YGJustifyCenter) {
+    child->layout.position[leading[mainAxis]] = (node->layout.measuredDimensions[dim[mainAxis]] -
+                                                   child->layout.measuredDimensions[dim[mainAxis]]) / 2.0f;
   }
 
   if (YGNodeIsTrailingPosDefined(child, crossAxis) &&
@@ -1394,6 +1387,10 @@ static void YGNodeAbsoluteLayoutChild(const YGNodeRef node,
                                                  child->layout.measuredDimensions[dim[crossAxis]] -
                                                  YGNodeTrailingBorder(node, crossAxis) -
                                                  YGNodeTrailingPosition(child, crossAxis, width);
+  }else if (!YGNodeIsLeadingPosDefined(child, crossAxis) && 
+    node->style.alignItems == YGAlignCenter) {
+    child->layout.position[leading[crossAxis]] = (node->layout.measuredDimensions[dim[crossAxis]] -
+                                                   child->layout.measuredDimensions[dim[crossAxis]]) / 2.0f;
   }
 }
 

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -1376,11 +1376,11 @@ static void YGNodeAbsoluteLayoutChild(const YGNodeRef node,
                                                 child->layout.measuredDimensions[dim[mainAxis]] -
                                                 YGNodeTrailingBorder(node, mainAxis) -
                                                 YGNodeTrailingPosition(child, mainAxis, width);
-  }else if (!YGNodeIsLeadingPosDefined(child, mainAxis) && 
+  } else if (!YGNodeIsLeadingPosDefined(child, mainAxis) && 
       node->style.justifyContent == YGJustifyCenter) {
     child->layout.position[leading[mainAxis]] = (node->layout.measuredDimensions[dim[mainAxis]] -
                                                  child->layout.measuredDimensions[dim[mainAxis]]) / 2.0f;
-  }else if (!YGNodeIsLeadingPosDefined(child, mainAxis) && 
+  } else if (!YGNodeIsLeadingPosDefined(child, mainAxis) && 
       node->style.justifyContent == YGJustifyFlexEnd) {
     child->layout.position[leading[mainAxis]] = (node->layout.measuredDimensions[dim[mainAxis]] -
                                                  child->layout.measuredDimensions[dim[mainAxis]]);
@@ -1392,11 +1392,11 @@ static void YGNodeAbsoluteLayoutChild(const YGNodeRef node,
                                                  child->layout.measuredDimensions[dim[crossAxis]] -
                                                  YGNodeTrailingBorder(node, crossAxis) -
                                                  YGNodeTrailingPosition(child, crossAxis, width);
-  }else if (!YGNodeIsLeadingPosDefined(child, crossAxis) && 
+  } else if (!YGNodeIsLeadingPosDefined(child, crossAxis) && 
     YGNodeAlignItem(node, child) == YGAlignCenter) {
     child->layout.position[leading[crossAxis]] = (node->layout.measuredDimensions[dim[crossAxis]] -
                                                   child->layout.measuredDimensions[dim[crossAxis]]) / 2.0f;
-  }else if (!YGNodeIsLeadingPosDefined(child, crossAxis) && 
+  } else if (!YGNodeIsLeadingPosDefined(child, crossAxis) && 
     YGNodeAlignItem(node, child) == YGAlignFlexEnd) {
     child->layout.position[leading[crossAxis]] = (node->layout.measuredDimensions[dim[crossAxis]] -
                                                   child->layout.measuredDimensions[dim[crossAxis]]);


### PR DESCRIPTION
Fix #310 (```center```)

additionally fixes if ```flex-end``` is set.