### PR TITLE
flex-wrap: wrap-reverse support

### DIFF
--- a/csharp/Facebook.Yoga/YogaWrap.cs
+++ b/csharp/Facebook.Yoga/YogaWrap.cs
@@ -13,5 +13,6 @@ namespace Facebook.Yoga
     {
         NoWrap,
         Wrap,
+        WrapReverse,
     }
 }

--- a/csharp/tests/Facebook.Yoga/YGFlexWrapTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGFlexWrapTest.cs
@@ -544,5 +544,603 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root_child1.LayoutHeight);
         }
 
+        [Test]
+        public void Test_wrap_reverse_row_align_content_flex_start()
+        {
+            YogaNode root = new YogaNode();
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.Wrap = YogaWrap.WrapReverse;
+            root.Width = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.Width = 30;
+            root_child0.Height = 10;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode();
+            root_child1.Width = 30;
+            root_child1.Height = 20;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode();
+            root_child2.Width = 30;
+            root_child2.Height = 30;
+            root.Insert(2, root_child2);
+
+            YogaNode root_child3 = new YogaNode();
+            root_child3.Width = 30;
+            root_child3.Height = 40;
+            root.Insert(3, root_child3);
+
+            YogaNode root_child4 = new YogaNode();
+            root_child4.Width = 30;
+            root_child4.Height = 50;
+            root.Insert(4, root_child4);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(80f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(70f, root_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child1.LayoutX);
+            Assert.AreEqual(60f, root_child1.LayoutY);
+            Assert.AreEqual(30f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(60f, root_child2.LayoutX);
+            Assert.AreEqual(50f, root_child2.LayoutY);
+            Assert.AreEqual(30f, root_child2.LayoutWidth);
+            Assert.AreEqual(30f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child3.LayoutX);
+            Assert.AreEqual(10f, root_child3.LayoutY);
+            Assert.AreEqual(30f, root_child3.LayoutWidth);
+            Assert.AreEqual(40f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child4.LayoutX);
+            Assert.AreEqual(0f, root_child4.LayoutY);
+            Assert.AreEqual(30f, root_child4.LayoutWidth);
+            Assert.AreEqual(50f, root_child4.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(80f, root.LayoutHeight);
+
+            Assert.AreEqual(70f, root_child0.LayoutX);
+            Assert.AreEqual(70f, root_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(40f, root_child1.LayoutX);
+            Assert.AreEqual(60f, root_child1.LayoutY);
+            Assert.AreEqual(30f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(10f, root_child2.LayoutX);
+            Assert.AreEqual(50f, root_child2.LayoutY);
+            Assert.AreEqual(30f, root_child2.LayoutWidth);
+            Assert.AreEqual(30f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(70f, root_child3.LayoutX);
+            Assert.AreEqual(10f, root_child3.LayoutY);
+            Assert.AreEqual(30f, root_child3.LayoutWidth);
+            Assert.AreEqual(40f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(40f, root_child4.LayoutX);
+            Assert.AreEqual(0f, root_child4.LayoutY);
+            Assert.AreEqual(30f, root_child4.LayoutWidth);
+            Assert.AreEqual(50f, root_child4.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_wrap_reverse_row_align_content_center()
+        {
+            YogaNode root = new YogaNode();
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignContent = YogaAlign.Center;
+            root.Wrap = YogaWrap.WrapReverse;
+            root.Width = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.Width = 30;
+            root_child0.Height = 10;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode();
+            root_child1.Width = 30;
+            root_child1.Height = 20;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode();
+            root_child2.Width = 30;
+            root_child2.Height = 30;
+            root.Insert(2, root_child2);
+
+            YogaNode root_child3 = new YogaNode();
+            root_child3.Width = 30;
+            root_child3.Height = 40;
+            root.Insert(3, root_child3);
+
+            YogaNode root_child4 = new YogaNode();
+            root_child4.Width = 30;
+            root_child4.Height = 50;
+            root.Insert(4, root_child4);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(80f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(70f, root_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child1.LayoutX);
+            Assert.AreEqual(60f, root_child1.LayoutY);
+            Assert.AreEqual(30f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(60f, root_child2.LayoutX);
+            Assert.AreEqual(50f, root_child2.LayoutY);
+            Assert.AreEqual(30f, root_child2.LayoutWidth);
+            Assert.AreEqual(30f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child3.LayoutX);
+            Assert.AreEqual(10f, root_child3.LayoutY);
+            Assert.AreEqual(30f, root_child3.LayoutWidth);
+            Assert.AreEqual(40f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child4.LayoutX);
+            Assert.AreEqual(0f, root_child4.LayoutY);
+            Assert.AreEqual(30f, root_child4.LayoutWidth);
+            Assert.AreEqual(50f, root_child4.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(80f, root.LayoutHeight);
+
+            Assert.AreEqual(70f, root_child0.LayoutX);
+            Assert.AreEqual(70f, root_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(40f, root_child1.LayoutX);
+            Assert.AreEqual(60f, root_child1.LayoutY);
+            Assert.AreEqual(30f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(10f, root_child2.LayoutX);
+            Assert.AreEqual(50f, root_child2.LayoutY);
+            Assert.AreEqual(30f, root_child2.LayoutWidth);
+            Assert.AreEqual(30f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(70f, root_child3.LayoutX);
+            Assert.AreEqual(10f, root_child3.LayoutY);
+            Assert.AreEqual(30f, root_child3.LayoutWidth);
+            Assert.AreEqual(40f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(40f, root_child4.LayoutX);
+            Assert.AreEqual(0f, root_child4.LayoutY);
+            Assert.AreEqual(30f, root_child4.LayoutWidth);
+            Assert.AreEqual(50f, root_child4.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_wrap_reverse_row_single_line_different_size()
+        {
+            YogaNode root = new YogaNode();
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.Wrap = YogaWrap.WrapReverse;
+            root.Width = 300;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.Width = 30;
+            root_child0.Height = 10;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode();
+            root_child1.Width = 30;
+            root_child1.Height = 20;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode();
+            root_child2.Width = 30;
+            root_child2.Height = 30;
+            root.Insert(2, root_child2);
+
+            YogaNode root_child3 = new YogaNode();
+            root_child3.Width = 30;
+            root_child3.Height = 40;
+            root.Insert(3, root_child3);
+
+            YogaNode root_child4 = new YogaNode();
+            root_child4.Width = 30;
+            root_child4.Height = 50;
+            root.Insert(4, root_child4);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(300f, root.LayoutWidth);
+            Assert.AreEqual(50f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(40f, root_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child1.LayoutX);
+            Assert.AreEqual(30f, root_child1.LayoutY);
+            Assert.AreEqual(30f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(60f, root_child2.LayoutX);
+            Assert.AreEqual(20f, root_child2.LayoutY);
+            Assert.AreEqual(30f, root_child2.LayoutWidth);
+            Assert.AreEqual(30f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(90f, root_child3.LayoutX);
+            Assert.AreEqual(10f, root_child3.LayoutY);
+            Assert.AreEqual(30f, root_child3.LayoutWidth);
+            Assert.AreEqual(40f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(120f, root_child4.LayoutX);
+            Assert.AreEqual(0f, root_child4.LayoutY);
+            Assert.AreEqual(30f, root_child4.LayoutWidth);
+            Assert.AreEqual(50f, root_child4.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(300f, root.LayoutWidth);
+            Assert.AreEqual(50f, root.LayoutHeight);
+
+            Assert.AreEqual(270f, root_child0.LayoutX);
+            Assert.AreEqual(40f, root_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(240f, root_child1.LayoutX);
+            Assert.AreEqual(30f, root_child1.LayoutY);
+            Assert.AreEqual(30f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(210f, root_child2.LayoutX);
+            Assert.AreEqual(20f, root_child2.LayoutY);
+            Assert.AreEqual(30f, root_child2.LayoutWidth);
+            Assert.AreEqual(30f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(180f, root_child3.LayoutX);
+            Assert.AreEqual(10f, root_child3.LayoutY);
+            Assert.AreEqual(30f, root_child3.LayoutWidth);
+            Assert.AreEqual(40f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(150f, root_child4.LayoutX);
+            Assert.AreEqual(0f, root_child4.LayoutY);
+            Assert.AreEqual(30f, root_child4.LayoutWidth);
+            Assert.AreEqual(50f, root_child4.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_wrap_reverse_row_align_content_stretch()
+        {
+            YogaNode root = new YogaNode();
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignContent = YogaAlign.Stretch;
+            root.Wrap = YogaWrap.WrapReverse;
+            root.Width = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.Width = 30;
+            root_child0.Height = 10;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode();
+            root_child1.Width = 30;
+            root_child1.Height = 20;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode();
+            root_child2.Width = 30;
+            root_child2.Height = 30;
+            root.Insert(2, root_child2);
+
+            YogaNode root_child3 = new YogaNode();
+            root_child3.Width = 30;
+            root_child3.Height = 40;
+            root.Insert(3, root_child3);
+
+            YogaNode root_child4 = new YogaNode();
+            root_child4.Width = 30;
+            root_child4.Height = 50;
+            root.Insert(4, root_child4);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(80f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(70f, root_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child1.LayoutX);
+            Assert.AreEqual(60f, root_child1.LayoutY);
+            Assert.AreEqual(30f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(60f, root_child2.LayoutX);
+            Assert.AreEqual(50f, root_child2.LayoutY);
+            Assert.AreEqual(30f, root_child2.LayoutWidth);
+            Assert.AreEqual(30f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child3.LayoutX);
+            Assert.AreEqual(10f, root_child3.LayoutY);
+            Assert.AreEqual(30f, root_child3.LayoutWidth);
+            Assert.AreEqual(40f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child4.LayoutX);
+            Assert.AreEqual(0f, root_child4.LayoutY);
+            Assert.AreEqual(30f, root_child4.LayoutWidth);
+            Assert.AreEqual(50f, root_child4.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(80f, root.LayoutHeight);
+
+            Assert.AreEqual(70f, root_child0.LayoutX);
+            Assert.AreEqual(70f, root_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(40f, root_child1.LayoutX);
+            Assert.AreEqual(60f, root_child1.LayoutY);
+            Assert.AreEqual(30f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(10f, root_child2.LayoutX);
+            Assert.AreEqual(50f, root_child2.LayoutY);
+            Assert.AreEqual(30f, root_child2.LayoutWidth);
+            Assert.AreEqual(30f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(70f, root_child3.LayoutX);
+            Assert.AreEqual(10f, root_child3.LayoutY);
+            Assert.AreEqual(30f, root_child3.LayoutWidth);
+            Assert.AreEqual(40f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(40f, root_child4.LayoutX);
+            Assert.AreEqual(0f, root_child4.LayoutY);
+            Assert.AreEqual(30f, root_child4.LayoutWidth);
+            Assert.AreEqual(50f, root_child4.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_wrap_reverse_row_align_content_space_around()
+        {
+            YogaNode root = new YogaNode();
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignContent = YogaAlign.SpaceAround;
+            root.Wrap = YogaWrap.WrapReverse;
+            root.Width = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.Width = 30;
+            root_child0.Height = 10;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode();
+            root_child1.Width = 30;
+            root_child1.Height = 20;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode();
+            root_child2.Width = 30;
+            root_child2.Height = 30;
+            root.Insert(2, root_child2);
+
+            YogaNode root_child3 = new YogaNode();
+            root_child3.Width = 30;
+            root_child3.Height = 40;
+            root.Insert(3, root_child3);
+
+            YogaNode root_child4 = new YogaNode();
+            root_child4.Width = 30;
+            root_child4.Height = 50;
+            root.Insert(4, root_child4);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(80f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(70f, root_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child1.LayoutX);
+            Assert.AreEqual(60f, root_child1.LayoutY);
+            Assert.AreEqual(30f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(60f, root_child2.LayoutX);
+            Assert.AreEqual(50f, root_child2.LayoutY);
+            Assert.AreEqual(30f, root_child2.LayoutWidth);
+            Assert.AreEqual(30f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child3.LayoutX);
+            Assert.AreEqual(10f, root_child3.LayoutY);
+            Assert.AreEqual(30f, root_child3.LayoutWidth);
+            Assert.AreEqual(40f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child4.LayoutX);
+            Assert.AreEqual(0f, root_child4.LayoutY);
+            Assert.AreEqual(30f, root_child4.LayoutWidth);
+            Assert.AreEqual(50f, root_child4.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(80f, root.LayoutHeight);
+
+            Assert.AreEqual(70f, root_child0.LayoutX);
+            Assert.AreEqual(70f, root_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(40f, root_child1.LayoutX);
+            Assert.AreEqual(60f, root_child1.LayoutY);
+            Assert.AreEqual(30f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(10f, root_child2.LayoutX);
+            Assert.AreEqual(50f, root_child2.LayoutY);
+            Assert.AreEqual(30f, root_child2.LayoutWidth);
+            Assert.AreEqual(30f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(70f, root_child3.LayoutX);
+            Assert.AreEqual(10f, root_child3.LayoutY);
+            Assert.AreEqual(30f, root_child3.LayoutWidth);
+            Assert.AreEqual(40f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(40f, root_child4.LayoutX);
+            Assert.AreEqual(0f, root_child4.LayoutY);
+            Assert.AreEqual(30f, root_child4.LayoutWidth);
+            Assert.AreEqual(50f, root_child4.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_wrap_reverse_column_fixed_size()
+        {
+            YogaNode root = new YogaNode();
+            root.AlignItems = YogaAlign.Center;
+            root.Wrap = YogaWrap.WrapReverse;
+            root.Width = 200;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode();
+            root_child0.Width = 30;
+            root_child0.Height = 10;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode();
+            root_child1.Width = 30;
+            root_child1.Height = 20;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode();
+            root_child2.Width = 30;
+            root_child2.Height = 30;
+            root.Insert(2, root_child2);
+
+            YogaNode root_child3 = new YogaNode();
+            root_child3.Width = 30;
+            root_child3.Height = 40;
+            root.Insert(3, root_child3);
+
+            YogaNode root_child4 = new YogaNode();
+            root_child4.Width = 30;
+            root_child4.Height = 50;
+            root.Insert(4, root_child4);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(200f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(170f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(170f, root_child1.LayoutX);
+            Assert.AreEqual(10f, root_child1.LayoutY);
+            Assert.AreEqual(30f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(170f, root_child2.LayoutX);
+            Assert.AreEqual(30f, root_child2.LayoutY);
+            Assert.AreEqual(30f, root_child2.LayoutWidth);
+            Assert.AreEqual(30f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(170f, root_child3.LayoutX);
+            Assert.AreEqual(60f, root_child3.LayoutY);
+            Assert.AreEqual(30f, root_child3.LayoutWidth);
+            Assert.AreEqual(40f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(140f, root_child4.LayoutX);
+            Assert.AreEqual(0f, root_child4.LayoutY);
+            Assert.AreEqual(30f, root_child4.LayoutWidth);
+            Assert.AreEqual(50f, root_child4.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(200f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(10f, root_child1.LayoutY);
+            Assert.AreEqual(30f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child2.LayoutX);
+            Assert.AreEqual(30f, root_child2.LayoutY);
+            Assert.AreEqual(30f, root_child2.LayoutWidth);
+            Assert.AreEqual(30f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child3.LayoutX);
+            Assert.AreEqual(60f, root_child3.LayoutY);
+            Assert.AreEqual(30f, root_child3.LayoutWidth);
+            Assert.AreEqual(40f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child4.LayoutX);
+            Assert.AreEqual(0f, root_child4.LayoutY);
+            Assert.AreEqual(30f, root_child4.LayoutWidth);
+            Assert.AreEqual(50f, root_child4.LayoutHeight);
+        }
+
     }
 }

--- a/enums.py
+++ b/enums.py
@@ -61,6 +61,7 @@ ENUMS = {
     'Wrap': [
         'NoWrap',
         'Wrap',
+        'WrapReverse',
     ],
     'MeasureMode': [
         'Undefined',

--- a/gentest/fixtures/YGFlexWrapTest.html
+++ b/gentest/fixtures/YGFlexWrapTest.html
@@ -44,3 +44,17 @@
   <div style="width: 50px;"></div>
   <div style="width: 50px;"></div>
 </div>
+
+<div id="wrap_reverse_row_align_items_center" style="width: 100px; flex-direction: row; flex-wrap: wrap-reverse; align-items: center;">
+  <div style="height: 10px; width: 30px;"></div>
+  <div style="height: 20px; width: 30px;"></div>
+  <div style="height: 30px; width: 30px;"></div>
+  <div style="height: 40px; width: 30px;"></div>
+</div>
+
+<div id="wrap_reverse_row_align_items_flex_end" style="width: 100px; flex-direction: row; flex-wrap: wrap-reverse; align-items: flex-end;">
+  <div style="height: 10px; width: 30px;"></div>
+  <div style="height: 20px; width: 30px;"></div>
+  <div style="height: 30px; width: 30px;"></div>
+  <div style="height: 40px; width: 30px;"></div>
+</div>

--- a/gentest/fixtures/YGFlexWrapTest.html
+++ b/gentest/fixtures/YGFlexWrapTest.html
@@ -45,7 +45,23 @@
   <div style="width: 50px;"></div>
 </div>
 
-<div id="wrap_reverse_row_align_items_center" style="width: 100px; flex-direction: row; flex-wrap: wrap-reverse; align-items: center;">
+<div id="wrap_reverse_row_align_content_flex_start" style="width: 100px; flex-direction: row; flex-wrap: wrap-reverse; align-content: flex-start;">
+  <div style="height: 10px; width: 30px;"></div>
+  <div style="height: 20px; width: 30px;"></div>
+  <div style="height: 30px; width: 30px;"></div>
+  <div style="height: 40px; width: 30px;"></div>
+  <div style="height: 50px; width: 30px;"></div>
+</div>
+
+<div id="wrap_reverse_row_align_content_center" style="width: 100px; flex-direction: row; flex-wrap: wrap-reverse; align-content: center;">
+  <div style="height: 10px; width: 30px;"></div>
+  <div style="height: 20px; width: 30px;"></div>
+  <div style="height: 30px; width: 30px;"></div>
+  <div style="height: 40px; width: 30px;"></div>
+  <div style="height: 50px; width: 30px;"></div>
+</div>
+
+<div id="wrap_reverse_row_single_line_different_size" style="width: 300px; flex-direction: row; flex-wrap: wrap-reverse; align-content: flex-start;">
   <div style="height: 10px; width: 30px;"></div>
   <div style="height: 20px; width: 30px;"></div>
   <div style="height: 30px; width: 30px;"></div>

--- a/gentest/fixtures/YGFlexWrapTest.html
+++ b/gentest/fixtures/YGFlexWrapTest.html
@@ -50,11 +50,30 @@
   <div style="height: 20px; width: 30px;"></div>
   <div style="height: 30px; width: 30px;"></div>
   <div style="height: 40px; width: 30px;"></div>
+  <div style="height: 50px; width: 30px;"></div>
 </div>
 
-<div id="wrap_reverse_row_align_items_flex_end" style="width: 100px; flex-direction: row; flex-wrap: wrap-reverse; align-items: flex-end;">
+<div id="wrap_reverse_row_align_content_stretch" style="width: 100px; flex-direction: row; flex-wrap: wrap-reverse; align-content: stretch;">
   <div style="height: 10px; width: 30px;"></div>
   <div style="height: 20px; width: 30px;"></div>
   <div style="height: 30px; width: 30px;"></div>
   <div style="height: 40px; width: 30px;"></div>
+  <div style="height: 50px; width: 30px;"></div>
 </div>
+
+<div id="wrap_reverse_row_align_content_space_around" style="width: 100px; flex-direction: row; flex-wrap: wrap-reverse; align-content: space-around;">
+  <div style="height: 10px; width: 30px;"></div>
+  <div style="height: 20px; width: 30px;"></div>
+  <div style="height: 30px; width: 30px;"></div>
+  <div style="height: 40px; width: 30px;"></div>
+  <div style="height: 50px; width: 30px;"></div>
+</div>
+
+<div id="wrap_reverse_column_fixed_size" style="width: 200px; height: 100px; flex-direction: column; flex-wrap: wrap-reverse; align-items: center;">
+  <div style="height: 10px; width: 30px;"></div>
+  <div style="height: 20px; width: 30px;"></div>
+  <div style="height: 30px; width: 30px;"></div>
+  <div style="height: 40px; width: 30px;"></div>
+  <div style="height: 50px; width: 30px;"></div>
+</div>
+

--- a/gentest/gentest-cpp.js
+++ b/gentest/gentest-cpp.js
@@ -116,6 +116,7 @@ CPPEmitter.prototype = Object.create(Emitter.prototype, {
 
   YGWrapNoWrap:{value:'YGWrapNoWrap'},
   YGWrapWrap:{value:'YGWrapWrap'},
+  YGWrapWrapReverse:{value: 'YGWrapWrapReverse'},
 
   YGUndefined:{value:'YGUndefined'},
 

--- a/gentest/gentest-cs.js
+++ b/gentest/gentest-cs.js
@@ -135,6 +135,7 @@ CSEmitter.prototype = Object.create(Emitter.prototype, {
 
   YGWrapNoWrap:{value:'YogaWrap.NoWrap'},
   YGWrapWrap:{value:'YogaWrap.Wrap'},
+  YGWrapWrapReverse:{value: 'YogaWrap.WrapReverse'},
 
   YGNodeCalculateLayout:{value:function(node, dir) {
     this.push(node + '.StyleDirection = ' + dir + ';');

--- a/gentest/gentest-java.js
+++ b/gentest/gentest-java.js
@@ -139,6 +139,7 @@ JavaEmitter.prototype = Object.create(Emitter.prototype, {
 
   YGWrapNoWrap:{value:'YogaWrap.NO_WRAP'},
   YGWrapWrap:{value:'YogaWrap.WRAP'},
+  YGWrapWrapReverse:{value: 'YogaWrap.WRAP_REVERSE'},
 
   YGNodeCalculateLayout:{value:function(node, dir) {
     this.push(node + '.setDirection(' + dir + ');');

--- a/gentest/gentest-javascript.js
+++ b/gentest/gentest-javascript.js
@@ -124,6 +124,7 @@ JavascriptEmitter.prototype = Object.create(Emitter.prototype, {
 
   YGWrapNoWrap:{value:'Yoga.WRAP_NO_WRAP'},
   YGWrapWrap:{value:'Yoga.WRAP_WRAP'},
+  YGWrapWrapReverse:{value: 'Yoga.WRAP_WRAP_REVERSE'},
 
   YGUndefined:{value:'Yoga.UNDEFINED'},
 

--- a/gentest/gentest.js
+++ b/gentest/gentest.js
@@ -336,6 +336,7 @@ function overflowValue(e, value) {
 function wrapValue(e, value) {
   switch (value) {
     case 'wrap': return e.YGWrapWrap;
+    case 'wrap-reverse': return e.YGWrapWrapReverse;
     case 'nowrap': return e.YGWrapNoWrap;
   }
 }

--- a/java/com/facebook/yoga/YogaWrap.java
+++ b/java/com/facebook/yoga/YogaWrap.java
@@ -14,7 +14,8 @@ import com.facebook.proguard.annotations.DoNotStrip;
 @DoNotStrip
 public enum YogaWrap {
   NO_WRAP(0),
-  WRAP(1);
+  WRAP(1),
+  WRAP_REVERSE(2);
 
   private int mIntValue;
 
@@ -30,6 +31,7 @@ public enum YogaWrap {
     switch (value) {
       case 0: return NO_WRAP;
       case 1: return WRAP;
+      case 2: return WRAP_REVERSE;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);
     }
   }

--- a/java/tests/com/facebook/yoga/YGFlexWrapTest.java
+++ b/java/tests/com/facebook/yoga/YGFlexWrapTest.java
@@ -536,4 +536,596 @@ public class YGFlexWrapTest {
     assertEquals(100f, root_child1.getLayoutHeight(), 0.0f);
   }
 
+  @Test
+  public void test_wrap_reverse_row_align_content_flex_start() {
+    final YogaNode root = new YogaNode();
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setWrap(YogaWrap.WRAP_REVERSE);
+    root.setWidth(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setWidth(30f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode();
+    root_child1.setWidth(30f);
+    root_child1.setHeight(20f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = new YogaNode();
+    root_child2.setWidth(30f);
+    root_child2.setHeight(30f);
+    root.addChildAt(root_child2, 2);
+
+    final YogaNode root_child3 = new YogaNode();
+    root_child3.setWidth(30f);
+    root_child3.setHeight(40f);
+    root.addChildAt(root_child3, 3);
+
+    final YogaNode root_child4 = new YogaNode();
+    root_child4.setWidth(30f);
+    root_child4.setHeight(50f);
+    root.addChildAt(root_child4, 4);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(80f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(70f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(80f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(70f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(70f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(70f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_wrap_reverse_row_align_content_center() {
+    final YogaNode root = new YogaNode();
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.CENTER);
+    root.setWrap(YogaWrap.WRAP_REVERSE);
+    root.setWidth(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setWidth(30f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode();
+    root_child1.setWidth(30f);
+    root_child1.setHeight(20f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = new YogaNode();
+    root_child2.setWidth(30f);
+    root_child2.setHeight(30f);
+    root.addChildAt(root_child2, 2);
+
+    final YogaNode root_child3 = new YogaNode();
+    root_child3.setWidth(30f);
+    root_child3.setHeight(40f);
+    root.addChildAt(root_child3, 3);
+
+    final YogaNode root_child4 = new YogaNode();
+    root_child4.setWidth(30f);
+    root_child4.setHeight(50f);
+    root.addChildAt(root_child4, 4);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(80f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(70f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(80f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(70f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(70f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(70f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_wrap_reverse_row_single_line_different_size() {
+    final YogaNode root = new YogaNode();
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setWrap(YogaWrap.WRAP_REVERSE);
+    root.setWidth(300f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setWidth(30f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode();
+    root_child1.setWidth(30f);
+    root_child1.setHeight(20f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = new YogaNode();
+    root_child2.setWidth(30f);
+    root_child2.setHeight(30f);
+    root.addChildAt(root_child2, 2);
+
+    final YogaNode root_child3 = new YogaNode();
+    root_child3.setWidth(30f);
+    root_child3.setHeight(40f);
+    root.addChildAt(root_child3, 3);
+
+    final YogaNode root_child4 = new YogaNode();
+    root_child4.setWidth(30f);
+    root_child4.setHeight(50f);
+    root.addChildAt(root_child4, 4);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(300f, root.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(120f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(300f, root.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(270f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(240f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(210f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(180f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(150f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_wrap_reverse_row_align_content_stretch() {
+    final YogaNode root = new YogaNode();
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.STRETCH);
+    root.setWrap(YogaWrap.WRAP_REVERSE);
+    root.setWidth(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setWidth(30f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode();
+    root_child1.setWidth(30f);
+    root_child1.setHeight(20f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = new YogaNode();
+    root_child2.setWidth(30f);
+    root_child2.setHeight(30f);
+    root.addChildAt(root_child2, 2);
+
+    final YogaNode root_child3 = new YogaNode();
+    root_child3.setWidth(30f);
+    root_child3.setHeight(40f);
+    root.addChildAt(root_child3, 3);
+
+    final YogaNode root_child4 = new YogaNode();
+    root_child4.setWidth(30f);
+    root_child4.setHeight(50f);
+    root.addChildAt(root_child4, 4);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(80f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(70f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(80f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(70f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(70f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(70f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_wrap_reverse_row_align_content_space_around() {
+    final YogaNode root = new YogaNode();
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.SPACE_AROUND);
+    root.setWrap(YogaWrap.WRAP_REVERSE);
+    root.setWidth(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setWidth(30f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode();
+    root_child1.setWidth(30f);
+    root_child1.setHeight(20f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = new YogaNode();
+    root_child2.setWidth(30f);
+    root_child2.setHeight(30f);
+    root.addChildAt(root_child2, 2);
+
+    final YogaNode root_child3 = new YogaNode();
+    root_child3.setWidth(30f);
+    root_child3.setHeight(40f);
+    root.addChildAt(root_child3, 3);
+
+    final YogaNode root_child4 = new YogaNode();
+    root_child4.setWidth(30f);
+    root_child4.setHeight(50f);
+    root.addChildAt(root_child4, 4);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(80f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(70f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(80f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(70f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(70f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(70f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_wrap_reverse_column_fixed_size() {
+    final YogaNode root = new YogaNode();
+    root.setAlignItems(YogaAlign.CENTER);
+    root.setWrap(YogaWrap.WRAP_REVERSE);
+    root.setWidth(200f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = new YogaNode();
+    root_child0.setWidth(30f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode();
+    root_child1.setWidth(30f);
+    root_child1.setHeight(20f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = new YogaNode();
+    root_child2.setWidth(30f);
+    root_child2.setHeight(30f);
+    root.addChildAt(root_child2, 2);
+
+    final YogaNode root_child3 = new YogaNode();
+    root_child3.setWidth(30f);
+    root_child3.setHeight(40f);
+    root.addChildAt(root_child3, 3);
+
+    final YogaNode root_child4 = new YogaNode();
+    root_child4.setWidth(30f);
+    root_child4.setHeight(50f);
+    root.addChildAt(root_child4, 4);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(200f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(170f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(170f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(170f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(170f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(140f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(200f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutHeight(), 0.0f);
+  }
+
 }

--- a/javascript/sources/YGEnums.js
+++ b/javascript/sources/YGEnums.js
@@ -91,8 +91,9 @@ module.exports = {
   UNIT_PIXEL: 1,
   UNIT_PERCENT: 2,
 
-  WRAP_COUNT: 2,
+  WRAP_COUNT: 3,
   WRAP_NO_WRAP: 0,
   WRAP_WRAP: 1,
+  WRAP_WRAP_REVERSE: 2,
 
 };

--- a/javascript/tests/Facebook.Yoga/YGFlexWrapTest.js
+++ b/javascript/tests/Facebook.Yoga/YGFlexWrapTest.js
@@ -545,3 +545,607 @@ it("flex_wrap_align_stretch_fits_one_row", function () {
   (typeof gc !== "undefined") && gc();
   console.assert(0 === Yoga.getInstanceCount(), "0 === Yoga.getInstanceCount() (" + Yoga.getInstanceCount() + ")");
 });
+it("wrap_reverse_row_align_content_flex_start", function () {
+  var root = Yoga.Node.create();
+  root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+  root.setFlexWrap(Yoga.WRAP_WRAP_REVERSE);
+  root.setWidth(100);
+
+  var root_child0 = Yoga.Node.create();
+  root_child0.setWidth(30);
+  root_child0.setHeight(10);
+  root.insertChild(root_child0, 0);
+
+  var root_child1 = Yoga.Node.create();
+  root_child1.setWidth(30);
+  root_child1.setHeight(20);
+  root.insertChild(root_child1, 1);
+
+  var root_child2 = Yoga.Node.create();
+  root_child2.setWidth(30);
+  root_child2.setHeight(30);
+  root.insertChild(root_child2, 2);
+
+  var root_child3 = Yoga.Node.create();
+  root_child3.setWidth(30);
+  root_child3.setHeight(40);
+  root.insertChild(root_child3, 3);
+
+  var root_child4 = Yoga.Node.create();
+  root_child4.setWidth(30);
+  root_child4.setHeight(50);
+  root.insertChild(root_child4, 4);
+  root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+  console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+  console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+  console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+  console.assert(80 === root.getComputedHeight(), "80 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+  console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+  console.assert(70 === root_child0.getComputedTop(), "70 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+  console.assert(30 === root_child0.getComputedWidth(), "30 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+  console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+  console.assert(30 === root_child1.getComputedLeft(), "30 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+  console.assert(60 === root_child1.getComputedTop(), "60 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+  console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+  console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+  console.assert(60 === root_child2.getComputedLeft(), "60 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+  console.assert(50 === root_child2.getComputedTop(), "50 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+  console.assert(30 === root_child2.getComputedWidth(), "30 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+  console.assert(30 === root_child2.getComputedHeight(), "30 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+  console.assert(0 === root_child3.getComputedLeft(), "0 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+  console.assert(10 === root_child3.getComputedTop(), "10 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+  console.assert(30 === root_child3.getComputedWidth(), "30 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+  console.assert(40 === root_child3.getComputedHeight(), "40 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+  console.assert(30 === root_child4.getComputedLeft(), "30 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+  console.assert(0 === root_child4.getComputedTop(), "0 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+  console.assert(30 === root_child4.getComputedWidth(), "30 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+  console.assert(50 === root_child4.getComputedHeight(), "50 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+  root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+  console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+  console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+  console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+  console.assert(80 === root.getComputedHeight(), "80 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+  console.assert(70 === root_child0.getComputedLeft(), "70 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+  console.assert(70 === root_child0.getComputedTop(), "70 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+  console.assert(30 === root_child0.getComputedWidth(), "30 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+  console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+  console.assert(40 === root_child1.getComputedLeft(), "40 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+  console.assert(60 === root_child1.getComputedTop(), "60 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+  console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+  console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+  console.assert(10 === root_child2.getComputedLeft(), "10 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+  console.assert(50 === root_child2.getComputedTop(), "50 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+  console.assert(30 === root_child2.getComputedWidth(), "30 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+  console.assert(30 === root_child2.getComputedHeight(), "30 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+  console.assert(70 === root_child3.getComputedLeft(), "70 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+  console.assert(10 === root_child3.getComputedTop(), "10 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+  console.assert(30 === root_child3.getComputedWidth(), "30 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+  console.assert(40 === root_child3.getComputedHeight(), "40 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+  console.assert(40 === root_child4.getComputedLeft(), "40 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+  console.assert(0 === root_child4.getComputedTop(), "0 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+  console.assert(30 === root_child4.getComputedWidth(), "30 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+  console.assert(50 === root_child4.getComputedHeight(), "50 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+  if (typeof root !== "undefined")
+    root.freeRecursive();
+
+  (typeof gc !== "undefined") && gc();
+  console.assert(0 === Yoga.getInstanceCount(), "0 === Yoga.getInstanceCount() (" + Yoga.getInstanceCount() + ")");
+});
+it("wrap_reverse_row_align_content_center", function () {
+  var root = Yoga.Node.create();
+  root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+  root.setAlignContent(Yoga.ALIGN_CENTER);
+  root.setFlexWrap(Yoga.WRAP_WRAP_REVERSE);
+  root.setWidth(100);
+
+  var root_child0 = Yoga.Node.create();
+  root_child0.setWidth(30);
+  root_child0.setHeight(10);
+  root.insertChild(root_child0, 0);
+
+  var root_child1 = Yoga.Node.create();
+  root_child1.setWidth(30);
+  root_child1.setHeight(20);
+  root.insertChild(root_child1, 1);
+
+  var root_child2 = Yoga.Node.create();
+  root_child2.setWidth(30);
+  root_child2.setHeight(30);
+  root.insertChild(root_child2, 2);
+
+  var root_child3 = Yoga.Node.create();
+  root_child3.setWidth(30);
+  root_child3.setHeight(40);
+  root.insertChild(root_child3, 3);
+
+  var root_child4 = Yoga.Node.create();
+  root_child4.setWidth(30);
+  root_child4.setHeight(50);
+  root.insertChild(root_child4, 4);
+  root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+  console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+  console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+  console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+  console.assert(80 === root.getComputedHeight(), "80 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+  console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+  console.assert(70 === root_child0.getComputedTop(), "70 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+  console.assert(30 === root_child0.getComputedWidth(), "30 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+  console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+  console.assert(30 === root_child1.getComputedLeft(), "30 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+  console.assert(60 === root_child1.getComputedTop(), "60 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+  console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+  console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+  console.assert(60 === root_child2.getComputedLeft(), "60 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+  console.assert(50 === root_child2.getComputedTop(), "50 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+  console.assert(30 === root_child2.getComputedWidth(), "30 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+  console.assert(30 === root_child2.getComputedHeight(), "30 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+  console.assert(0 === root_child3.getComputedLeft(), "0 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+  console.assert(10 === root_child3.getComputedTop(), "10 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+  console.assert(30 === root_child3.getComputedWidth(), "30 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+  console.assert(40 === root_child3.getComputedHeight(), "40 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+  console.assert(30 === root_child4.getComputedLeft(), "30 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+  console.assert(0 === root_child4.getComputedTop(), "0 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+  console.assert(30 === root_child4.getComputedWidth(), "30 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+  console.assert(50 === root_child4.getComputedHeight(), "50 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+  root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+  console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+  console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+  console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+  console.assert(80 === root.getComputedHeight(), "80 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+  console.assert(70 === root_child0.getComputedLeft(), "70 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+  console.assert(70 === root_child0.getComputedTop(), "70 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+  console.assert(30 === root_child0.getComputedWidth(), "30 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+  console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+  console.assert(40 === root_child1.getComputedLeft(), "40 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+  console.assert(60 === root_child1.getComputedTop(), "60 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+  console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+  console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+  console.assert(10 === root_child2.getComputedLeft(), "10 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+  console.assert(50 === root_child2.getComputedTop(), "50 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+  console.assert(30 === root_child2.getComputedWidth(), "30 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+  console.assert(30 === root_child2.getComputedHeight(), "30 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+  console.assert(70 === root_child3.getComputedLeft(), "70 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+  console.assert(10 === root_child3.getComputedTop(), "10 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+  console.assert(30 === root_child3.getComputedWidth(), "30 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+  console.assert(40 === root_child3.getComputedHeight(), "40 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+  console.assert(40 === root_child4.getComputedLeft(), "40 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+  console.assert(0 === root_child4.getComputedTop(), "0 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+  console.assert(30 === root_child4.getComputedWidth(), "30 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+  console.assert(50 === root_child4.getComputedHeight(), "50 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+  if (typeof root !== "undefined")
+    root.freeRecursive();
+
+  (typeof gc !== "undefined") && gc();
+  console.assert(0 === Yoga.getInstanceCount(), "0 === Yoga.getInstanceCount() (" + Yoga.getInstanceCount() + ")");
+});
+it("wrap_reverse_row_single_line_different_size", function () {
+  var root = Yoga.Node.create();
+  root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+  root.setFlexWrap(Yoga.WRAP_WRAP_REVERSE);
+  root.setWidth(300);
+
+  var root_child0 = Yoga.Node.create();
+  root_child0.setWidth(30);
+  root_child0.setHeight(10);
+  root.insertChild(root_child0, 0);
+
+  var root_child1 = Yoga.Node.create();
+  root_child1.setWidth(30);
+  root_child1.setHeight(20);
+  root.insertChild(root_child1, 1);
+
+  var root_child2 = Yoga.Node.create();
+  root_child2.setWidth(30);
+  root_child2.setHeight(30);
+  root.insertChild(root_child2, 2);
+
+  var root_child3 = Yoga.Node.create();
+  root_child3.setWidth(30);
+  root_child3.setHeight(40);
+  root.insertChild(root_child3, 3);
+
+  var root_child4 = Yoga.Node.create();
+  root_child4.setWidth(30);
+  root_child4.setHeight(50);
+  root.insertChild(root_child4, 4);
+  root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+  console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+  console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+  console.assert(300 === root.getComputedWidth(), "300 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+  console.assert(50 === root.getComputedHeight(), "50 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+  console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+  console.assert(40 === root_child0.getComputedTop(), "40 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+  console.assert(30 === root_child0.getComputedWidth(), "30 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+  console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+  console.assert(30 === root_child1.getComputedLeft(), "30 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+  console.assert(30 === root_child1.getComputedTop(), "30 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+  console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+  console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+  console.assert(60 === root_child2.getComputedLeft(), "60 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+  console.assert(20 === root_child2.getComputedTop(), "20 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+  console.assert(30 === root_child2.getComputedWidth(), "30 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+  console.assert(30 === root_child2.getComputedHeight(), "30 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+  console.assert(90 === root_child3.getComputedLeft(), "90 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+  console.assert(10 === root_child3.getComputedTop(), "10 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+  console.assert(30 === root_child3.getComputedWidth(), "30 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+  console.assert(40 === root_child3.getComputedHeight(), "40 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+  console.assert(120 === root_child4.getComputedLeft(), "120 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+  console.assert(0 === root_child4.getComputedTop(), "0 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+  console.assert(30 === root_child4.getComputedWidth(), "30 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+  console.assert(50 === root_child4.getComputedHeight(), "50 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+  root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+  console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+  console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+  console.assert(300 === root.getComputedWidth(), "300 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+  console.assert(50 === root.getComputedHeight(), "50 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+  console.assert(270 === root_child0.getComputedLeft(), "270 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+  console.assert(40 === root_child0.getComputedTop(), "40 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+  console.assert(30 === root_child0.getComputedWidth(), "30 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+  console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+  console.assert(240 === root_child1.getComputedLeft(), "240 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+  console.assert(30 === root_child1.getComputedTop(), "30 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+  console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+  console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+  console.assert(210 === root_child2.getComputedLeft(), "210 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+  console.assert(20 === root_child2.getComputedTop(), "20 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+  console.assert(30 === root_child2.getComputedWidth(), "30 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+  console.assert(30 === root_child2.getComputedHeight(), "30 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+  console.assert(180 === root_child3.getComputedLeft(), "180 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+  console.assert(10 === root_child3.getComputedTop(), "10 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+  console.assert(30 === root_child3.getComputedWidth(), "30 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+  console.assert(40 === root_child3.getComputedHeight(), "40 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+  console.assert(150 === root_child4.getComputedLeft(), "150 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+  console.assert(0 === root_child4.getComputedTop(), "0 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+  console.assert(30 === root_child4.getComputedWidth(), "30 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+  console.assert(50 === root_child4.getComputedHeight(), "50 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+  if (typeof root !== "undefined")
+    root.freeRecursive();
+
+  (typeof gc !== "undefined") && gc();
+  console.assert(0 === Yoga.getInstanceCount(), "0 === Yoga.getInstanceCount() (" + Yoga.getInstanceCount() + ")");
+});
+it("wrap_reverse_row_align_content_stretch", function () {
+  var root = Yoga.Node.create();
+  root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+  root.setAlignContent(Yoga.ALIGN_STRETCH);
+  root.setFlexWrap(Yoga.WRAP_WRAP_REVERSE);
+  root.setWidth(100);
+
+  var root_child0 = Yoga.Node.create();
+  root_child0.setWidth(30);
+  root_child0.setHeight(10);
+  root.insertChild(root_child0, 0);
+
+  var root_child1 = Yoga.Node.create();
+  root_child1.setWidth(30);
+  root_child1.setHeight(20);
+  root.insertChild(root_child1, 1);
+
+  var root_child2 = Yoga.Node.create();
+  root_child2.setWidth(30);
+  root_child2.setHeight(30);
+  root.insertChild(root_child2, 2);
+
+  var root_child3 = Yoga.Node.create();
+  root_child3.setWidth(30);
+  root_child3.setHeight(40);
+  root.insertChild(root_child3, 3);
+
+  var root_child4 = Yoga.Node.create();
+  root_child4.setWidth(30);
+  root_child4.setHeight(50);
+  root.insertChild(root_child4, 4);
+  root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+  console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+  console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+  console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+  console.assert(80 === root.getComputedHeight(), "80 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+  console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+  console.assert(70 === root_child0.getComputedTop(), "70 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+  console.assert(30 === root_child0.getComputedWidth(), "30 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+  console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+  console.assert(30 === root_child1.getComputedLeft(), "30 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+  console.assert(60 === root_child1.getComputedTop(), "60 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+  console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+  console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+  console.assert(60 === root_child2.getComputedLeft(), "60 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+  console.assert(50 === root_child2.getComputedTop(), "50 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+  console.assert(30 === root_child2.getComputedWidth(), "30 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+  console.assert(30 === root_child2.getComputedHeight(), "30 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+  console.assert(0 === root_child3.getComputedLeft(), "0 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+  console.assert(10 === root_child3.getComputedTop(), "10 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+  console.assert(30 === root_child3.getComputedWidth(), "30 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+  console.assert(40 === root_child3.getComputedHeight(), "40 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+  console.assert(30 === root_child4.getComputedLeft(), "30 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+  console.assert(0 === root_child4.getComputedTop(), "0 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+  console.assert(30 === root_child4.getComputedWidth(), "30 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+  console.assert(50 === root_child4.getComputedHeight(), "50 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+  root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+  console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+  console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+  console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+  console.assert(80 === root.getComputedHeight(), "80 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+  console.assert(70 === root_child0.getComputedLeft(), "70 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+  console.assert(70 === root_child0.getComputedTop(), "70 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+  console.assert(30 === root_child0.getComputedWidth(), "30 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+  console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+  console.assert(40 === root_child1.getComputedLeft(), "40 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+  console.assert(60 === root_child1.getComputedTop(), "60 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+  console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+  console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+  console.assert(10 === root_child2.getComputedLeft(), "10 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+  console.assert(50 === root_child2.getComputedTop(), "50 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+  console.assert(30 === root_child2.getComputedWidth(), "30 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+  console.assert(30 === root_child2.getComputedHeight(), "30 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+  console.assert(70 === root_child3.getComputedLeft(), "70 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+  console.assert(10 === root_child3.getComputedTop(), "10 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+  console.assert(30 === root_child3.getComputedWidth(), "30 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+  console.assert(40 === root_child3.getComputedHeight(), "40 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+  console.assert(40 === root_child4.getComputedLeft(), "40 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+  console.assert(0 === root_child4.getComputedTop(), "0 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+  console.assert(30 === root_child4.getComputedWidth(), "30 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+  console.assert(50 === root_child4.getComputedHeight(), "50 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+  if (typeof root !== "undefined")
+    root.freeRecursive();
+
+  (typeof gc !== "undefined") && gc();
+  console.assert(0 === Yoga.getInstanceCount(), "0 === Yoga.getInstanceCount() (" + Yoga.getInstanceCount() + ")");
+});
+it("wrap_reverse_row_align_content_space_around", function () {
+  var root = Yoga.Node.create();
+  root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+  root.setAlignContent(Yoga.ALIGN_SPACE_AROUND);
+  root.setFlexWrap(Yoga.WRAP_WRAP_REVERSE);
+  root.setWidth(100);
+
+  var root_child0 = Yoga.Node.create();
+  root_child0.setWidth(30);
+  root_child0.setHeight(10);
+  root.insertChild(root_child0, 0);
+
+  var root_child1 = Yoga.Node.create();
+  root_child1.setWidth(30);
+  root_child1.setHeight(20);
+  root.insertChild(root_child1, 1);
+
+  var root_child2 = Yoga.Node.create();
+  root_child2.setWidth(30);
+  root_child2.setHeight(30);
+  root.insertChild(root_child2, 2);
+
+  var root_child3 = Yoga.Node.create();
+  root_child3.setWidth(30);
+  root_child3.setHeight(40);
+  root.insertChild(root_child3, 3);
+
+  var root_child4 = Yoga.Node.create();
+  root_child4.setWidth(30);
+  root_child4.setHeight(50);
+  root.insertChild(root_child4, 4);
+  root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+  console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+  console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+  console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+  console.assert(80 === root.getComputedHeight(), "80 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+  console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+  console.assert(70 === root_child0.getComputedTop(), "70 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+  console.assert(30 === root_child0.getComputedWidth(), "30 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+  console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+  console.assert(30 === root_child1.getComputedLeft(), "30 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+  console.assert(60 === root_child1.getComputedTop(), "60 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+  console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+  console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+  console.assert(60 === root_child2.getComputedLeft(), "60 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+  console.assert(50 === root_child2.getComputedTop(), "50 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+  console.assert(30 === root_child2.getComputedWidth(), "30 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+  console.assert(30 === root_child2.getComputedHeight(), "30 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+  console.assert(0 === root_child3.getComputedLeft(), "0 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+  console.assert(10 === root_child3.getComputedTop(), "10 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+  console.assert(30 === root_child3.getComputedWidth(), "30 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+  console.assert(40 === root_child3.getComputedHeight(), "40 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+  console.assert(30 === root_child4.getComputedLeft(), "30 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+  console.assert(0 === root_child4.getComputedTop(), "0 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+  console.assert(30 === root_child4.getComputedWidth(), "30 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+  console.assert(50 === root_child4.getComputedHeight(), "50 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+  root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+  console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+  console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+  console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+  console.assert(80 === root.getComputedHeight(), "80 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+  console.assert(70 === root_child0.getComputedLeft(), "70 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+  console.assert(70 === root_child0.getComputedTop(), "70 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+  console.assert(30 === root_child0.getComputedWidth(), "30 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+  console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+  console.assert(40 === root_child1.getComputedLeft(), "40 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+  console.assert(60 === root_child1.getComputedTop(), "60 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+  console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+  console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+  console.assert(10 === root_child2.getComputedLeft(), "10 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+  console.assert(50 === root_child2.getComputedTop(), "50 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+  console.assert(30 === root_child2.getComputedWidth(), "30 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+  console.assert(30 === root_child2.getComputedHeight(), "30 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+  console.assert(70 === root_child3.getComputedLeft(), "70 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+  console.assert(10 === root_child3.getComputedTop(), "10 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+  console.assert(30 === root_child3.getComputedWidth(), "30 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+  console.assert(40 === root_child3.getComputedHeight(), "40 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+  console.assert(40 === root_child4.getComputedLeft(), "40 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+  console.assert(0 === root_child4.getComputedTop(), "0 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+  console.assert(30 === root_child4.getComputedWidth(), "30 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+  console.assert(50 === root_child4.getComputedHeight(), "50 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+  if (typeof root !== "undefined")
+    root.freeRecursive();
+
+  (typeof gc !== "undefined") && gc();
+  console.assert(0 === Yoga.getInstanceCount(), "0 === Yoga.getInstanceCount() (" + Yoga.getInstanceCount() + ")");
+});
+it("wrap_reverse_column_fixed_size", function () {
+  var root = Yoga.Node.create();
+  root.setAlignItems(Yoga.ALIGN_CENTER);
+  root.setFlexWrap(Yoga.WRAP_WRAP_REVERSE);
+  root.setWidth(200);
+  root.setHeight(100);
+
+  var root_child0 = Yoga.Node.create();
+  root_child0.setWidth(30);
+  root_child0.setHeight(10);
+  root.insertChild(root_child0, 0);
+
+  var root_child1 = Yoga.Node.create();
+  root_child1.setWidth(30);
+  root_child1.setHeight(20);
+  root.insertChild(root_child1, 1);
+
+  var root_child2 = Yoga.Node.create();
+  root_child2.setWidth(30);
+  root_child2.setHeight(30);
+  root.insertChild(root_child2, 2);
+
+  var root_child3 = Yoga.Node.create();
+  root_child3.setWidth(30);
+  root_child3.setHeight(40);
+  root.insertChild(root_child3, 3);
+
+  var root_child4 = Yoga.Node.create();
+  root_child4.setWidth(30);
+  root_child4.setHeight(50);
+  root.insertChild(root_child4, 4);
+  root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+  console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+  console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+  console.assert(200 === root.getComputedWidth(), "200 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+  console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+  console.assert(170 === root_child0.getComputedLeft(), "170 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+  console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+  console.assert(30 === root_child0.getComputedWidth(), "30 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+  console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+  console.assert(170 === root_child1.getComputedLeft(), "170 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+  console.assert(10 === root_child1.getComputedTop(), "10 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+  console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+  console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+  console.assert(170 === root_child2.getComputedLeft(), "170 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+  console.assert(30 === root_child2.getComputedTop(), "30 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+  console.assert(30 === root_child2.getComputedWidth(), "30 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+  console.assert(30 === root_child2.getComputedHeight(), "30 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+  console.assert(170 === root_child3.getComputedLeft(), "170 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+  console.assert(60 === root_child3.getComputedTop(), "60 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+  console.assert(30 === root_child3.getComputedWidth(), "30 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+  console.assert(40 === root_child3.getComputedHeight(), "40 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+  console.assert(140 === root_child4.getComputedLeft(), "140 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+  console.assert(0 === root_child4.getComputedTop(), "0 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+  console.assert(30 === root_child4.getComputedWidth(), "30 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+  console.assert(50 === root_child4.getComputedHeight(), "50 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+  root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+  console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+  console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+  console.assert(200 === root.getComputedWidth(), "200 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+  console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+  console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+  console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+  console.assert(30 === root_child0.getComputedWidth(), "30 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+  console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+  console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+  console.assert(10 === root_child1.getComputedTop(), "10 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+  console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+  console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+  console.assert(0 === root_child2.getComputedLeft(), "0 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+  console.assert(30 === root_child2.getComputedTop(), "30 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+  console.assert(30 === root_child2.getComputedWidth(), "30 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+  console.assert(30 === root_child2.getComputedHeight(), "30 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+  console.assert(0 === root_child3.getComputedLeft(), "0 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+  console.assert(60 === root_child3.getComputedTop(), "60 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+  console.assert(30 === root_child3.getComputedWidth(), "30 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+  console.assert(40 === root_child3.getComputedHeight(), "40 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+  console.assert(30 === root_child4.getComputedLeft(), "30 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+  console.assert(0 === root_child4.getComputedTop(), "0 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+  console.assert(30 === root_child4.getComputedWidth(), "30 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+  console.assert(50 === root_child4.getComputedHeight(), "50 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+  if (typeof root !== "undefined")
+    root.freeRecursive();
+
+  (typeof gc !== "undefined") && gc();
+  console.assert(0 === Yoga.getInstanceCount(), "0 === Yoga.getInstanceCount() (" + Yoga.getInstanceCount() + ")");
+});

--- a/tests/YGFlexWrapTest.cpp
+++ b/tests/YGFlexWrapTest.cpp
@@ -524,3 +524,589 @@ TEST(YogaTest, flex_wrap_align_stretch_fits_one_row) {
 
   YGNodeFreeRecursive(root);
 }
+
+TEST(YogaTest, wrap_reverse_row_align_content_flex_start) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrapReverse);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child0, 30);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child1, 30);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child2, 30);
+  YGNodeStyleSetHeight(root_child2, 30);
+  YGNodeInsertChild(root, root_child2, 2);
+
+  const YGNodeRef root_child3 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child3, 30);
+  YGNodeStyleSetHeight(root_child3, 40);
+  YGNodeInsertChild(root, root_child3, 3);
+
+  const YGNodeRef root_child4 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child4, 30);
+  YGNodeStyleSetHeight(root_child4, 50);
+  YGNodeInsertChild(root, root_child4, 4);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, wrap_reverse_row_align_content_center) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignCenter);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrapReverse);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child0, 30);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child1, 30);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child2, 30);
+  YGNodeStyleSetHeight(root_child2, 30);
+  YGNodeInsertChild(root, root_child2, 2);
+
+  const YGNodeRef root_child3 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child3, 30);
+  YGNodeStyleSetHeight(root_child3, 40);
+  YGNodeInsertChild(root, root_child3, 3);
+
+  const YGNodeRef root_child4 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child4, 30);
+  YGNodeStyleSetHeight(root_child4, 50);
+  YGNodeInsertChild(root, root_child4, 4);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, wrap_reverse_row_single_line_different_size) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrapReverse);
+  YGNodeStyleSetWidth(root, 300);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child0, 30);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child1, 30);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child2, 30);
+  YGNodeStyleSetHeight(root_child2, 30);
+  YGNodeInsertChild(root, root_child2, 2);
+
+  const YGNodeRef root_child3 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child3, 30);
+  YGNodeStyleSetHeight(root_child3, 40);
+  YGNodeInsertChild(root, root_child3, 3);
+
+  const YGNodeRef root_child4 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child4, 30);
+  YGNodeStyleSetHeight(root_child4, 50);
+  YGNodeInsertChild(root, root_child4, 4);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(300, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(300, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(270, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(240, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(210, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(180, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(150, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, wrap_reverse_row_align_content_stretch) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignStretch);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrapReverse);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child0, 30);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child1, 30);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child2, 30);
+  YGNodeStyleSetHeight(root_child2, 30);
+  YGNodeInsertChild(root, root_child2, 2);
+
+  const YGNodeRef root_child3 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child3, 30);
+  YGNodeStyleSetHeight(root_child3, 40);
+  YGNodeInsertChild(root, root_child3, 3);
+
+  const YGNodeRef root_child4 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child4, 30);
+  YGNodeStyleSetHeight(root_child4, 50);
+  YGNodeInsertChild(root, root_child4, 4);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, wrap_reverse_row_align_content_space_around) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignSpaceAround);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrapReverse);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child0, 30);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child1, 30);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child2, 30);
+  YGNodeStyleSetHeight(root_child2, 30);
+  YGNodeInsertChild(root, root_child2, 2);
+
+  const YGNodeRef root_child3 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child3, 30);
+  YGNodeStyleSetHeight(root_child3, 40);
+  YGNodeInsertChild(root, root_child3, 3);
+
+  const YGNodeRef root_child4 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child4, 30);
+  YGNodeStyleSetHeight(root_child4, 50);
+  YGNodeInsertChild(root, root_child4, 4);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, wrap_reverse_column_fixed_size) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrapReverse);
+  YGNodeStyleSetWidth(root, 200);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child0, 30);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child1, 30);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child2, 30);
+  YGNodeStyleSetHeight(root_child2, 30);
+  YGNodeInsertChild(root, root_child2, 2);
+
+  const YGNodeRef root_child3 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child3, 30);
+  YGNodeStyleSetHeight(root_child3, 40);
+  YGNodeInsertChild(root, root_child3, 3);
+
+  const YGNodeRef root_child4 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child4, 30);
+  YGNodeStyleSetHeight(root_child4, 50);
+  YGNodeInsertChild(root, root_child4, 4);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(170, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(170, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(170, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(170, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeFreeRecursive(root);
+}

--- a/yoga/YGEnums.h
+++ b/yoga/YGEnums.h
@@ -123,10 +123,11 @@ typedef YG_ENUM_BEGIN(YGUnit) {
   YGUnitPercent,
 } YG_ENUM_END(YGUnit);
 
-#define YGWrapCount 2
+#define YGWrapCount 3
 typedef YG_ENUM_BEGIN(YGWrap) {
   YGWrapNoWrap,
   YGWrapWrap,
+  YGWrapWrapReverse,
 } YG_ENUM_END(YGWrap);
 
 YG_EXTERN_C_END

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -1017,7 +1017,8 @@ static float YGBaseline(const YGNodeRef node) {
   }
 
   YGNodeRef baselineChild = NULL;
-  for (uint32_t i = 0; i < YGNodeGetChildCount(node); i++) {
+  const uint32_t childCount = YGNodeGetChildCount(node);
+  for (uint32_t i = 0; i < childCount; i++) {
     const YGNodeRef child = YGNodeGetChild(node, i);
     if (child->lineIndex > 0) {
       break;
@@ -1075,7 +1076,8 @@ static bool YGIsBaselineLayout(const YGNodeRef node) {
   if (node->style.alignItems == YGAlignBaseline) {
     return true;
   }
-  for (uint32_t i = 0; i < YGNodeGetChildCount(node); i++) {
+  const uint32_t childCount = YGNodeGetChildCount(node);
+  for (uint32_t i = 0; i < childCount; i++) {
     const YGNodeRef child = YGNodeGetChild(node, i);
     if (child->style.positionType == YGPositionTypeRelative &&
         child->style.alignSelf == YGAlignBaseline) {
@@ -1679,7 +1681,8 @@ static void YGZeroOutLayoutRecursivly(const YGNodeRef node) {
   node->layout.position[YGEdgeBottom] = 0;
   node->layout.position[YGEdgeLeft] = 0;
   node->layout.position[YGEdgeRight] = 0;
-  for (uint32_t i = 0; i < YGNodeGetChildCount(node); i++) {
+  const uint32_t childCount = YGNodeGetChildCount(node);
+  for (uint32_t i = 0; i < childCount; i++) {
     const YGNodeRef child = YGNodeListGet(node->children, i);
     YGZeroOutLayoutRecursivly(child);
   }
@@ -2861,8 +2864,9 @@ static void YGNodelayoutImpl(const YGNodeRef node,
               paddingAndBorderAxisCross);
   }
 
-  if (performLayout && lineCount > 1 && node->style.flexWrap == YGWrapWrapReverse) {
-    for (uint32_t i = 0; i < YGNodeGetChildCount(node); i++) {
+  // As we only wrapped in normal direction yet, we need to reverse the positions on wrap-reverse
+  if (performLayout && node->style.flexWrap == YGWrapWrapReverse) {
+    for (uint32_t i = 0; i < childCount; i++) {
       const YGNodeRef child = YGNodeGetChild(node, i);
       if (child->style.positionType == YGPositionTypeRelative) {
         child->layout.position[pos[crossAxis]] = node->layout.measuredDimensions[dim[crossAxis]] -

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -1876,7 +1876,7 @@ static void YGNodelayoutImpl(const YGNodeRef node,
   const YGFlexDirection crossAxis = YGFlexDirectionCross(mainAxis, direction);
   const bool isMainAxisRow = YGFlexDirectionIsRow(mainAxis);
   const YGJustify justifyContent = node->style.justifyContent;
-  const bool isNodeFlexWrap = node->style.flexWrap == YGWrapWrap;
+  const bool isNodeFlexWrap = node->style.flexWrap != YGWrapNoWrap;
 
   const float mainAxisParentSize = isMainAxisRow ? parentWidth : parentHeight;
   const float crossAxisParentSize = isMainAxisRow ? parentHeight : parentWidth;
@@ -2859,6 +2859,17 @@ static void YGNodelayoutImpl(const YGNodeRef node,
                                                    totalLineCrossDim + paddingAndBorderAxisCross,
                                                    crossAxisParentSize)),
               paddingAndBorderAxisCross);
+  }
+
+  if (performLayout && lineCount > 1 && node->style.flexWrap == YGWrapWrapReverse) {
+    for (uint32_t i = 0; i < YGNodeGetChildCount(node); i++) {
+      const YGNodeRef child = YGNodeGetChild(node, i);
+      if (child->style.positionType == YGPositionTypeRelative) {
+        child->layout.position[pos[crossAxis]] = node->layout.measuredDimensions[dim[crossAxis]] -
+                                                 child->layout.position[pos[crossAxis]] -
+                                                 child->layout.measuredDimensions[dim[crossAxis]];
+      }
+    }
   }
 
   if (performLayout) {

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -1706,9 +1706,6 @@ static void YGZeroOutLayoutRecursivly(const YGNodeRef node) {
 //  * The 'visibility' property is always assumed to be 'visible'. Values of
 //  'collapse'
 //    and 'hidden' are not supported.
-//  * The 'wrap' property supports only 'nowrap' (which is the default) or
-//  'wrap'. The
-//    rarely-used 'wrap-reverse' is not supported.
 //  * Rather than allowing arbitrary combinations of flexGrow, flexShrink and
 //    flexBasis, this algorithm supports only the three most common
 //    combinations:
@@ -2864,7 +2861,7 @@ static void YGNodelayoutImpl(const YGNodeRef node,
               paddingAndBorderAxisCross);
   }
 
-  // As we only wrapped in normal direction yet, we need to reverse the positions on wrap-reverse
+  // As we only wrapped in normal direction yet, we need to reverse the positions on wrap-reverse.
   if (performLayout && node->style.flexWrap == YGWrapWrapReverse) {
     for (uint32_t i = 0; i < childCount; i++) {
       const YGNodeRef child = YGNodeGetChild(node, i);


### PR DESCRIPTION
I couldn't resist to do this 😄 #394

This adds ```flex-wrap: wrap-reverse```

I think we hit a edge case here:
https://stackoverflow.com/questions/33891709/when-flexbox-items-wrap-in-column-mode-container-does-not-grow-its-width

as is differs here from chrome, but I think that yoga is here more correct. 

So I haven't added this test yet as this would fail against chrome, as chrome outputs a width of 30 for root, whereas yoga gets a width of 60 here, which I think is correct. Strangely the output of ```flex-wrap:wrap``` is in jsfiddle also only with a (visual) width of 30 on chrome, while the tests gets generated with 60.
 
```html
<div id="wrap_reverse_column" style="height: 100px; flex-wrap: wrap-reverse">
  <div style="height: 30px; width: 30px;"></div>
  <div style="height: 30px; width: 30px;"></div>
  <div style="height: 30px; width: 30px;"></div>
  <div style="height: 30px; width: 30px;"></div>
</div>
```

Looking forward what you think here @emilsjolander 
