### PR TITLE
Fix typo in test class to use same name as the others

### DIFF
--- a/tests/YGDirtyMarkingTest.cpp
+++ b/tests/YGDirtyMarkingTest.cpp
@@ -70,7 +70,7 @@ TEST(YogaTest, dirty_propagation_only_if_prop_changed) {
   YGNodeFreeRecursive(root);
 }
 
-TEST(Yogatest, dirty_mark_all_children_as_dirty_when_display_changes){
+TEST(YogaTest, dirty_mark_all_children_as_dirty_when_display_changes){
   const YGNodeRef root = YGNodeNew();
   YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
   YGNodeStyleSetHeight(root, 100);


### PR DESCRIPTION
Fixes a typo in the test class to use the same name as the other tests.