### PR TITLE
Removed duplicate code by calculating with mainSize/crossSize

### DIFF
--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -1440,8 +1440,7 @@ static void YGNodeComputeFlexBasisForChild(const YGNodeRef node,
                          "measure");
 
     child->layout.computedFlexBasis =
-        fmaxf(isMainAxisRow ? child->layout.measuredDimensions[YGDimensionWidth]
-                            : child->layout.measuredDimensions[YGDimensionHeight],
+        fmaxf(child->layout.measuredDimensions[dim[mainAxis]],
               YGNodePaddingAndBorderForAxis(child, mainAxis, parentWidth));
   }
 
@@ -2331,117 +2330,79 @@ static void YGNodelayoutImpl(const YGNodeRef node,
 
         deltaFreeSpace -= updatedMainSize - childFlexBasis;
 
-        float childWidth;
-        float childHeight;
-        YGMeasureMode childWidthMeasureMode;
-        YGMeasureMode childHeightMeasureMode;
+        float childMainSize;
+        float childCrossSize;
+        YGMeasureMode childMainMeasureMode;
+        YGMeasureMode childCrossMeasureMode;
 
-        const float marginRow =
-            YGNodeMarginForAxis(currentRelativeChild, YGFlexDirectionRow, availableInnerWidth);
-        const float marginColumn =
-            YGNodeMarginForAxis(currentRelativeChild, YGFlexDirectionColumn, availableInnerWidth);
+        const float marginMain =
+            YGNodeMarginForAxis(currentRelativeChild, mainAxis, availableInnerWidth);
+        const float marginCross =
+            YGNodeMarginForAxis(currentRelativeChild, crossAxis, availableInnerWidth);
 
-        if (isMainAxisRow) {
-          childWidth = updatedMainSize + marginRow;
-          childWidthMeasureMode = YGMeasureModeExactly;
+        childMainSize = updatedMainSize + marginMain;
+        childMainMeasureMode = YGMeasureModeExactly;
 
-          if (!YGFloatIsUndefined(availableInnerCrossDim) &&
-              !YGNodeIsStyleDimDefined(currentRelativeChild,
-                                       YGFlexDirectionColumn,
-                                       availableInnerHeight) &&
-              heightMeasureMode == YGMeasureModeExactly &&
+        if (!YGFloatIsUndefined(availableInnerCrossDim) &&
+            !YGNodeIsStyleDimDefined(currentRelativeChild, crossAxis, availableInnerCrossDim) &&
+            heightMeasureMode == YGMeasureModeExactly &&
               !(isNodeFlexWrap && flexBasisOverflows) &&
-              YGNodeAlignItem(node, currentRelativeChild) == YGAlignStretch) {
-            childHeight = availableInnerCrossDim;
-            childHeightMeasureMode = YGMeasureModeExactly;
-          } else if (!YGNodeIsStyleDimDefined(currentRelativeChild,
-                                              YGFlexDirectionColumn,
-                                              availableInnerHeight)) {
-            childHeight = availableInnerCrossDim;
-            childHeightMeasureMode =
-                YGFloatIsUndefined(childHeight) ? YGMeasureModeUndefined : YGMeasureModeAtMost;
-          } else {
-            childHeight =
-                YGValueResolve(currentRelativeChild->resolvedDimensions[YGDimensionHeight],
-                               availableInnerHeight) +
-                marginColumn;
-            childHeightMeasureMode =
-                YGFloatIsUndefined(childHeight) ? YGMeasureModeUndefined : YGMeasureModeExactly;
-          }
+            YGNodeAlignItem(node, currentRelativeChild) == YGAlignStretch) {
+          childCrossSize = availableInnerCrossDim;
+          childCrossMeasureMode = YGMeasureModeExactly;
+        } else if (!YGNodeIsStyleDimDefined(currentRelativeChild,
+                                            crossAxis,
+                                            availableInnerCrossDim)) {
+          childCrossSize = availableInnerCrossDim;
+          childCrossMeasureMode =
+              YGFloatIsUndefined(childCrossSize) ? YGMeasureModeUndefined : YGMeasureModeAtMost;
         } else {
-          childHeight = updatedMainSize + marginColumn;
-          childHeightMeasureMode = YGMeasureModeExactly;
-
-          if (!YGFloatIsUndefined(availableInnerCrossDim) &&
-              !YGNodeIsStyleDimDefined(currentRelativeChild,
-                                       YGFlexDirectionRow,
-                                       availableInnerWidth) &&
-              widthMeasureMode == YGMeasureModeExactly && !(isNodeFlexWrap && flexBasisOverflows) &&
-              YGNodeAlignItem(node, currentRelativeChild) == YGAlignStretch) {
-            childWidth = availableInnerCrossDim;
-            childWidthMeasureMode = YGMeasureModeExactly;
-          } else if (!YGNodeIsStyleDimDefined(currentRelativeChild,
-                                              YGFlexDirectionRow,
-                                              availableInnerWidth)) {
-            childWidth = availableInnerCrossDim;
-            childWidthMeasureMode =
-                YGFloatIsUndefined(childWidth) ? YGMeasureModeUndefined : YGMeasureModeAtMost;
-          } else {
-            childWidth = YGValueResolve(currentRelativeChild->resolvedDimensions[YGDimensionWidth],
-                                        availableInnerWidth) +
-                         marginRow;
-            childWidthMeasureMode =
-                YGFloatIsUndefined(childWidth) ? YGMeasureModeUndefined : YGMeasureModeExactly;
-          }
+          childCrossSize = YGValueResolve(currentRelativeChild->resolvedDimensions[dim[crossAxis]],
+                                          availableInnerCrossDim) +
+                           marginCross;
+          childCrossMeasureMode =
+              YGFloatIsUndefined(childCrossSize) ? YGMeasureModeUndefined : YGMeasureModeExactly;
         }
 
         if (!YGFloatIsUndefined(currentRelativeChild->style.aspectRatio)) {
-          if (isMainAxisRow) {
-            childHeight = fmaxf((childWidth - marginRow) / currentRelativeChild->style.aspectRatio,
-                                YGNodePaddingAndBorderForAxis(currentRelativeChild,
-                                                              YGFlexDirectionColumn,
-                                                              availableInnerWidth));
-            childHeightMeasureMode = YGMeasureModeExactly;
+          childCrossSize =
+              fmaxf((childCrossSize - marginCross) / currentRelativeChild->style.aspectRatio,
+                    YGNodePaddingAndBorderForAxis(currentRelativeChild,
+                                                  YGFlexDirectionColumn,
+                                                  availableInnerWidth));
+          childMainMeasureMode = YGMeasureModeExactly;
 
-            // Parent size constraint should have higher priority than flex
-            if (YGNodeIsFlex(currentRelativeChild)) {
-              childHeight = fminf((childHeight - marginColumn), availableInnerHeight);
-              childWidth = marginRow + childHeight * currentRelativeChild->style.aspectRatio;
-            }
-
-            childHeight += marginColumn;
-          } else {
-            childWidth =
-                fmaxf((childHeight - marginColumn) * currentRelativeChild->style.aspectRatio,
-                      YGNodePaddingAndBorderForAxis(currentRelativeChild,
-                                                    YGFlexDirectionRow,
-                                                    availableInnerWidth));
-            childWidthMeasureMode = YGMeasureModeExactly;
-
-            // Parent size constraint should have higher priority than flex
-            if (YGNodeIsFlex(currentRelativeChild)) {
-              childWidth = fminf((childWidth - marginRow), availableInnerWidth);
-              childHeight = marginColumn + childWidth / currentRelativeChild->style.aspectRatio;
-            }
-
-            childWidth += marginRow;
+          // Parent size constraint should have higher priority than flex
+          if (YGNodeIsFlex(currentRelativeChild)) {
+            childMainSize = fminf(childMainSize - marginMain, availableInnerHeight);
+            childCrossSize = marginCross + childMainSize * currentRelativeChild->style.aspectRatio;
           }
+
+          childMainSize += marginMain;
         }
 
         YGConstrainMaxSizeForMode(
-            YGValueResolve(&currentRelativeChild->style.maxDimensions[YGDimensionWidth],
+            YGValueResolve(&currentRelativeChild->style.maxDimensions[dim[mainAxis]],
                            availableInnerWidth),
-            &childWidthMeasureMode,
-            &childWidth);
+            &childMainMeasureMode,
+            &childMainSize);
         YGConstrainMaxSizeForMode(
-            YGValueResolve(&currentRelativeChild->style.maxDimensions[YGDimensionHeight],
+            YGValueResolve(&currentRelativeChild->style.maxDimensions[dim[crossAxis]],
                            availableInnerHeight),
-            &childHeightMeasureMode,
-            &childHeight);
+            &childCrossMeasureMode,
+            &childCrossSize);
 
         const bool requiresStretchLayout =
             !YGNodeIsStyleDimDefined(currentRelativeChild, crossAxis, availableInnerCrossDim) &&
             YGNodeAlignItem(node, currentRelativeChild) == YGAlignStretch;
+
+        const float childWidth = isMainAxisRow ? childMainSize : childCrossSize;
+        const float childHeight = !isMainAxisRow ? childMainSize : childCrossSize;
+
+        const YGMeasureMode childWidthMeasureMode =
+            isMainAxisRow ? childMainMeasureMode : childCrossMeasureMode;
+        const YGMeasureMode childHeightMeasureMode =
+            !isMainAxisRow ? childMainMeasureMode : childCrossMeasureMode;
 
         // Recursively call the layout algorithm for this child with the updated
         // main size.
@@ -2651,59 +2612,39 @@ static void YGNodelayoutImpl(const YGNodeRef node,
           if (alignItem == YGAlignStretch &&
               child->style.margin[leading[crossAxis]].unit != YGUnitAuto &&
               child->style.margin[trailing[crossAxis]].unit != YGUnitAuto) {
-            const bool isCrossSizeDefinite =
-                (isMainAxisRow &&
-                 YGNodeIsStyleDimDefined(child, YGFlexDirectionColumn, availableInnerHeight)) ||
-                (!isMainAxisRow &&
-                 YGNodeIsStyleDimDefined(child, YGFlexDirectionRow, availableInnerWidth));
+              
+            const bool isCrossSizeDefined =
+                YGNodeIsStyleDimDefined(child, crossAxis, availableInnerCrossDim);
 
-            float childWidth;
-            float childHeight;
-            YGMeasureMode childWidthMeasureMode = YGMeasureModeExactly;
-            YGMeasureMode childHeightMeasureMode = YGMeasureModeExactly;
+            float childMainSize = child->layout.measuredDimensions[dim[mainAxis]];
+            float childCrossSize =
+                !YGFloatIsUndefined(child->style.aspectRatio)
+                    ? (YGNodeMarginForAxis(child, crossAxis, availableInnerWidth) +
+                       childMainSize / child->style.aspectRatio)
+                    : crossDim;
 
-            const float marginRow =
-                YGNodeMarginForAxis(child, YGFlexDirectionRow, availableInnerWidth);
-            const float marginColumn =
-                YGNodeMarginForAxis(child, YGFlexDirectionColumn, availableInnerWidth);
+            childMainSize += YGNodeMarginForAxis(child, mainAxis, availableInnerWidth);
 
-            if (isMainAxisRow) {
-              childWidth = child->layout.measuredDimensions[YGDimensionWidth];
-
-              if (!YGFloatIsUndefined(child->style.aspectRatio)) {
-                childHeight = marginColumn + childWidth / child->style.aspectRatio;
-              } else {
-                childHeight = crossDim;
-              }
-
-              childWidth += marginRow;
-            } else {
-              childHeight = child->layout.measuredDimensions[YGDimensionHeight];
-
-              if (!YGFloatIsUndefined(child->style.aspectRatio)) {
-                childWidth = marginRow + childHeight * child->style.aspectRatio;
-              } else {
-                childWidth = crossDim;
-              }
-
-              childHeight += marginColumn;
-            }
-
-            YGConstrainMaxSizeForMode(YGValueResolve(&child->style.maxDimensions[YGDimensionWidth],
-                                                     availableInnerWidth),
-                                      &childWidthMeasureMode,
-                                      &childWidth);
-            YGConstrainMaxSizeForMode(YGValueResolve(&child->style.maxDimensions[YGDimensionHeight],
-                                                     availableInnerHeight),
-                                      &childHeightMeasureMode,
-                                      &childHeight);
+            YGMeasureMode childMainMeasureMode = YGMeasureModeExactly;
+            YGMeasureMode childCrossMeasureMode = YGMeasureModeExactly;
+            YGConstrainMaxSizeForMode(YGValueResolve(&child->style.maxDimensions[dim[mainAxis]],
+                                                     availableInnerMainDim),
+                                      &childMainMeasureMode,
+                                      &childMainSize);
+            YGConstrainMaxSizeForMode(YGValueResolve(&child->style.maxDimensions[dim[crossAxis]],
+                                                     availableInnerCrossDim),
+                                      &childCrossMeasureMode,
+                                      &childCrossSize);
 
             // If the child defines a definite size for its cross axis, there's
             // no need to stretch.
-            if (!isCrossSizeDefinite) {
-              childWidthMeasureMode =
+            if (!isCrossSizeDefined) {
+              const float childWidth = isMainAxisRow ? childMainSize : childCrossSize;
+              const float childHeight = !isMainAxisRow ? childMainSize : childCrossSize;
+
+              const YGMeasureMode childWidthMeasureMode =
                   YGFloatIsUndefined(childWidth) ? YGMeasureModeUndefined : YGMeasureModeExactly;
-              childHeightMeasureMode =
+              const YGMeasureMode childHeightMeasureMode =
                   YGFloatIsUndefined(childHeight) ? YGMeasureModeUndefined : YGMeasureModeExactly;
 
               YGLayoutNodeInternal(child,


### PR DESCRIPTION
This PR removes some duplicate code by calculating with ```mainSize```/```crossSize``` and converting that to ```width``` or ```height``` at the end. See #395 .