### PR TITLE
Fix align-content: center, flex-end alignment with margin

### DIFF
--- a/csharp/tests/Facebook.Yoga/YGAlignItemsTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGAlignItemsTest.cs
@@ -1587,5 +1587,64 @@ namespace Facebook.Yoga
             Assert.AreEqual(20f, root_child3.LayoutHeight);
         }
 
+        [Test]
+        public void Test_align_items_center_nested()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.JustifyContent = YogaJustify.Center;
+            root.AlignItems = YogaAlign.Center;
+            root.PositionType = YogaPositionType.Absolute;
+            root.Width = 52;
+            root.Height = 52;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.AlignItems = YogaAlign.Center;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child0_child0 = new YogaNode(config);
+            root_child0_child0.MarginLeft = 10;
+            root_child0_child0.MarginRight = 10;
+            root_child0_child0.Width = 52;
+            root_child0_child0.Height = 52;
+            root_child0.Insert(0, root_child0_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(-10f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(52f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(10f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(52f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(52f, root_child0_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(-10f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(52f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(10f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(52f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(52f, root_child0_child0.LayoutHeight);
+        }
+
     }
 }

--- a/csharp/tests/Facebook.Yoga/YGAlignItemsTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGAlignItemsTest.cs
@@ -1595,7 +1595,6 @@ namespace Facebook.Yoga
             YogaNode root = new YogaNode(config);
             root.JustifyContent = YogaJustify.Center;
             root.AlignItems = YogaAlign.Center;
-            root.PositionType = YogaPositionType.Absolute;
             root.Width = 52;
             root.Height = 52;
 
@@ -1654,7 +1653,6 @@ namespace Facebook.Yoga
             YogaNode root = new YogaNode(config);
             root.JustifyContent = YogaJustify.Center;
             root.AlignItems = YogaAlign.Center;
-            root.PositionType = YogaPositionType.Absolute;
             root.Width = 52;
             root.Height = 52;
 
@@ -1713,7 +1711,6 @@ namespace Facebook.Yoga
             YogaNode root = new YogaNode(config);
             root.JustifyContent = YogaJustify.Center;
             root.AlignItems = YogaAlign.Center;
-            root.PositionType = YogaPositionType.Absolute;
             root.Width = 52;
             root.Height = 52;
 
@@ -1770,7 +1767,6 @@ namespace Facebook.Yoga
             YogaNode root = new YogaNode(config);
             root.JustifyContent = YogaJustify.Center;
             root.AlignItems = YogaAlign.Center;
-            root.PositionType = YogaPositionType.Absolute;
             root.Width = 52;
             root.Height = 52;
 

--- a/csharp/tests/Facebook.Yoga/YGAlignItemsTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGAlignItemsTest.cs
@@ -1588,7 +1588,7 @@ namespace Facebook.Yoga
         }
 
         [Test]
-        public void Test_align_items_center_nested()
+        public void Test_align_items_center_child_with_margin_bigger_than_parent()
         {
             YogaConfig config = new YogaConfig();
 
@@ -1644,6 +1644,179 @@ namespace Facebook.Yoga
             Assert.AreEqual(0f, root_child0_child0.LayoutY);
             Assert.AreEqual(52f, root_child0_child0.LayoutWidth);
             Assert.AreEqual(52f, root_child0_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_items_flex_end_child_with_margin_bigger_than_parent()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.JustifyContent = YogaJustify.Center;
+            root.AlignItems = YogaAlign.Center;
+            root.PositionType = YogaPositionType.Absolute;
+            root.Width = 52;
+            root.Height = 52;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.AlignItems = YogaAlign.FlexEnd;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child0_child0 = new YogaNode(config);
+            root_child0_child0.MarginLeft = 10;
+            root_child0_child0.MarginRight = 10;
+            root_child0_child0.Width = 52;
+            root_child0_child0.Height = 52;
+            root_child0.Insert(0, root_child0_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(-10f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(52f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(10f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(52f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(52f, root_child0_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(-10f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(52f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(10f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(52f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(52f, root_child0_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_items_center_child_without_margin_bigger_than_parent()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.JustifyContent = YogaJustify.Center;
+            root.AlignItems = YogaAlign.Center;
+            root.PositionType = YogaPositionType.Absolute;
+            root.Width = 52;
+            root.Height = 52;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.AlignItems = YogaAlign.Center;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child0_child0 = new YogaNode(config);
+            root_child0_child0.Width = 72;
+            root_child0_child0.Height = 72;
+            root_child0.Insert(0, root_child0_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(-10f, root_child0.LayoutX);
+            Assert.AreEqual(-10f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(-10f, root_child0.LayoutX);
+            Assert.AreEqual(-10f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_items_flex_end_child_without_margin_bigger_than_parent()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.JustifyContent = YogaJustify.Center;
+            root.AlignItems = YogaAlign.Center;
+            root.PositionType = YogaPositionType.Absolute;
+            root.Width = 52;
+            root.Height = 52;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.AlignItems = YogaAlign.FlexEnd;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child0_child0 = new YogaNode(config);
+            root_child0_child0.Width = 72;
+            root_child0_child0.Height = 72;
+            root_child0.Insert(0, root_child0_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(-10f, root_child0.LayoutX);
+            Assert.AreEqual(-10f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(-10f, root_child0.LayoutX);
+            Assert.AreEqual(-10f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0_child0.LayoutHeight);
         }
 
     }

--- a/csharp/tests/Facebook.Yoga/YGMarginTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGMarginTest.cs
@@ -1436,5 +1436,180 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root_child0.LayoutHeight);
         }
 
+        [Test]
+        public void Test_margin_auto_left_right_child_bigger_than_parent()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.JustifyContent = YogaJustify.Center;
+            root.PositionType = YogaPositionType.Absolute;
+            root.Width = 52;
+            root.Height = 52;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.MarginLeft = YogaValue.Auto();
+            root_child0.MarginRight = YogaValue.Auto();
+            root_child0.Width = 72;
+            root_child0.Height = 72;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(-10f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(-20f, root_child0.LayoutX);
+            Assert.AreEqual(-10f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_margin_auto_left_child_bigger_than_parent()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.JustifyContent = YogaJustify.Center;
+            root.PositionType = YogaPositionType.Absolute;
+            root.Width = 52;
+            root.Height = 52;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.MarginLeft = YogaValue.Auto();
+            root_child0.Width = 72;
+            root_child0.Height = 72;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(-10f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(-20f, root_child0.LayoutX);
+            Assert.AreEqual(-10f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_margin_fix_left_auto_right_child_bigger_than_parent()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.JustifyContent = YogaJustify.Center;
+            root.PositionType = YogaPositionType.Absolute;
+            root.Width = 52;
+            root.Height = 52;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.MarginLeft = 10;
+            root_child0.MarginRight = YogaValue.Auto();
+            root_child0.Width = 72;
+            root_child0.Height = 72;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(10f, root_child0.LayoutX);
+            Assert.AreEqual(-10f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(-20f, root_child0.LayoutX);
+            Assert.AreEqual(-10f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_margin_auto_left_fix_right_child_bigger_than_parent()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.JustifyContent = YogaJustify.Center;
+            root.PositionType = YogaPositionType.Absolute;
+            root.Width = 52;
+            root.Height = 52;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.MarginLeft = YogaValue.Auto();
+            root_child0.MarginRight = 10;
+            root_child0.Width = 72;
+            root_child0.Height = 72;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(-10f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(52f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(-30f, root_child0.LayoutX);
+            Assert.AreEqual(-10f, root_child0.LayoutY);
+            Assert.AreEqual(72f, root_child0.LayoutWidth);
+            Assert.AreEqual(72f, root_child0.LayoutHeight);
+        }
+
     }
 }

--- a/csharp/tests/Facebook.Yoga/YGMarginTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGMarginTest.cs
@@ -1443,7 +1443,6 @@ namespace Facebook.Yoga
 
             YogaNode root = new YogaNode(config);
             root.JustifyContent = YogaJustify.Center;
-            root.PositionType = YogaPositionType.Absolute;
             root.Width = 52;
             root.Height = 52;
 
@@ -1487,7 +1486,6 @@ namespace Facebook.Yoga
 
             YogaNode root = new YogaNode(config);
             root.JustifyContent = YogaJustify.Center;
-            root.PositionType = YogaPositionType.Absolute;
             root.Width = 52;
             root.Height = 52;
 
@@ -1530,7 +1528,6 @@ namespace Facebook.Yoga
 
             YogaNode root = new YogaNode(config);
             root.JustifyContent = YogaJustify.Center;
-            root.PositionType = YogaPositionType.Absolute;
             root.Width = 52;
             root.Height = 52;
 
@@ -1574,7 +1571,6 @@ namespace Facebook.Yoga
 
             YogaNode root = new YogaNode(config);
             root.JustifyContent = YogaJustify.Center;
-            root.PositionType = YogaPositionType.Absolute;
             root.Width = 52;
             root.Height = 52;
 

--- a/gentest/fixtures/YGAlignItemsTest.html
+++ b/gentest/fixtures/YGAlignItemsTest.html
@@ -144,25 +144,25 @@
   <div style="width: 50px; height: 20px;"></div>
 </div>
 
-<div id="align_items_center_child_with_margin_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; align-items: center; justify-content: center;">
+<div id="align_items_center_child_with_margin_bigger_than_parent" style="height: 52px; width: 52px; align-items: center; justify-content: center;">
   <div style="align-items: center;">
     <div style="width: 52px; height: 52px; margin-left: 10px; margin-right: 10px;"></div>
   </div>
 </div>
 
-<div id="align_items_flex_end_child_with_margin_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; align-items: center; justify-content: center;">
+<div id="align_items_flex_end_child_with_margin_bigger_than_parent" style="height: 52px; width: 52px; align-items: center; justify-content: center;">
   <div style="align-items: flex-end;">
     <div style="width: 52px; height: 52px; margin-left: 10px; margin-right: 10px;"></div>
   </div>
 </div>
 
-<div id="align_items_center_child_without_margin_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; align-items: center; justify-content: center;">
+<div id="align_items_center_child_without_margin_bigger_than_parent" style="height: 52px; width: 52px; align-items: center; justify-content: center;">
   <div style="align-items: center;">
     <div style="width: 72px; height: 72px;"></div>
   </div>
 </div>
 
-<div id="align_items_flex_end_child_without_margin_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; align-items: center; justify-content: center;">
+<div id="align_items_flex_end_child_without_margin_bigger_than_parent" style="height: 52px; width: 52px; align-items: center; justify-content: center;">
   <div style="align-items: flex-end;">
     <div style="width: 72px; height: 72px;"></div>
   </div>

--- a/gentest/fixtures/YGAlignItemsTest.html
+++ b/gentest/fixtures/YGAlignItemsTest.html
@@ -144,9 +144,26 @@
   <div style="width: 50px; height: 20px;"></div>
 </div>
 
-
-<div id="align_items_center_nested" style="height: 52px; width: 52px; position: absolute; align-items: center; justify-content: center;">
+<div id="align_items_center_child_with_margin_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; align-items: center; justify-content: center;">
   <div style="align-items: center;">
     <div style="width: 52px; height: 52px; margin-left: 10px; margin-right: 10px;"></div>
+  </div>
+</div>
+
+<div id="align_items_flex_end_child_with_margin_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; align-items: center; justify-content: center;">
+  <div style="align-items: flex-end;">
+    <div style="width: 52px; height: 52px; margin-left: 10px; margin-right: 10px;"></div>
+  </div>
+</div>
+
+<div id="align_items_center_child_without_margin_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; align-items: center; justify-content: center;">
+  <div style="align-items: center;">
+    <div style="width: 72px; height: 72px;"></div>
+  </div>
+</div>
+
+<div id="align_items_flex_end_child_without_margin_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; align-items: center; justify-content: center;">
+  <div style="align-items: flex-end;">
+    <div style="width: 72px; height: 72px;"></div>
   </div>
 </div>

--- a/gentest/fixtures/YGAlignItemsTest.html
+++ b/gentest/fixtures/YGAlignItemsTest.html
@@ -133,8 +133,6 @@
   <div style="width: 50px; height: 20px;flex-direction:column;"></div>
 </div>
 
-
-
 <div id="align_baseline_multiline_row_and_column" style="width: 100px; height: 100px; flex-direction:row; align-items: baseline;flex-wrap:wrap;">
   <div style="width: 50px; height: 50px;"></div>
   <div style="width: 50px; height: 50px;flex-direction:column;">
@@ -144,4 +142,11 @@
     <div style="width: 50px; height: 10px;"></div>
   </div>
   <div style="width: 50px; height: 20px;"></div>
+</div>
+
+
+<div id="align_items_center_nested" style="height: 52px; width: 52px; position: absolute; align-items: center; justify-content: center;">
+  <div style="align-items: center;">
+    <div style="width: 52px; height: 52px; margin-left: 10px; margin-right: 10px;"></div>
+  </div>
 </div>

--- a/gentest/fixtures/YGMarginTest.html
+++ b/gentest/fixtures/YGMarginTest.html
@@ -125,18 +125,18 @@
   <div style="width: 100px; height: 100px; max-width: 100px; margin-left: 20px;"></div>
 </div>
 
-<div id="margin_auto_left_right_child_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; justify-content: center;">
+<div id="margin_auto_left_right_child_bigger_than_parent" style="height: 52px; width: 52px; justify-content: center;">
   <div style="width: 72px; height: 72px; margin-left: auto; margin-right:auto;"></div>
 </div>
 
-<div id="margin_auto_left_child_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; justify-content: center;">
+<div id="margin_auto_left_child_bigger_than_parent" style="height: 52px; width: 52px; justify-content: center;">
   <div style="width: 72px; height: 72px; margin-left: auto;"></div>
 </div>
 
-<div id="margin_fix_left_auto_right_child_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; justify-content: center;">
+<div id="margin_fix_left_auto_right_child_bigger_than_parent" style="height: 52px; width: 52px; justify-content: center;">
   <div style="width: 72px; height: 72px; margin-left: 10px; margin-right: auto;"></div>
 </div>
 
-<div id="margin_auto_left_fix_right_child_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; justify-content: center;">
+<div id="margin_auto_left_fix_right_child_bigger_than_parent" style="height: 52px; width: 52px; justify-content: center;">
   <div style="width: 72px; height: 72px; margin-left: auto; margin-right: 10px;"></div>
 </div>

--- a/gentest/fixtures/YGMarginTest.html
+++ b/gentest/fixtures/YGMarginTest.html
@@ -124,3 +124,19 @@
 <div id="margin_should_not_be_part_of_max_width" style="width: 250px; height: 250px;">
   <div style="width: 100px; height: 100px; max-width: 100px; margin-left: 20px;"></div>
 </div>
+
+<div id="margin_auto_left_right_child_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; justify-content: center;">
+  <div style="width: 72px; height: 72px; margin-left: auto; margin-right:auto;"></div>
+</div>
+
+<div id="margin_auto_left_child_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; justify-content: center;">
+  <div style="width: 72px; height: 72px; margin-left: auto;"></div>
+</div>
+
+<div id="margin_fix_left_auto_right_child_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; justify-content: center;">
+  <div style="width: 72px; height: 72px; margin-left: 10px; margin-right: auto;"></div>
+</div>
+
+<div id="margin_auto_left_fix_right_child_bigger_than_parent" style="height: 52px; width: 52px; position: absolute; justify-content: center;">
+  <div style="width: 72px; height: 72px; margin-left: auto; margin-right: 10px;"></div>
+</div>

--- a/java/tests/com/facebook/yoga/YGAlignItemsTest.java
+++ b/java/tests/com/facebook/yoga/YGAlignItemsTest.java
@@ -1567,4 +1567,62 @@ public class YGAlignItemsTest {
     assertEquals(20f, root_child3.getLayoutHeight(), 0.0f);
   }
 
+  @Test
+  public void test_align_items_center_nested() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setAlignItems(YogaAlign.CENTER);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(52f);
+    root.setHeight(52f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setAlignItems(YogaAlign.CENTER);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = new YogaNode(config);
+    root_child0_child0.setMargin(YogaEdge.LEFT, 10f);
+    root_child0_child0.setMargin(YogaEdge.RIGHT, 10f);
+    root_child0_child0.setWidth(52f);
+    root_child0_child0.setHeight(52f);
+    root_child0.addChildAt(root_child0_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(-10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(52f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(-10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(52f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root_child0_child0.getLayoutHeight(), 0.0f);
+  }
+
 }

--- a/java/tests/com/facebook/yoga/YGAlignItemsTest.java
+++ b/java/tests/com/facebook/yoga/YGAlignItemsTest.java
@@ -1574,7 +1574,6 @@ public class YGAlignItemsTest {
     final YogaNode root = new YogaNode(config);
     root.setJustifyContent(YogaJustify.CENTER);
     root.setAlignItems(YogaAlign.CENTER);
-    root.setPositionType(YogaPositionType.ABSOLUTE);
     root.setWidth(52f);
     root.setHeight(52f);
 
@@ -1632,7 +1631,6 @@ public class YGAlignItemsTest {
     final YogaNode root = new YogaNode(config);
     root.setJustifyContent(YogaJustify.CENTER);
     root.setAlignItems(YogaAlign.CENTER);
-    root.setPositionType(YogaPositionType.ABSOLUTE);
     root.setWidth(52f);
     root.setHeight(52f);
 
@@ -1690,7 +1688,6 @@ public class YGAlignItemsTest {
     final YogaNode root = new YogaNode(config);
     root.setJustifyContent(YogaJustify.CENTER);
     root.setAlignItems(YogaAlign.CENTER);
-    root.setPositionType(YogaPositionType.ABSOLUTE);
     root.setWidth(52f);
     root.setHeight(52f);
 
@@ -1746,7 +1743,6 @@ public class YGAlignItemsTest {
     final YogaNode root = new YogaNode(config);
     root.setJustifyContent(YogaJustify.CENTER);
     root.setAlignItems(YogaAlign.CENTER);
-    root.setPositionType(YogaPositionType.ABSOLUTE);
     root.setWidth(52f);
     root.setHeight(52f);
 

--- a/java/tests/com/facebook/yoga/YGAlignItemsTest.java
+++ b/java/tests/com/facebook/yoga/YGAlignItemsTest.java
@@ -1568,7 +1568,7 @@ public class YGAlignItemsTest {
   }
 
   @Test
-  public void test_align_items_center_nested() {
+  public void test_align_items_center_child_with_margin_bigger_than_parent() {
     YogaConfig config = new YogaConfig();
 
     final YogaNode root = new YogaNode(config);
@@ -1623,6 +1623,176 @@ public class YGAlignItemsTest {
     assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
     assertEquals(52f, root_child0_child0.getLayoutWidth(), 0.0f);
     assertEquals(52f, root_child0_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_items_flex_end_child_with_margin_bigger_than_parent() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setAlignItems(YogaAlign.CENTER);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(52f);
+    root.setHeight(52f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setAlignItems(YogaAlign.FLEX_END);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = new YogaNode(config);
+    root_child0_child0.setMargin(YogaEdge.LEFT, 10f);
+    root_child0_child0.setMargin(YogaEdge.RIGHT, 10f);
+    root_child0_child0.setWidth(52f);
+    root_child0_child0.setHeight(52f);
+    root_child0.addChildAt(root_child0_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(-10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(52f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(-10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(52f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root_child0_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_items_center_child_without_margin_bigger_than_parent() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setAlignItems(YogaAlign.CENTER);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(52f);
+    root.setHeight(52f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setAlignItems(YogaAlign.CENTER);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = new YogaNode(config);
+    root_child0_child0.setWidth(72f);
+    root_child0_child0.setHeight(72f);
+    root_child0.addChildAt(root_child0_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(-10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(-10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_items_flex_end_child_without_margin_bigger_than_parent() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setAlignItems(YogaAlign.CENTER);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(52f);
+    root.setHeight(52f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setAlignItems(YogaAlign.FLEX_END);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = new YogaNode(config);
+    root_child0_child0.setWidth(72f);
+    root_child0_child0.setHeight(72f);
+    root_child0.addChildAt(root_child0_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(-10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(-10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0_child0.getLayoutHeight(), 0.0f);
   }
 
 }

--- a/java/tests/com/facebook/yoga/YGMarginTest.java
+++ b/java/tests/com/facebook/yoga/YGMarginTest.java
@@ -1414,7 +1414,6 @@ public class YGMarginTest {
 
     final YogaNode root = new YogaNode(config);
     root.setJustifyContent(YogaJustify.CENTER);
-    root.setPositionType(YogaPositionType.ABSOLUTE);
     root.setWidth(52f);
     root.setHeight(52f);
 
@@ -1457,7 +1456,6 @@ public class YGMarginTest {
 
     final YogaNode root = new YogaNode(config);
     root.setJustifyContent(YogaJustify.CENTER);
-    root.setPositionType(YogaPositionType.ABSOLUTE);
     root.setWidth(52f);
     root.setHeight(52f);
 
@@ -1499,7 +1497,6 @@ public class YGMarginTest {
 
     final YogaNode root = new YogaNode(config);
     root.setJustifyContent(YogaJustify.CENTER);
-    root.setPositionType(YogaPositionType.ABSOLUTE);
     root.setWidth(52f);
     root.setHeight(52f);
 
@@ -1542,7 +1539,6 @@ public class YGMarginTest {
 
     final YogaNode root = new YogaNode(config);
     root.setJustifyContent(YogaJustify.CENTER);
-    root.setPositionType(YogaPositionType.ABSOLUTE);
     root.setWidth(52f);
     root.setHeight(52f);
 

--- a/java/tests/com/facebook/yoga/YGMarginTest.java
+++ b/java/tests/com/facebook/yoga/YGMarginTest.java
@@ -1408,4 +1408,175 @@ public class YGMarginTest {
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
   }
 
+  @Test
+  public void test_margin_auto_left_right_child_bigger_than_parent() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(52f);
+    root.setHeight(52f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setMarginAuto(YogaEdge.LEFT);
+    root_child0.setMarginAuto(YogaEdge.RIGHT);
+    root_child0.setWidth(72f);
+    root_child0.setHeight(72f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(-20f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_margin_auto_left_child_bigger_than_parent() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(52f);
+    root.setHeight(52f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setMarginAuto(YogaEdge.LEFT);
+    root_child0.setWidth(72f);
+    root_child0.setHeight(72f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(-20f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_margin_fix_left_auto_right_child_bigger_than_parent() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(52f);
+    root.setHeight(52f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setMargin(YogaEdge.LEFT, 10f);
+    root_child0.setMarginAuto(YogaEdge.RIGHT);
+    root_child0.setWidth(72f);
+    root_child0.setHeight(72f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(-20f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_margin_auto_left_fix_right_child_bigger_than_parent() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setJustifyContent(YogaJustify.CENTER);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(52f);
+    root.setHeight(52f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setMarginAuto(YogaEdge.LEFT);
+    root_child0.setMargin(YogaEdge.RIGHT, 10f);
+    root_child0.setWidth(72f);
+    root_child0.setHeight(72f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(52f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(-30f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(72f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
 }

--- a/javascript/tests/Facebook.Yoga/YGAlignItemsTest.js
+++ b/javascript/tests/Facebook.Yoga/YGAlignItemsTest.js
@@ -1562,7 +1562,7 @@ it("align_baseline_multiline_row_and_column", function () {
     }
   }
 });
-it("align_items_center_nested", function () {
+it("align_items_center_child_with_margin_bigger_than_parent", function () {
   try {
     var root = Yoga.Node.create(config);
     root.setJustifyContent(Yoga.JUSTIFY_CENTER);
@@ -1614,6 +1614,176 @@ it("align_items_center_nested", function () {
     console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
     console.assert(52 === root_child0_child0.getComputedWidth(), "52 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
     console.assert(52 === root_child0_child0.getComputedHeight(), "52 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+  }
+});
+it("align_items_flex_end_child_with_margin_bigger_than_parent", function () {
+  try {
+    var root = Yoga.Node.create(config);
+    root.setJustifyContent(Yoga.JUSTIFY_CENTER);
+    root.setAlignItems(Yoga.ALIGN_CENTER);
+    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root.setWidth(52);
+    root.setHeight(52);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setAlignItems(Yoga.ALIGN_FLEX_END);
+    root.insertChild(root_child0, 0);
+
+    var root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setMargin(Yoga.EDGE_LEFT, 10);
+    root_child0_child0.setMargin(Yoga.EDGE_RIGHT, 10);
+    root_child0_child0.setWidth(52);
+    root_child0_child0.setHeight(52);
+    root_child0.insertChild(root_child0_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(-10 === root_child0.getComputedLeft(), "-10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(52 === root_child0.getComputedHeight(), "52 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(10 === root_child0_child0.getComputedLeft(), "10 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(52 === root_child0_child0.getComputedWidth(), "52 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(52 === root_child0_child0.getComputedHeight(), "52 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(-10 === root_child0.getComputedLeft(), "-10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(52 === root_child0.getComputedHeight(), "52 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(10 === root_child0_child0.getComputedLeft(), "10 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(52 === root_child0_child0.getComputedWidth(), "52 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(52 === root_child0_child0.getComputedHeight(), "52 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+  }
+});
+it("align_items_center_child_without_margin_bigger_than_parent", function () {
+  try {
+    var root = Yoga.Node.create(config);
+    root.setJustifyContent(Yoga.JUSTIFY_CENTER);
+    root.setAlignItems(Yoga.ALIGN_CENTER);
+    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root.setWidth(52);
+    root.setHeight(52);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setAlignItems(Yoga.ALIGN_CENTER);
+    root.insertChild(root_child0, 0);
+
+    var root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth(72);
+    root_child0_child0.setHeight(72);
+    root_child0.insertChild(root_child0_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(-10 === root_child0.getComputedLeft(), "-10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(-10 === root_child0.getComputedTop(), "-10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0.getComputedHeight(), "72 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0_child0.getComputedWidth(), "72 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0_child0.getComputedHeight(), "72 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(-10 === root_child0.getComputedLeft(), "-10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(-10 === root_child0.getComputedTop(), "-10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0.getComputedHeight(), "72 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0_child0.getComputedWidth(), "72 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0_child0.getComputedHeight(), "72 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+  }
+});
+it("align_items_flex_end_child_without_margin_bigger_than_parent", function () {
+  try {
+    var root = Yoga.Node.create(config);
+    root.setJustifyContent(Yoga.JUSTIFY_CENTER);
+    root.setAlignItems(Yoga.ALIGN_CENTER);
+    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root.setWidth(52);
+    root.setHeight(52);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setAlignItems(Yoga.ALIGN_FLEX_END);
+    root.insertChild(root_child0, 0);
+
+    var root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth(72);
+    root_child0_child0.setHeight(72);
+    root_child0.insertChild(root_child0_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(-10 === root_child0.getComputedLeft(), "-10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(-10 === root_child0.getComputedTop(), "-10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0.getComputedHeight(), "72 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0_child0.getComputedWidth(), "72 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0_child0.getComputedHeight(), "72 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(-10 === root_child0.getComputedLeft(), "-10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(-10 === root_child0.getComputedTop(), "-10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0.getComputedHeight(), "72 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0_child0.getComputedWidth(), "72 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0_child0.getComputedHeight(), "72 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
   } finally {
     if (typeof root !== "undefined") {
       root.freeRecursive();

--- a/javascript/tests/Facebook.Yoga/YGAlignItemsTest.js
+++ b/javascript/tests/Facebook.Yoga/YGAlignItemsTest.js
@@ -1567,7 +1567,6 @@ it("align_items_center_child_with_margin_bigger_than_parent", function () {
     var root = Yoga.Node.create(config);
     root.setJustifyContent(Yoga.JUSTIFY_CENTER);
     root.setAlignItems(Yoga.ALIGN_CENTER);
-    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
     root.setWidth(52);
     root.setHeight(52);
 
@@ -1625,7 +1624,6 @@ it("align_items_flex_end_child_with_margin_bigger_than_parent", function () {
     var root = Yoga.Node.create(config);
     root.setJustifyContent(Yoga.JUSTIFY_CENTER);
     root.setAlignItems(Yoga.ALIGN_CENTER);
-    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
     root.setWidth(52);
     root.setHeight(52);
 
@@ -1683,7 +1681,6 @@ it("align_items_center_child_without_margin_bigger_than_parent", function () {
     var root = Yoga.Node.create(config);
     root.setJustifyContent(Yoga.JUSTIFY_CENTER);
     root.setAlignItems(Yoga.ALIGN_CENTER);
-    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
     root.setWidth(52);
     root.setHeight(52);
 
@@ -1739,7 +1736,6 @@ it("align_items_flex_end_child_without_margin_bigger_than_parent", function () {
     var root = Yoga.Node.create(config);
     root.setJustifyContent(Yoga.JUSTIFY_CENTER);
     root.setAlignItems(Yoga.ALIGN_CENTER);
-    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
     root.setWidth(52);
     root.setHeight(52);
 

--- a/javascript/tests/Facebook.Yoga/YGAlignItemsTest.js
+++ b/javascript/tests/Facebook.Yoga/YGAlignItemsTest.js
@@ -1562,3 +1562,61 @@ it("align_baseline_multiline_row_and_column", function () {
     }
   }
 });
+it("align_items_center_nested", function () {
+  try {
+    var root = Yoga.Node.create(config);
+    root.setJustifyContent(Yoga.JUSTIFY_CENTER);
+    root.setAlignItems(Yoga.ALIGN_CENTER);
+    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root.setWidth(52);
+    root.setHeight(52);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setAlignItems(Yoga.ALIGN_CENTER);
+    root.insertChild(root_child0, 0);
+
+    var root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setMargin(Yoga.EDGE_LEFT, 10);
+    root_child0_child0.setMargin(Yoga.EDGE_RIGHT, 10);
+    root_child0_child0.setWidth(52);
+    root_child0_child0.setHeight(52);
+    root_child0.insertChild(root_child0_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(-10 === root_child0.getComputedLeft(), "-10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(52 === root_child0.getComputedHeight(), "52 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(10 === root_child0_child0.getComputedLeft(), "10 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(52 === root_child0_child0.getComputedWidth(), "52 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(52 === root_child0_child0.getComputedHeight(), "52 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(-10 === root_child0.getComputedLeft(), "-10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(52 === root_child0.getComputedHeight(), "52 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(10 === root_child0_child0.getComputedLeft(), "10 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(52 === root_child0_child0.getComputedWidth(), "52 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(52 === root_child0_child0.getComputedHeight(), "52 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+  }
+});

--- a/javascript/tests/Facebook.Yoga/YGMarginTest.js
+++ b/javascript/tests/Facebook.Yoga/YGMarginTest.js
@@ -1403,3 +1403,174 @@ it("margin_should_not_be_part_of_max_width", function () {
     }
   }
 });
+it("margin_auto_left_right_child_bigger_than_parent", function () {
+  try {
+    var root = Yoga.Node.create(config);
+    root.setJustifyContent(Yoga.JUSTIFY_CENTER);
+    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root.setWidth(52);
+    root.setHeight(52);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setMargin(Yoga.EDGE_LEFT, "auto");
+    root_child0.setMargin(Yoga.EDGE_RIGHT, "auto");
+    root_child0.setWidth(72);
+    root_child0.setHeight(72);
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(-10 === root_child0.getComputedTop(), "-10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0.getComputedHeight(), "72 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(-20 === root_child0.getComputedLeft(), "-20 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(-10 === root_child0.getComputedTop(), "-10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0.getComputedHeight(), "72 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+  }
+});
+it("margin_auto_left_child_bigger_than_parent", function () {
+  try {
+    var root = Yoga.Node.create(config);
+    root.setJustifyContent(Yoga.JUSTIFY_CENTER);
+    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root.setWidth(52);
+    root.setHeight(52);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setMargin(Yoga.EDGE_LEFT, "auto");
+    root_child0.setWidth(72);
+    root_child0.setHeight(72);
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(-10 === root_child0.getComputedTop(), "-10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0.getComputedHeight(), "72 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(-20 === root_child0.getComputedLeft(), "-20 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(-10 === root_child0.getComputedTop(), "-10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0.getComputedHeight(), "72 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+  }
+});
+it("margin_fix_left_auto_right_child_bigger_than_parent", function () {
+  try {
+    var root = Yoga.Node.create(config);
+    root.setJustifyContent(Yoga.JUSTIFY_CENTER);
+    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root.setWidth(52);
+    root.setHeight(52);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setMargin(Yoga.EDGE_LEFT, 10);
+    root_child0.setMargin(Yoga.EDGE_RIGHT, "auto");
+    root_child0.setWidth(72);
+    root_child0.setHeight(72);
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(10 === root_child0.getComputedLeft(), "10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(-10 === root_child0.getComputedTop(), "-10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0.getComputedHeight(), "72 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(-20 === root_child0.getComputedLeft(), "-20 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(-10 === root_child0.getComputedTop(), "-10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0.getComputedHeight(), "72 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+  }
+});
+it("margin_auto_left_fix_right_child_bigger_than_parent", function () {
+  try {
+    var root = Yoga.Node.create(config);
+    root.setJustifyContent(Yoga.JUSTIFY_CENTER);
+    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root.setWidth(52);
+    root.setHeight(52);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setMargin(Yoga.EDGE_LEFT, "auto");
+    root_child0.setMargin(Yoga.EDGE_RIGHT, 10);
+    root_child0.setWidth(72);
+    root_child0.setHeight(72);
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(-10 === root_child0.getComputedTop(), "-10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0.getComputedHeight(), "72 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(52 === root.getComputedWidth(), "52 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(-30 === root_child0.getComputedLeft(), "-30 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(-10 === root_child0.getComputedTop(), "-10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(72 === root_child0.getComputedWidth(), "72 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(72 === root_child0.getComputedHeight(), "72 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+  }
+});

--- a/javascript/tests/Facebook.Yoga/YGMarginTest.js
+++ b/javascript/tests/Facebook.Yoga/YGMarginTest.js
@@ -1407,7 +1407,6 @@ it("margin_auto_left_right_child_bigger_than_parent", function () {
   try {
     var root = Yoga.Node.create(config);
     root.setJustifyContent(Yoga.JUSTIFY_CENTER);
-    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
     root.setWidth(52);
     root.setHeight(52);
 
@@ -1450,7 +1449,6 @@ it("margin_auto_left_child_bigger_than_parent", function () {
   try {
     var root = Yoga.Node.create(config);
     root.setJustifyContent(Yoga.JUSTIFY_CENTER);
-    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
     root.setWidth(52);
     root.setHeight(52);
 
@@ -1492,7 +1490,6 @@ it("margin_fix_left_auto_right_child_bigger_than_parent", function () {
   try {
     var root = Yoga.Node.create(config);
     root.setJustifyContent(Yoga.JUSTIFY_CENTER);
-    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
     root.setWidth(52);
     root.setHeight(52);
 
@@ -1535,7 +1532,6 @@ it("margin_auto_left_fix_right_child_bigger_than_parent", function () {
   try {
     var root = Yoga.Node.create(config);
     root.setJustifyContent(Yoga.JUSTIFY_CENTER);
-    root.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
     root.setWidth(52);
     root.setHeight(52);
 

--- a/tests/YGAlignItemsTest.cpp
+++ b/tests/YGAlignItemsTest.cpp
@@ -1588,7 +1588,6 @@ TEST(YogaTest, align_items_center_child_with_margin_bigger_than_parent) {
   const YGNodeRef root = YGNodeNewWithConfig(config);
   YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
   YGNodeStyleSetAlignItems(root, YGAlignCenter);
-  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
   YGNodeStyleSetWidth(root, 52);
   YGNodeStyleSetHeight(root, 52);
 
@@ -1647,7 +1646,6 @@ TEST(YogaTest, align_items_flex_end_child_with_margin_bigger_than_parent) {
   const YGNodeRef root = YGNodeNewWithConfig(config);
   YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
   YGNodeStyleSetAlignItems(root, YGAlignCenter);
-  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
   YGNodeStyleSetWidth(root, 52);
   YGNodeStyleSetHeight(root, 52);
 
@@ -1706,7 +1704,6 @@ TEST(YogaTest, align_items_center_child_without_margin_bigger_than_parent) {
   const YGNodeRef root = YGNodeNewWithConfig(config);
   YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
   YGNodeStyleSetAlignItems(root, YGAlignCenter);
-  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
   YGNodeStyleSetWidth(root, 52);
   YGNodeStyleSetHeight(root, 52);
 
@@ -1763,7 +1760,6 @@ TEST(YogaTest, align_items_flex_end_child_without_margin_bigger_than_parent) {
   const YGNodeRef root = YGNodeNewWithConfig(config);
   YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
   YGNodeStyleSetAlignItems(root, YGAlignCenter);
-  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
   YGNodeStyleSetWidth(root, 52);
   YGNodeStyleSetHeight(root, 52);
 

--- a/tests/YGAlignItemsTest.cpp
+++ b/tests/YGAlignItemsTest.cpp
@@ -1581,3 +1581,62 @@ TEST(YogaTest, align_baseline_multiline_row_and_column) {
 
   YGConfigFree(config);
 }
+
+TEST(YogaTest, align_items_center_nested) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 52);
+  YGNodeStyleSetHeight(root, 52);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignItems(root_child0, YGAlignCenter);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMargin(root_child0_child0, YGEdgeLeft, 10);
+  YGNodeStyleSetMargin(root_child0_child0, YGEdgeRight, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 52);
+  YGNodeStyleSetHeight(root_child0_child0, 52);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root_child0_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root_child0_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}

--- a/tests/YGAlignItemsTest.cpp
+++ b/tests/YGAlignItemsTest.cpp
@@ -1582,7 +1582,7 @@ TEST(YogaTest, align_baseline_multiline_row_and_column) {
   YGConfigFree(config);
 }
 
-TEST(YogaTest, align_items_center_nested) {
+TEST(YogaTest, align_items_center_child_with_margin_bigger_than_parent) {
   const YGConfigRef config = YGConfigNew();
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
@@ -1635,6 +1635,179 @@ TEST(YogaTest, align_items_center_nested) {
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
   ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root_child0_child0));
   ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root_child0_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_items_flex_end_child_with_margin_bigger_than_parent) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 52);
+  YGNodeStyleSetHeight(root, 52);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignItems(root_child0, YGAlignFlexEnd);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMargin(root_child0_child0, YGEdgeLeft, 10);
+  YGNodeStyleSetMargin(root_child0_child0, YGEdgeRight, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 52);
+  YGNodeStyleSetHeight(root_child0_child0, 52);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root_child0_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root_child0_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_items_center_child_without_margin_bigger_than_parent) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 52);
+  YGNodeStyleSetHeight(root, 52);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignItems(root_child0, YGAlignCenter);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0, 72);
+  YGNodeStyleSetHeight(root_child0_child0, 72);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_items_flex_end_child_without_margin_bigger_than_parent) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 52);
+  YGNodeStyleSetHeight(root, 52);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignItems(root_child0, YGAlignFlexEnd);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0, 72);
+  YGNodeStyleSetHeight(root_child0_child0, 72);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0_child0));
 
   YGNodeFreeRecursive(root);
 

--- a/tests/YGMarginTest.cpp
+++ b/tests/YGMarginTest.cpp
@@ -1430,3 +1430,178 @@ TEST(YogaTest, margin_should_not_be_part_of_max_width) {
 
   YGConfigFree(config);
 }
+
+TEST(YogaTest, margin_auto_left_right_child_bigger_than_parent) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 52);
+  YGNodeStyleSetHeight(root, 52);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMarginAuto(root_child0, YGEdgeLeft);
+  YGNodeStyleSetMarginAuto(root_child0, YGEdgeRight);
+  YGNodeStyleSetWidth(root_child0, 72);
+  YGNodeStyleSetHeight(root_child0, 72);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(-20, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, margin_auto_left_child_bigger_than_parent) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 52);
+  YGNodeStyleSetHeight(root, 52);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMarginAuto(root_child0, YGEdgeLeft);
+  YGNodeStyleSetWidth(root_child0, 72);
+  YGNodeStyleSetHeight(root_child0, 72);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(-20, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, margin_fix_left_auto_right_child_bigger_than_parent) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 52);
+  YGNodeStyleSetHeight(root, 52);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMargin(root_child0, YGEdgeLeft, 10);
+  YGNodeStyleSetMarginAuto(root_child0, YGEdgeRight);
+  YGNodeStyleSetWidth(root_child0, 72);
+  YGNodeStyleSetHeight(root_child0, 72);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(-20, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, margin_auto_left_fix_right_child_bigger_than_parent) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 52);
+  YGNodeStyleSetHeight(root, 52);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMarginAuto(root_child0, YGEdgeLeft);
+  YGNodeStyleSetMargin(root_child0, YGEdgeRight, 10);
+  YGNodeStyleSetWidth(root_child0, 72);
+  YGNodeStyleSetHeight(root_child0, 72);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(-30, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}

--- a/tests/YGMarginTest.cpp
+++ b/tests/YGMarginTest.cpp
@@ -1436,7 +1436,6 @@ TEST(YogaTest, margin_auto_left_right_child_bigger_than_parent) {
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
   YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
-  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
   YGNodeStyleSetWidth(root, 52);
   YGNodeStyleSetHeight(root, 52);
 
@@ -1480,7 +1479,6 @@ TEST(YogaTest, margin_auto_left_child_bigger_than_parent) {
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
   YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
-  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
   YGNodeStyleSetWidth(root, 52);
   YGNodeStyleSetHeight(root, 52);
 
@@ -1523,7 +1521,6 @@ TEST(YogaTest, margin_fix_left_auto_right_child_bigger_than_parent) {
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
   YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
-  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
   YGNodeStyleSetWidth(root, 52);
   YGNodeStyleSetHeight(root, 52);
 
@@ -1567,7 +1564,6 @@ TEST(YogaTest, margin_auto_left_fix_right_child_bigger_than_parent) {
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
   YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
-  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
   YGNodeStyleSetWidth(root, 52);
   YGNodeStyleSetHeight(root, 52);
 

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -2625,9 +2625,6 @@ static void YGNodelayoutImpl(const YGNodeRef node,
                                            parentWidth) -
                            paddingAndBorderAxisCross;
 
-      if (measureModeCrossDim == YGMeasureModeAtMost) {
-        containerCrossAxis = fminf(containerCrossAxis, availableInnerCrossDim);
-      }
     }
 
     // If there's no flex wrap, the cross dimension is defined by the container.

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -2624,7 +2624,6 @@ static void YGNodelayoutImpl(const YGNodeRef node,
                                            crossAxisParentSize,
                                            parentWidth) -
                            paddingAndBorderAxisCross;
-
     }
 
     // If there's no flex wrap, the cross dimension is defined by the container.

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -2731,11 +2731,11 @@ static void YGNodelayoutImpl(const YGNodeRef node,
 
             if (YGMarginLeadingValue(child, crossAxis)->unit == YGUnitAuto &&
                 YGMarginTrailingValue(child, crossAxis)->unit == YGUnitAuto) {
-              leadingCrossDim += remainingCrossDim / 2;
+              leadingCrossDim += fmaxf(0.0f, remainingCrossDim / 2);
             } else if (YGMarginTrailingValue(child, crossAxis)->unit == YGUnitAuto) {
               // No-Op
             } else if (YGMarginLeadingValue(child, crossAxis)->unit == YGUnitAuto) {
-              leadingCrossDim += remainingCrossDim;
+              leadingCrossDim += fmaxf(0.0f, remainingCrossDim);
             } else if (alignItem == YGAlignFlexStart) {
               // No-Op
             } else if (alignItem == YGAlignCenter) {


### PR DESCRIPTION
This fixes ```align-content: center``` and ```align-content: flex-end``` when the child exceeds the parents size. See #476. It also fixes those layouts if the child has ```margin: auto``` set.