### PR TITLE
Solve build target error while building Android with Buck.

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
 
   <uses-sdk
     android:minSdkVersion="15"
-    android:targetSdkVersion="19"
+    android:targetSdkVersion="21"
     />
 
   <application/>


### PR DESCRIPTION
SoLoader library targets Android API 21 but main manifest targets 19. This will block buck android build.