### PR TITLE
[YogaKit] Implemented auto-detection of dirtying

### DIFF
--- a/YogaKit/Tests/YogaKitTests.m
+++ b/YogaKit/Tests/YogaKitTests.m
@@ -284,16 +284,15 @@
 
   [container.yoga applyLayout];
 
-  XCTAssertEqual(subview1.bounds.size.width, 150);
-  XCTAssertEqual(subview2.bounds.size.width, 150);
-  XCTAssertEqual(subview3.bounds.size.width, 0);
+  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(150, 50), subview1.bounds.size), @"Actual size is %@", NSStringFromCGSize(subview1.bounds.size));
+  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(150, 50), subview2.bounds.size), @"Actual size is %@", NSStringFromCGSize(subview2.bounds.size));
+  XCTAssertTrue(CGSizeEqualToSize(CGSizeZero, subview3.bounds.size), @"Actual size %@", NSStringFromCGSize(subview3.bounds.size));
 
   subview3.yoga.isIncludedInLayout = YES;
   [container.yoga applyLayout];
-  
-  XCTAssertEqual(subview1.bounds.size.width, 100);
-  XCTAssertEqual(subview2.bounds.size.width, 100);
-  XCTAssertEqual(subview3.bounds.size.width, 100);
+  for (UIView *view in container.subviews) {
+    XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(100, 50), view.bounds.size), @"Actual size is %@", NSStringFromCGSize(view.bounds.size));
+  }
 }
 
 - (void)testyg_isLeafFlag

--- a/YogaKit/Tests/YogaKitTests.m
+++ b/YogaKit/Tests/YogaKitTests.m
@@ -98,7 +98,7 @@
   XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(514,21), containerSize), @"Size is actually %@", NSStringFromCGSize(containerSize));
 }
 
-- (void)testThatMarkingLeafsAsDirtyWillTriggerASizeRecalculation
+- (void)testThatLeafsDetectWhenTheyBecomeDirty
 {
   UIView *container = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 50)];
   container.yoga.isEnabled = YES;
@@ -115,7 +115,6 @@
   XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(146,21), label.bounds.size), @"Size is actually %@", NSStringFromCGSize(label.bounds.size));
 
   label.text = @"This is a slightly longer text.";
-  [label.yoga markDirty];
 
   [container.yoga applyLayout];
   XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(213,21), label.bounds.size), @"Size is actually %@", NSStringFromCGSize(label.bounds.size));
@@ -267,30 +266,34 @@
   UIView *subview1 = [[UIView alloc] initWithFrame:CGRectZero];
   subview1.yoga.isEnabled = YES;
   subview1.yoga.flexGrow = 1;
+  subview1.yoga.flexBasis = 0;
   [container addSubview:subview1];
 
   UIView *subview2 = [[UIView alloc] initWithFrame:CGRectZero];
   subview2.yoga.isEnabled = YES;
   subview2.yoga.flexGrow = 1;
+  subview2.yoga.flexBasis = 0;
   [container addSubview:subview2];
 
   UIView *subview3 = [[UIView alloc] initWithFrame:CGRectZero];
   subview3.yoga.isEnabled = YES;
   subview3.yoga.flexGrow = 1;
+  subview3.yoga.flexBasis = 0;
   subview3.yoga.isIncludedInLayout = NO;
   [container addSubview:subview3];
 
   [container.yoga applyLayout];
 
-  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(150, 50), subview1.bounds.size), @"Actual size is %@", NSStringFromCGSize(subview1.bounds.size));
-  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(150, 50), subview2.bounds.size), @"Actual size is %@", NSStringFromCGSize(subview2.bounds.size));
-  XCTAssertTrue(CGSizeEqualToSize(CGSizeZero, subview3.bounds.size), @"Actual size %@", NSStringFromCGSize(subview3.bounds.size));
+  XCTAssertEqual(subview1.bounds.size.width, 150);
+  XCTAssertEqual(subview2.bounds.size.width, 150);
+  XCTAssertEqual(subview3.bounds.size.width, 0);
 
   subview3.yoga.isIncludedInLayout = YES;
   [container.yoga applyLayout];
-  for (UIView *view in container.subviews) {
-    XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(100, 50), view.bounds.size), @"Actual size is %@", NSStringFromCGSize(view.bounds.size));
-  }
+  
+  XCTAssertEqual(subview1.bounds.size.width, 100);
+  XCTAssertEqual(subview2.bounds.size.width, 100);
+  XCTAssertEqual(subview3.bounds.size.width, 100);
 }
 
 - (void)testyg_isLeafFlag

--- a/YogaKit/YGLayout.h
+++ b/YogaKit/YGLayout.h
@@ -106,9 +106,4 @@
  */
  @property (nonatomic, readonly, assign) BOOL isLeaf;
 
-/**
- Mark that a view's layout needs to be recalculated. Only works for leaf views.
- */
-- (void)markDirty;
-
 @end

--- a/YogaKit/YGLayout.m
+++ b/YogaKit/YGLayout.m
@@ -102,6 +102,7 @@ YG_VALUE_SHORTHAND_EDGE_PROPERTY(lowercased_name, capitalized_name, capitalized_
 @interface YGLayout ()
 
 @property (nonatomic, weak, readonly) UIView *view;
+@property (nonatomic, assign) YGSize cachedSize;
 
 @end
 
@@ -132,13 +133,6 @@ YG_VALUE_SHORTHAND_EDGE_PROPERTY(lowercased_name, capitalized_name, capitalized_
 - (void)dealloc
 {
   YGNodeFree(self.node);
-}
-
-- (void)markDirty
-{
-  if (self.isLeaf) {
-    YGNodeMarkDirty(self.node);
-  }
 }
 
 - (NSUInteger)numberOfChildren
@@ -318,6 +312,14 @@ static void YGAttachNodesFromViewHierachy(UIView *const view)
   if (yoga.isLeaf) {
     YGRemoveAllChildren(node);
     YGNodeSetMeasureFunc(node, YGMeasureView);
+
+    YGSize oldSize = yoga.cachedSize;
+    YGSize newSize = YGMeasureView(node, 0, YGMeasureModeUndefined, 0, YGMeasureModeUndefined);
+    yoga.cachedSize = newSize;
+
+    if (!YGNodeIsDirty(node) && (oldSize.width != newSize.width || oldSize.height != newSize.height)) {
+        YGNodeMarkDirty(node);
+    }
   } else {
     YGNodeSetMeasureFunc(node, NULL);
 


### PR DESCRIPTION
I've come back with my earlier proposal. As we saw on the previous PR, it seems that the only reliable way to do it is to cache the previous size and set the leaf dirty if the measure function returns a different value.

On the previous PR, my modifications caused the `testThatViewNotIncludedInFirstLayoutPassAreIncludedInSecond` test to fail. I finally found out why: the auto-dirtying was actually performing so well that it surfaced a bug in the test :) Because UIKit's `sizeThatFits` returns the current size by default, and because the leafs were not set with a `flexBasis` of `0`, the previous calculated size is taken into account. I fixed the test.