### PR TITLE
Mark all children as dirty if display changes

### DIFF
--- a/tests/YGDirtyMarkingTest.cpp
+++ b/tests/YGDirtyMarkingTest.cpp
@@ -70,6 +70,54 @@ TEST(YogaTest, dirty_propagation_only_if_prop_changed) {
   YGNodeFreeRecursive(root);
 }
 
+TEST(Yogatest, dirty_mark_all_children_as_dirty_when_display_changes){
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetHeight(root, 100);
+  
+  const YGNodeRef child0 = YGNodeNew();
+  YGNodeStyleSetFlexGrow(child0, 1);
+  const YGNodeRef child1 = YGNodeNew();
+  YGNodeStyleSetFlexGrow(child1, 1);
+  
+  const YGNodeRef child1_child0 = YGNodeNew();
+  const YGNodeRef child1_child0_child0 = YGNodeNew();
+  YGNodeStyleSetWidth(child1_child0_child0, 8);
+  YGNodeStyleSetHeight(child1_child0_child0, 16);
+  
+  YGNodeInsertChild(child1_child0, child1_child0_child0, 0);
+  
+  YGNodeInsertChild(child1, child1_child0, 0);
+  YGNodeInsertChild(root, child0, 0);
+  YGNodeInsertChild(root, child1, 0);
+  
+  YGNodeStyleSetDisplay(child0, YGDisplayFlex);
+  YGNodeStyleSetDisplay(child1, YGDisplayNone);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(child1_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(child1_child0_child0));
+
+  YGNodeStyleSetDisplay(child0, YGDisplayNone);
+  YGNodeStyleSetDisplay(child1, YGDisplayFlex);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+  ASSERT_FLOAT_EQ(8, YGNodeLayoutGetWidth(child1_child0_child0));
+  ASSERT_FLOAT_EQ(16, YGNodeLayoutGetHeight(child1_child0_child0));
+
+  YGNodeStyleSetDisplay(child0, YGDisplayFlex);
+  YGNodeStyleSetDisplay(child1, YGDisplayNone);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(child1_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(child1_child0_child0));
+
+  YGNodeStyleSetDisplay(child0, YGDisplayNone);
+  YGNodeStyleSetDisplay(child1, YGDisplayFlex);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+  ASSERT_FLOAT_EQ(8, YGNodeLayoutGetWidth(child1_child0_child0));
+  ASSERT_FLOAT_EQ(16, YGNodeLayoutGetHeight(child1_child0_child0));
+  
+  YGNodeFreeRecursive(root);
+}
+
 TEST(YogaTest, dirty_node_only_if_children_are_actually_removed) {
   const YGNodeRef root = YGNodeNew();
   YGNodeStyleSetAlignItems(root, YGAlignFlexStart);

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -379,6 +379,15 @@ static void YGNodeMarkDirtyInternal(const YGNodeRef node) {
   }
 }
 
+static void YGNodeMarkChildrenAsDirtyRecursive(const YGNodeRef node) {
+  for (uint32_t i = 0; i < YGNodeGetChildCount(node); ++i) {
+    const YGNodeRef child = YGNodeGetChild(node, i);
+    child->isDirty = true;
+    child->layout.computedFlexBasis = YGUndefined;
+    YGNodeMarkChildrenAsDirtyRecursive(child);
+  }
+}
+
 void YGNodeSetMeasureFunc(const YGNodeRef node, YGMeasureFunc measureFunc) {
   if (measureFunc == NULL) {
     node->measure = NULL;
@@ -663,7 +672,6 @@ YG_NODE_STYLE_PROPERTY_IMPL(YGAlign, AlignSelf, alignSelf, alignSelf);
 YG_NODE_STYLE_PROPERTY_IMPL(YGPositionType, PositionType, positionType, positionType);
 YG_NODE_STYLE_PROPERTY_IMPL(YGWrap, FlexWrap, flexWrap, flexWrap);
 YG_NODE_STYLE_PROPERTY_IMPL(YGOverflow, Overflow, overflow, overflow);
-YG_NODE_STYLE_PROPERTY_IMPL(YGDisplay, Display, display, display);
 
 YG_NODE_STYLE_PROPERTY_IMPL(float, Flex, flex, flex);
 YG_NODE_STYLE_PROPERTY_SETTER_IMPL(float, FlexGrow, flexGrow, flexGrow);
@@ -697,6 +705,18 @@ YG_NODE_LAYOUT_PROPERTY_IMPL(YGDirection, Direction, direction);
 YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(float, Margin, margin);
 YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(float, Border, border);
 YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(float, Padding, padding);
+
+void YGNodeStyleSetDisplay(const YGNodeRef node, const YGDisplay display) {
+  if (node->style.display != display) {
+    node->style.display = display;
+    YGNodeMarkDirtyInternal(node);
+    YGNodeMarkChildrenAsDirtyRecursive(node);
+  }
+}
+
+YGDisplay YGNodeStyleGetDisplay(const YGNodeRef node) {
+  return node->style.display;
+}
 
 uint32_t gCurrentGenerationCount = 0;
 


### PR DESCRIPTION
If we set ```display:none``` all children are set with layout sizes/values of 0. We need do mark all those children as dirty to force a relayout if we toggle the display on a higher parent node. This fixes #443