### PR TITLE
Add support for showing the YogaKit README on CocoaPods.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Yoga [![Build Status](https://travis-ci.org/facebook/yoga.svg?branch=master)](https://travis-ci.org/facebook/yoga) [![Cocoapods](https://img.shields.io/cocoapods/v/Yoga.svg)](http://cocoapods.org/pods/Yoga)[![Cocoapods](https://img.shields.io/cocoapods/v/YogaKit.svg)](http://cocoapods.org/pods/YogaKit)[![npm](https://img.shields.io/npm/v/yoga-layout.svg)](https://www.npmjs.com/package/yoga-layout)
+# Yoga [![Build Status](https://travis-ci.org/facebook/yoga.svg?branch=master)](https://travis-ci.org/facebook/yoga) [![CocoaPods](https://img.shields.io/cocoapods/v/YogaKit.svg)](http://cocoapods.org/pods/YogaKit) [![npm](https://img.shields.io/npm/v/yoga-layout.svg)](https://www.npmjs.com/package/yoga-layout)
 
 ## Building
 Yoga builds with [buck](https://buckbuild.com). Make sure you install buck before contributing to Yoga. Yoga's main implementation is in C, with bindings to supported languages and frameworks. When making changes to Yoga please ensure the changes are also propagated to these bindings when applicable.

--- a/YogaKit/README.md
+++ b/YogaKit/README.md
@@ -1,11 +1,11 @@
 # YogaKit
 
-[![Cocoapods](https://img.shields.io/cocoapods/v/YogaKit.svg?style=flat)](https://cocoapods.org/pods/YogaKit)
+[![CocoaPods](https://img.shields.io/cocoapods/v/YogaKit.svg?style=flat)](https://cocoapods.org/pods/YogaKit)
 [![Platform](https://img.shields.io/badge/platforms-iOS-orange.svg)](https://facebook.github.io/yoga/docs/api/yogakit/)
 [![Languages](https://img.shields.io/badge/languages-ObjC%20%7C%20Swift-orange.svg)](https://facebook.github.io/yoga/docs/api/yogakit/)
 
 ## Installation
-YogaKit is available to install via [Cocoapods](https://cocoapods.org/).
+YogaKit is available to install via [CocoaPods](https://cocoapods.org/).
 
 ```
 pod 'YogaKit', '~> 1.0.2'

--- a/YogaKit/YogaKit.podspec
+++ b/YogaKit/YogaKit.podspec
@@ -1,4 +1,4 @@
-Pod::Spec.new do |spec|
+podspec = Pod::Spec.new do |spec|
   spec.name = 'YogaKit'
   spec.version = '1.0.2'
   spec.license =  { :type => 'BSD', :file => "LICENSE" }
@@ -23,3 +23,7 @@ Pod::Spec.new do |spec|
   spec.public_header_files = 'YogaKit/Source/{YGLayout,UIView+Yoga}.h'
   spec.private_header_files = 'YogaKit/Source/YGLayout+Private.h'
 end
+
+# See https://github.com/facebook/yoga/pull/366
+podspec.attributes_hash["readme"] = "YogaKit/README.md"
+podspec


### PR DESCRIPTION
Hey there, congrats on the launch - we use React Native at Artsy, and I've been wondering about what Yoga + Jest Snapshots for RN looks like but haven't had the time to explore that yet. 

With https://github.com/CocoaPods/cocoadocs.org/pull/501 I added the ability to customize the location of the README for the front-page of the CocoaPods site. That is being deployed as I speak, so it should be available the next time you decide to ship a version of Yoga.

I also fixed the capitalisation of CocoaPods, and removed a redundant CocoaPods badge on your initial README.