### PR TITLE
Don't transfer layout outputs to java for unset edges

### DIFF
--- a/java/com/facebook/yoga/YogaNode.java
+++ b/java/com/facebook/yoga/YogaNode.java
@@ -42,9 +42,14 @@ public class YogaNode implements YogaNodeAPI<YogaNode> {
   private long mNativePointer;
   private Object mData;
 
-  private boolean mHasSetPadding = false;
-  private boolean mHasSetMargin = false;
-  private boolean mHasSetBorder = false;
+  /* Those flags needs be in sync with YGJNI.cpp */
+  private final static int MARGIN = 1;
+  private final static int PADDING = 2;
+  private final static int BORDER = 4;
+
+  @DoNotStrip
+  private int mEdgeSetFlag = 0;
+
   private boolean mHasSetPosition = false;
 
   @DoNotStrip
@@ -113,9 +118,7 @@ public class YogaNode implements YogaNodeAPI<YogaNode> {
   private native void jni_YGNodeReset(long nativePointer);
   @Override
   public void reset() {
-    mHasSetPadding = false;
-    mHasSetMargin = false;
-    mHasSetBorder = false;
+    mEdgeSetFlag = 0;
     mHasSetPosition = false;
     mHasNewLayout = true;
 
@@ -382,7 +385,7 @@ public class YogaNode implements YogaNodeAPI<YogaNode> {
   private native Object jni_YGNodeStyleGetMargin(long nativePointer, int edge);
   @Override
   public YogaValue getMargin(YogaEdge edge) {
-    if (!mHasSetMargin) {
+    if (!((mEdgeSetFlag & MARGIN) == MARGIN)) {
       return YogaValue.UNDEFINED;
     }
     return (YogaValue) jni_YGNodeStyleGetMargin(mNativePointer, edge.intValue());
@@ -391,28 +394,28 @@ public class YogaNode implements YogaNodeAPI<YogaNode> {
   private native void jni_YGNodeStyleSetMargin(long nativePointer, int edge, float margin);
   @Override
   public void setMargin(YogaEdge edge, float margin) {
-    mHasSetMargin = true;
+    mEdgeSetFlag |= MARGIN;
     jni_YGNodeStyleSetMargin(mNativePointer, edge.intValue(), margin);
   }
 
   private native void jni_YGNodeStyleSetMarginPercent(long nativePointer, int edge, float percent);
   @Override
   public void setMarginPercent(YogaEdge edge, float percent) {
-    mHasSetMargin = true;
+    mEdgeSetFlag |= MARGIN;
     jni_YGNodeStyleSetMarginPercent(mNativePointer, edge.intValue(), percent);
   }
 
   private native void jni_YGNodeStyleSetMarginAuto(long nativePointer, int edge);
   @Override
   public void setMarginAuto(YogaEdge edge) {
-    mHasSetMargin = true;
+    mEdgeSetFlag |= MARGIN;
     jni_YGNodeStyleSetMarginAuto(mNativePointer, edge.intValue());
   }
 
   private native Object jni_YGNodeStyleGetPadding(long nativePointer, int edge);
   @Override
   public YogaValue getPadding(YogaEdge edge) {
-    if (!mHasSetPadding) {
+    if (!((mEdgeSetFlag & PADDING) == PADDING)) {
       return YogaValue.UNDEFINED;
     }
     return (YogaValue) jni_YGNodeStyleGetPadding(mNativePointer, edge.intValue());
@@ -421,21 +424,21 @@ public class YogaNode implements YogaNodeAPI<YogaNode> {
   private native void jni_YGNodeStyleSetPadding(long nativePointer, int edge, float padding);
   @Override
   public void setPadding(YogaEdge edge, float padding) {
-    mHasSetPadding = true;
+    mEdgeSetFlag |= PADDING;
     jni_YGNodeStyleSetPadding(mNativePointer, edge.intValue(), padding);
   }
 
   private native void jni_YGNodeStyleSetPaddingPercent(long nativePointer, int edge, float percent);
   @Override
   public void setPaddingPercent(YogaEdge edge, float percent) {
-    mHasSetPadding = true;
+    mEdgeSetFlag |= PADDING;
     jni_YGNodeStyleSetPaddingPercent(mNativePointer, edge.intValue(), percent);
   }
 
   private native float jni_YGNodeStyleGetBorder(long nativePointer, int edge);
   @Override
   public float getBorder(YogaEdge edge) {
-    if (!mHasSetBorder) {
+    if (!((mEdgeSetFlag & BORDER) == BORDER)) {
       return YogaConstants.UNDEFINED;
     }
     return jni_YGNodeStyleGetBorder(mNativePointer, edge.intValue());
@@ -444,7 +447,7 @@ public class YogaNode implements YogaNodeAPI<YogaNode> {
   private native void jni_YGNodeStyleSetBorder(long nativePointer, int edge, float border);
   @Override
   public void setBorder(YogaEdge edge, float border) {
-    mHasSetBorder = true;
+    mEdgeSetFlag |= BORDER;
     jni_YGNodeStyleSetBorder(mNativePointer, edge.intValue(), border);
   }
 

--- a/java/jni/YGJNI.cpp
+++ b/java/jni/YGJNI.cpp
@@ -89,9 +89,8 @@ static void YGTransferLayoutOutputsRecursive(YGNodeRef root) {
       YGLog(YGLogLevelError, "Java YGNode was GCed during layout calculation\n");
       return;
     }
-      for (uint32_t i = 0; i < YGNodeGetChildCount(root); i++) {
-        YGTransferLayoutOutputsRecursive(YGNodeGetChild(root, i));
-      }
+    for (uint32_t i = 0; i < YGNodeGetChildCount(root); i++) {
+      YGTransferLayoutOutputsRecursive(YGNodeGetChild(root, i));
     }
   }
 }

--- a/java/jni/YGJNI.cpp
+++ b/java/jni/YGJNI.cpp
@@ -85,12 +85,12 @@ static void YGTransferLayoutOutputsRecursive(YGNodeRef root) {
       obj->setFieldValue<jboolean>(hasNewLayoutField, true);
       YGTransferLayoutDirection(root, obj);
       YGNodeSetHasNewLayout(root, false);
+
+      for (uint32_t i = 0; i < YGNodeGetChildCount(root); i++) {
+        YGTransferLayoutOutputsRecursive(YGNodeGetChild(root, i));
+      }
     } else {
       YGLog(YGLogLevelError, "Java YGNode was GCed during layout calculation\n");
-      return;
-    }
-    for (uint32_t i = 0; i < YGNodeGetChildCount(root); i++) {
-      YGTransferLayoutOutputsRecursive(YGNodeGetChild(root, i));
     }
   }
 }

--- a/java/jni/YGJNI.cpp
+++ b/java/jni/YGJNI.cpp
@@ -47,35 +47,51 @@ static void YGTransferLayoutOutputsRecursive(YGNodeRef root) {
       static auto borderBottomField = obj->getClass()->getField<jfloat>("mBorderBottom");
 
       static auto hasNewLayoutField = obj->getClass()->getField<jboolean>("mHasNewLayout");
+    static auto edgeSetFlagField = obj->getClass()->getField<jint>("mEdgeSetFlag");
+
+    /* Those flags needs be in sync with YogaNode.java */
+    const int MARGIN = 1;
+    const int PADDING = 2;
+    const int BORDER = 4;
+
+    int hasEdgeSetFlag = (int)obj->getFieldValue(edgeSetFlagField);
 
       obj->setFieldValue(widthField, YGNodeLayoutGetWidth(root));
       obj->setFieldValue(heightField, YGNodeLayoutGetHeight(root));
       obj->setFieldValue(leftField, YGNodeLayoutGetLeft(root));
       obj->setFieldValue(topField, YGNodeLayoutGetTop(root));
 
+    if((hasEdgeSetFlag & MARGIN) == MARGIN){
       obj->setFieldValue(marginLeftField, YGNodeLayoutGetMargin(root, YGEdgeLeft));
       obj->setFieldValue(marginTopField, YGNodeLayoutGetMargin(root, YGEdgeTop));
       obj->setFieldValue(marginRightField, YGNodeLayoutGetMargin(root, YGEdgeRight));
       obj->setFieldValue(marginBottomField, YGNodeLayoutGetMargin(root, YGEdgeBottom));
+    }
 
+    if((hasEdgeSetFlag & PADDING) == PADDING){
       obj->setFieldValue(paddingLeftField, YGNodeLayoutGetPadding(root, YGEdgeLeft));
       obj->setFieldValue(paddingTopField, YGNodeLayoutGetPadding(root, YGEdgeTop));
       obj->setFieldValue(paddingRightField, YGNodeLayoutGetPadding(root, YGEdgeRight));
       obj->setFieldValue(paddingBottomField, YGNodeLayoutGetPadding(root, YGEdgeBottom));
+    }
 
+    if((hasEdgeSetFlag & BORDER) == BORDER){
       obj->setFieldValue(borderLeftField, YGNodeLayoutGetBorder(root, YGEdgeLeft));
       obj->setFieldValue(borderTopField, YGNodeLayoutGetBorder(root, YGEdgeTop));
       obj->setFieldValue(borderRightField, YGNodeLayoutGetBorder(root, YGEdgeRight));
       obj->setFieldValue(borderBottomField, YGNodeLayoutGetBorder(root, YGEdgeBottom));
+    }
 
       obj->setFieldValue<jboolean>(hasNewLayoutField, true);
       YGTransferLayoutDirection(root, obj);
       YGNodeSetHasNewLayout(root, false);
+  } else {
+    YGLog(YGLogLevelError, "Java YGNode was GCed during layout calculation\n");
+    return;
+  }
       for (uint32_t i = 0; i < YGNodeGetChildCount(root); i++) {
         YGTransferLayoutOutputsRecursive(YGNodeGetChild(root, i));
       }
-    } else {
-      YGLog(YGLogLevelError, "Java YGNode was GCed during layout calculation\n");
     }
   }
 }

--- a/java/jni/YGJNI.cpp
+++ b/java/jni/YGJNI.cpp
@@ -46,49 +46,49 @@ static void YGTransferLayoutOutputsRecursive(YGNodeRef root) {
       static auto borderRightField = obj->getClass()->getField<jfloat>("mBorderRight");
       static auto borderBottomField = obj->getClass()->getField<jfloat>("mBorderBottom");
 
+      static auto edgeSetFlagField = obj->getClass()->getField<jint>("mEdgeSetFlag");
       static auto hasNewLayoutField = obj->getClass()->getField<jboolean>("mHasNewLayout");
-    static auto edgeSetFlagField = obj->getClass()->getField<jint>("mEdgeSetFlag");
 
-    /* Those flags needs be in sync with YogaNode.java */
-    const int MARGIN = 1;
-    const int PADDING = 2;
-    const int BORDER = 4;
+      /* Those flags needs be in sync with YogaNode.java */
+      const int MARGIN = 1;
+      const int PADDING = 2;
+      const int BORDER = 4;
 
-    int hasEdgeSetFlag = (int)obj->getFieldValue(edgeSetFlagField);
+      int hasEdgeSetFlag = (int)obj->getFieldValue(edgeSetFlagField);
 
       obj->setFieldValue(widthField, YGNodeLayoutGetWidth(root));
       obj->setFieldValue(heightField, YGNodeLayoutGetHeight(root));
       obj->setFieldValue(leftField, YGNodeLayoutGetLeft(root));
       obj->setFieldValue(topField, YGNodeLayoutGetTop(root));
 
-    if((hasEdgeSetFlag & MARGIN) == MARGIN){
-      obj->setFieldValue(marginLeftField, YGNodeLayoutGetMargin(root, YGEdgeLeft));
-      obj->setFieldValue(marginTopField, YGNodeLayoutGetMargin(root, YGEdgeTop));
-      obj->setFieldValue(marginRightField, YGNodeLayoutGetMargin(root, YGEdgeRight));
-      obj->setFieldValue(marginBottomField, YGNodeLayoutGetMargin(root, YGEdgeBottom));
-    }
+      if((hasEdgeSetFlag & MARGIN) == MARGIN){
+        obj->setFieldValue(marginLeftField, YGNodeLayoutGetMargin(root, YGEdgeLeft));
+        obj->setFieldValue(marginTopField, YGNodeLayoutGetMargin(root, YGEdgeTop));
+        obj->setFieldValue(marginRightField, YGNodeLayoutGetMargin(root, YGEdgeRight));
+        obj->setFieldValue(marginBottomField, YGNodeLayoutGetMargin(root, YGEdgeBottom));
+      }
 
-    if((hasEdgeSetFlag & PADDING) == PADDING){
-      obj->setFieldValue(paddingLeftField, YGNodeLayoutGetPadding(root, YGEdgeLeft));
-      obj->setFieldValue(paddingTopField, YGNodeLayoutGetPadding(root, YGEdgeTop));
-      obj->setFieldValue(paddingRightField, YGNodeLayoutGetPadding(root, YGEdgeRight));
-      obj->setFieldValue(paddingBottomField, YGNodeLayoutGetPadding(root, YGEdgeBottom));
-    }
+      if((hasEdgeSetFlag & PADDING) == PADDING){
+        obj->setFieldValue(paddingLeftField, YGNodeLayoutGetPadding(root, YGEdgeLeft));
+        obj->setFieldValue(paddingTopField, YGNodeLayoutGetPadding(root, YGEdgeTop));
+        obj->setFieldValue(paddingRightField, YGNodeLayoutGetPadding(root, YGEdgeRight));
+        obj->setFieldValue(paddingBottomField, YGNodeLayoutGetPadding(root, YGEdgeBottom));
+      }
 
-    if((hasEdgeSetFlag & BORDER) == BORDER){
-      obj->setFieldValue(borderLeftField, YGNodeLayoutGetBorder(root, YGEdgeLeft));
-      obj->setFieldValue(borderTopField, YGNodeLayoutGetBorder(root, YGEdgeTop));
-      obj->setFieldValue(borderRightField, YGNodeLayoutGetBorder(root, YGEdgeRight));
-      obj->setFieldValue(borderBottomField, YGNodeLayoutGetBorder(root, YGEdgeBottom));
-    }
+      if((hasEdgeSetFlag & BORDER) == BORDER){
+        obj->setFieldValue(borderLeftField, YGNodeLayoutGetBorder(root, YGEdgeLeft));
+        obj->setFieldValue(borderTopField, YGNodeLayoutGetBorder(root, YGEdgeTop));
+        obj->setFieldValue(borderRightField, YGNodeLayoutGetBorder(root, YGEdgeRight));
+        obj->setFieldValue(borderBottomField, YGNodeLayoutGetBorder(root, YGEdgeBottom));
+      }
 
       obj->setFieldValue<jboolean>(hasNewLayoutField, true);
       YGTransferLayoutDirection(root, obj);
       YGNodeSetHasNewLayout(root, false);
-  } else {
-    YGLog(YGLogLevelError, "Java YGNode was GCed during layout calculation\n");
-    return;
-  }
+    } else {
+      YGLog(YGLogLevelError, "Java YGNode was GCed during layout calculation\n");
+      return;
+    }
       for (uint32_t i = 0; i < YGNodeGetChildCount(root); i++) {
         YGTransferLayoutOutputsRecursive(YGNodeGetChild(root, i));
       }


### PR DESCRIPTION
See facebook/yoga#483. We should not transfer the layout if the layout didn't change. (using ```hasNewLayout```). This also changes that the lock on the java node is only aquired if needed, and it holds the lock only for the time the values are set and not for the time all it's children are set.