### PR TITLE
[C#] Change to access WeakReference

### DIFF
--- a/csharp/Facebook.Yoga/YogaNode.cs
+++ b/csharp/Facebook.Yoga/YogaNode.cs
@@ -138,7 +138,8 @@ namespace Facebook.Yoga
         {
             get
             {
-                return _parent != null ? _parent.Target as YogaNode : null;
+                var parent = _parent != null ? _parent.Target : null;
+                return (YogaNode)parent;
             }
         }
 


### PR DESCRIPTION
Based on this idea
https://blogs.msdn.microsoft.com/clyon/2006/04/20/why-you-shouldnt-rely-on-weakreference-isalive/

Since GC test failed on Travis CI

https://s3.amazonaws.com/archive.travis-ci.org/jobs/209409103/log.txt
   OS Version: Unix 16.1.0.0
   CLR Version: 4.0.30319.42000 ( Mono 4.0 ( 4.8.0 (Stable 4.8.0.495/e4a3cf3 Wed Mar  1 08:20:26 GMT 2017) ) )