### PR TITLE
Force scalefactor=1 for gentest to fix issues with test generation on hdpi devices

### DIFF
--- a/gentest/gentest.rb
+++ b/gentest/gentest.rb
@@ -9,7 +9,7 @@ caps = Selenium::WebDriver::Remote::Capabilities.chrome(
     "performance"=>"ALL"
   }
 )
-browser = Watir::Browser.new(:chrome, :desired_capabilities => caps)
+browser = Watir::Browser.new(:chrome, :desired_capabilities => caps, :switches => ['--force-device-scale-factor=1'])
 Dir.chdir(File.dirname($0))
 
 Dir['fixtures/*.html'].each do |file|

--- a/gentest/gentest.rb
+++ b/gentest/gentest.rb
@@ -9,8 +9,7 @@ caps = Selenium::WebDriver::Remote::Capabilities.chrome(
     "performance"=>"ALL"
   }
 )
-browser = Watir::Browser.new(:chrome, :desired_capabilities => caps, :switches => ['--force-device-scale-factor=1'])
-browser.window.move_to 0, 0
+browser = Watir::Browser.new(:chrome, :desired_capabilities => caps, :switches => ['--force-device-scale-factor=1', '--window-position=0,0'])
 Dir.chdir(File.dirname($0))
 
 Dir['fixtures/*.html'].each do |file|

--- a/gentest/gentest.rb
+++ b/gentest/gentest.rb
@@ -10,6 +10,7 @@ caps = Selenium::WebDriver::Remote::Capabilities.chrome(
   }
 )
 browser = Watir::Browser.new(:chrome, :desired_capabilities => caps, :switches => ['--force-device-scale-factor=1'])
+browser.window.move_to 0, 0
 Dir.chdir(File.dirname($0))
 
 Dir['fixtures/*.html'].each do |file|


### PR DESCRIPTION
Since my new main work maschine is a hdpi device, all the gentests with rounding are producing different outputs. 

This PR force the scalefactor=1 for gentest to fix issues with generation on hdpi devices. 