### PR TITLE
Silents errors when running copy-sources

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -13,7 +13,7 @@
         "emcc-path": "emcc-path",
 
         "is-monolithic": "test \"$(basename \"$(pwd)\")\" = javascript",
-        "copy-sources": "! npm -- run is-monolithic || (rsync -r --checksum --delete ../yoga/ sources/yoga/)",
+        "copy-sources": "! npm -s -- run is-monolithic || (rsync -r --checksum --delete ../yoga/ sources/yoga/)",
 
         "build:node": "npm -- run copy-sources && npm -- run node-gyp configure build",
         "build:browser": "npm -- run copy-sources && npm -- run node-gyp configure build --asmjs=1",


### PR DESCRIPTION
Being a environment test, `npm run is-monolithic` is expected to fail when pulling the package from npm and to succeed when pulling it from github. Unfortunately, when returning false, npm will throw a tantrum by default if not explicitely disabled. It's not a hard failure, the build still complete, but it's better this way.