### PR TITLE
Exclude YGEnums.h from format.sh

### DIFF
--- a/enums.py
+++ b/enums.py
@@ -132,20 +132,21 @@ with open(root + '/yoga/YGEnums.h', 'w') as f:
     for name, values in sorted(ENUMS.items()):
         f.write('#define YG%sCount %s\n' % (name, len(values)))        
         f.write('typedef YG_ENUM_BEGIN(YG%s) {\n ' % name)
-        charsOnLine = 0
+        charsOnLine = 1
         for value in values:
-            charsOnLine += len(name) + len(value) + 4
+            textToWrite = ''
             if isinstance(value, tuple):
-                charsOnLine += 4
-            if charsOnLine >= 100:
-                f.write('\n     ')
-                charsOnLine = 0
-
-            if isinstance(value, tuple):
-                f.write(' YG%s%s = %d,' % (name, value[0], value[1]))
+                textToWrite = ' YG%s%s = %d,' % (name, value[0], value[1])
             else:
-                f.write(' YG%s%s,' % (name, value))
-                
+                textToWrite = ' YG%s%s,' % (name, value)
+            
+            charsOnLine += len(textToWrite)
+            if charsOnLine > 100:
+                f.write('\n     ')
+                charsOnLine = 5
+            
+            f.write(textToWrite)
+     
         f.write('\n}\nYG_ENUM_END(YG%s);\n' % name)
         f.write('\n')
     f.write('YG_EXTERN_C_END\n')

--- a/enums.py
+++ b/enums.py
@@ -131,23 +131,13 @@ with open(root + '/yoga/YGEnums.h', 'w') as f:
     f.write('YG_EXTERN_C_BEGIN\n\n')
     for name, values in sorted(ENUMS.items()):
         f.write('#define YG%sCount %s\n' % (name, len(values)))        
-        f.write('typedef YG_ENUM_BEGIN(YG%s) {\n ' % name)
-        charsOnLine = 1
+        f.write('typedef YG_ENUM_BEGIN(YG%s) {\n' % name)
         for value in values:
-            textToWrite = ''
             if isinstance(value, tuple):
-                textToWrite = ' YG%s%s = %d,' % (name, value[0], value[1])
+                f.write('  YG%s%s = %d,\n' % (name, value[0], value[1]))
             else:
-                textToWrite = ' YG%s%s,' % (name, value)
-            
-            charsOnLine += len(textToWrite)
-            if charsOnLine > 100:
-                f.write('\n     ')
-                charsOnLine = 5
-            
-            f.write(textToWrite)
-     
-        f.write('\n}\nYG_ENUM_END(YG%s);\n' % name)
+                f.write('  YG%s%s,\n' % (name, value))
+        f.write('} YG_ENUM_END(YG%s);\n' % name)
         f.write('\n')
     f.write('YG_EXTERN_C_END\n')
 

--- a/enums.py
+++ b/enums.py
@@ -131,13 +131,22 @@ with open(root + '/yoga/YGEnums.h', 'w') as f:
     f.write('YG_EXTERN_C_BEGIN\n\n')
     for name, values in sorted(ENUMS.items()):
         f.write('#define YG%sCount %s\n' % (name, len(values)))        
-        f.write('typedef YG_ENUM_BEGIN(YG%s) {\n' % name)
+        f.write('typedef YG_ENUM_BEGIN(YG%s) {\n ' % name)
+        charsOnLine = 0
         for value in values:
+            charsOnLine += len(name) + len(value) + 4
             if isinstance(value, tuple):
-                f.write('  YG%s%s = %d,\n' % (name, value[0], value[1]))
+                charsOnLine += 4
+            if charsOnLine >= 100:
+                f.write('\n     ')
+                charsOnLine = 0
+
+            if isinstance(value, tuple):
+                f.write(' YG%s%s = %d,' % (name, value[0], value[1]))
             else:
-                f.write('  YG%s%s,\n' % (name, value))
-        f.write('} YG_ENUM_END(YG%s);\n' % name)
+                f.write(' YG%s%s,' % (name, value))
+                
+        f.write('\n}\nYG_ENUM_END(YG%s);\n' % name)
         f.write('\n')
     f.write('YG_EXTERN_C_END\n')
 

--- a/format.sh
+++ b/format.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 BASEDIR="$(dirname "$0")"
-FILES=$(find "$BASEDIR" \( -path "$BASEDIR/buck-out" -o -path "$BASEDIR/lib" \) -prune -o \
-  \( -name  \*.h -o -name \*.c -o -name \*.cpp \) -print)
+FILES=$(find $BASEDIR \( -path "$BASEDIR/buck-out" -o -path "$BASEDIR/lib" \) -prune -o \
+  \( -name  \*.h ! -name YGEnums.h -o -name \*.c -o -name \*.cpp \) -print)
 
 for f in $FILES "$@"; do
   clang-format \

--- a/format.sh
+++ b/format.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 BASEDIR="$(dirname "$0")"
-FILES=$(find $BASEDIR \( -path "$BASEDIR/buck-out" -o -path "$BASEDIR/lib" \) -prune -o \
+FILES=$(find "$BASEDIR" \( -path "$BASEDIR/buck-out" -o -path "$BASEDIR/lib" \) -prune -o \
   \( -name  \*.h ! -name YGEnums.h -o -name \*.c -o -name \*.cpp \) -print)
 
 for f in $FILES "$@"; do

--- a/yoga/YGEnums.h
+++ b/yoga/YGEnums.h
@@ -33,9 +33,9 @@ YG_ENUM_END(YGDirection);
 
 #define YGDisplayCount 2
 typedef YG_ENUM_BEGIN(YGDisplay) {
-  YGDisplayFlex,
-  YGDisplayNone,
-} YG_ENUM_END(YGDisplay);
+  YGDisplayFlex, YGDisplayNone,
+}
+YG_ENUM_END(YGDisplay);
 
 #define YGEdgeCount 9
 typedef YG_ENUM_BEGIN(YGEdge) {

--- a/yoga/YGEnums.h
+++ b/yoga/YGEnums.h
@@ -15,95 +15,116 @@ YG_EXTERN_C_BEGIN
 
 #define YGAlignCount 6
 typedef YG_ENUM_BEGIN(YGAlign) {
-  YGAlignAuto, YGAlignFlexStart, YGAlignCenter, YGAlignFlexEnd, YGAlignStretch, YGAlignBaseline,
-}
-YG_ENUM_END(YGAlign);
+  YGAlignAuto,
+  YGAlignFlexStart,
+  YGAlignCenter,
+  YGAlignFlexEnd,
+  YGAlignStretch,
+  YGAlignBaseline,
+} YG_ENUM_END(YGAlign);
 
 #define YGDimensionCount 2
 typedef YG_ENUM_BEGIN(YGDimension) {
-  YGDimensionWidth, YGDimensionHeight,
-}
-YG_ENUM_END(YGDimension);
+  YGDimensionWidth,
+  YGDimensionHeight,
+} YG_ENUM_END(YGDimension);
 
 #define YGDirectionCount 3
 typedef YG_ENUM_BEGIN(YGDirection) {
-  YGDirectionInherit, YGDirectionLTR, YGDirectionRTL,
-}
-YG_ENUM_END(YGDirection);
+  YGDirectionInherit,
+  YGDirectionLTR,
+  YGDirectionRTL,
+} YG_ENUM_END(YGDirection);
 
 #define YGDisplayCount 2
 typedef YG_ENUM_BEGIN(YGDisplay) {
-  YGDisplayFlex, YGDisplayNone,
-}
-YG_ENUM_END(YGDisplay);
+  YGDisplayFlex,
+  YGDisplayNone,
+} YG_ENUM_END(YGDisplay);
 
 #define YGEdgeCount 9
 typedef YG_ENUM_BEGIN(YGEdge) {
-  YGEdgeLeft, YGEdgeTop, YGEdgeRight, YGEdgeBottom, YGEdgeStart, YGEdgeEnd, YGEdgeHorizontal,
-      YGEdgeVertical, YGEdgeAll,
-}
-YG_ENUM_END(YGEdge);
+  YGEdgeLeft,
+  YGEdgeTop,
+  YGEdgeRight,
+  YGEdgeBottom,
+  YGEdgeStart,
+  YGEdgeEnd,
+  YGEdgeHorizontal,
+  YGEdgeVertical,
+  YGEdgeAll,
+} YG_ENUM_END(YGEdge);
 
 #define YGExperimentalFeatureCount 2
 typedef YG_ENUM_BEGIN(YGExperimentalFeature) {
-  YGExperimentalFeatureRounding, YGExperimentalFeatureWebFlexBasis,
-}
-YG_ENUM_END(YGExperimentalFeature);
+  YGExperimentalFeatureRounding,
+  YGExperimentalFeatureWebFlexBasis,
+} YG_ENUM_END(YGExperimentalFeature);
 
 #define YGFlexDirectionCount 4
 typedef YG_ENUM_BEGIN(YGFlexDirection) {
-  YGFlexDirectionColumn, YGFlexDirectionColumnReverse, YGFlexDirectionRow,
-      YGFlexDirectionRowReverse,
-}
-YG_ENUM_END(YGFlexDirection);
+  YGFlexDirectionColumn,
+  YGFlexDirectionColumnReverse,
+  YGFlexDirectionRow,
+  YGFlexDirectionRowReverse,
+} YG_ENUM_END(YGFlexDirection);
 
 #define YGJustifyCount 5
 typedef YG_ENUM_BEGIN(YGJustify) {
-  YGJustifyFlexStart, YGJustifyCenter, YGJustifyFlexEnd, YGJustifySpaceBetween,
-      YGJustifySpaceAround,
-}
-YG_ENUM_END(YGJustify);
+  YGJustifyFlexStart,
+  YGJustifyCenter,
+  YGJustifyFlexEnd,
+  YGJustifySpaceBetween,
+  YGJustifySpaceAround,
+} YG_ENUM_END(YGJustify);
 
 #define YGLogLevelCount 5
 typedef YG_ENUM_BEGIN(YGLogLevel) {
-  YGLogLevelError, YGLogLevelWarn, YGLogLevelInfo, YGLogLevelDebug, YGLogLevelVerbose,
-}
-YG_ENUM_END(YGLogLevel);
+  YGLogLevelError,
+  YGLogLevelWarn,
+  YGLogLevelInfo,
+  YGLogLevelDebug,
+  YGLogLevelVerbose,
+} YG_ENUM_END(YGLogLevel);
 
 #define YGMeasureModeCount 3
 typedef YG_ENUM_BEGIN(YGMeasureMode) {
-  YGMeasureModeUndefined, YGMeasureModeExactly, YGMeasureModeAtMost,
-}
-YG_ENUM_END(YGMeasureMode);
+  YGMeasureModeUndefined,
+  YGMeasureModeExactly,
+  YGMeasureModeAtMost,
+} YG_ENUM_END(YGMeasureMode);
 
 #define YGOverflowCount 3
 typedef YG_ENUM_BEGIN(YGOverflow) {
-  YGOverflowVisible, YGOverflowHidden, YGOverflowScroll,
-}
-YG_ENUM_END(YGOverflow);
+  YGOverflowVisible,
+  YGOverflowHidden,
+  YGOverflowScroll,
+} YG_ENUM_END(YGOverflow);
 
 #define YGPositionTypeCount 2
 typedef YG_ENUM_BEGIN(YGPositionType) {
-  YGPositionTypeRelative, YGPositionTypeAbsolute,
-}
-YG_ENUM_END(YGPositionType);
+  YGPositionTypeRelative,
+  YGPositionTypeAbsolute,
+} YG_ENUM_END(YGPositionType);
 
 #define YGPrintOptionsCount 3
 typedef YG_ENUM_BEGIN(YGPrintOptions) {
-  YGPrintOptionsLayout = 1, YGPrintOptionsStyle = 2, YGPrintOptionsChildren = 4,
-}
-YG_ENUM_END(YGPrintOptions);
+  YGPrintOptionsLayout = 1,
+  YGPrintOptionsStyle = 2,
+  YGPrintOptionsChildren = 4,
+} YG_ENUM_END(YGPrintOptions);
 
 #define YGUnitCount 3
 typedef YG_ENUM_BEGIN(YGUnit) {
-  YGUnitUndefined, YGUnitPixel, YGUnitPercent,
-}
-YG_ENUM_END(YGUnit);
+  YGUnitUndefined,
+  YGUnitPixel,
+  YGUnitPercent,
+} YG_ENUM_END(YGUnit);
 
 #define YGWrapCount 2
 typedef YG_ENUM_BEGIN(YGWrap) {
-  YGWrapNoWrap, YGWrapWrap,
-}
-YG_ENUM_END(YGWrap);
+  YGWrapNoWrap,
+  YGWrapWrap,
+} YG_ENUM_END(YGWrap);
 
 YG_EXTERN_C_END


### PR DESCRIPTION
This PR excludes YGEnums.h from formatting via format.sh. Reduces the clutter due to missed format.sh calls after enums.py generation.