### PR TITLE
[C#] Support IL2CPP and fix stale handle

### DIFF
--- a/csharp/Facebook.Yoga/Native.cs
+++ b/csharp/Facebook.Yoga/Native.cs
@@ -28,7 +28,7 @@ namespace Facebook.Yoga
 
         internal class YGNodeHandle : SafeHandle
         {
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
+#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
             private GCHandle _managed;
 #endif
 
@@ -46,24 +46,34 @@ namespace Facebook.Yoga
 
             protected override bool ReleaseHandle()
             {
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
-                if (_managed.IsAllocated)
-                {
-                    _managed.Free();
-                }
+#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+                ReleaseManaged();
 #endif
                 Native.YGNodeFree(this.handle);
                 GC.KeepAlive(this);
                 return true;
             }
 
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
+#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
             public void SetContext(YogaNode node)
             {
                 if (!_managed.IsAllocated)
                 {
+#if ENABLE_IL2CPP
+                    // Weak causes 'GCHandle value belongs to a different domain' error
+                    _managed = GCHandle.Alloc(node);
+#else
                     _managed = GCHandle.Alloc(node, GCHandleType.Weak);
+#endif
                     Native.YGNodeSetContext(this.handle, GCHandle.ToIntPtr(_managed));
+                }
+            }
+
+            public void ReleaseManaged()
+            {
+                if (_managed.IsAllocated)
+                {
+                    _managed.Free();
                 }
             }
 
@@ -83,10 +93,6 @@ namespace Facebook.Yoga
 
         internal class YGConfigHandle : SafeHandle
         {
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
-            private GCHandle _managed;
-#endif
-
             private YGConfigHandle() : base(IntPtr.Zero, true)
             {
             }
@@ -101,12 +107,6 @@ namespace Facebook.Yoga
 
             protected override bool ReleaseHandle()
             {
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
-                if (_managed.IsAllocated)
-                {
-                    _managed.Free();
-                }
-#endif
                 Native.YGConfigFree(this.handle);
                 GC.KeepAlive(this);
                 return true;
@@ -429,9 +429,9 @@ namespace Facebook.Yoga
 
 #endregion
 
-#region IOS
+#region AOT
 
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
+#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
         [DllImport(DllName, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr YGNodeGetContext(IntPtr node);
 

--- a/csharp/Facebook.Yoga/Native.cs
+++ b/csharp/Facebook.Yoga/Native.cs
@@ -28,7 +28,7 @@ namespace Facebook.Yoga
 
         internal class YGNodeHandle : SafeHandle
         {
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+#if (UNITY_IOS && !UNITY_EDITOR) || ENABLE_IL2CPP || __IOS__
             private GCHandle _managed;
 #endif
 
@@ -46,7 +46,7 @@ namespace Facebook.Yoga
 
             protected override bool ReleaseHandle()
             {
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+#if (UNITY_IOS && !UNITY_EDITOR) || ENABLE_IL2CPP || __IOS__
                 ReleaseManaged();
 #endif
                 Native.YGNodeFree(this.handle);
@@ -54,7 +54,7 @@ namespace Facebook.Yoga
                 return true;
             }
 
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+#if (UNITY_IOS && !UNITY_EDITOR) || ENABLE_IL2CPP || __IOS__
             public void SetContext(YogaNode node)
             {
                 if (!_managed.IsAllocated)
@@ -431,7 +431,7 @@ namespace Facebook.Yoga
 
 #region AOT
 
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+#if (UNITY_IOS && !UNITY_EDITOR) || ENABLE_IL2CPP || __IOS__
         [DllImport(DllName, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr YGNodeGetContext(IntPtr node);
 

--- a/csharp/Facebook.Yoga/YogaLogger.cs
+++ b/csharp/Facebook.Yoga/YogaLogger.cs
@@ -13,6 +13,9 @@ using System.Runtime.InteropServices;
 #if __IOS__
 using ObjCRuntime;
 #endif
+#if ENABLE_IL2CPP
+using AOT;
+#endif
 
 namespace Facebook.Yoga
 {
@@ -26,7 +29,7 @@ namespace Facebook.Yoga
 
         public static Func Logger = null;
 
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
+#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
         [MonoPInvokeCallback(typeof(Func))]
 #endif
         public static void LoggerInternal(YogaLogLevel level, string message)

--- a/csharp/Facebook.Yoga/YogaLogger.cs
+++ b/csharp/Facebook.Yoga/YogaLogger.cs
@@ -29,7 +29,7 @@ namespace Facebook.Yoga
 
         public static Func Logger = null;
 
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+#if (UNITY_IOS && !UNITY_EDITOR) || ENABLE_IL2CPP || __IOS__
         [MonoPInvokeCallback(typeof(Func))]
 #endif
         public static void LoggerInternal(YogaLogLevel level, string message)

--- a/csharp/Facebook.Yoga/YogaNode.cs
+++ b/csharp/Facebook.Yoga/YogaNode.cs
@@ -12,7 +12,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+#if (UNITY_IOS && !UNITY_EDITOR) || ENABLE_IL2CPP || __IOS__
 using System.Runtime.InteropServices;
 #endif
 #if __IOS__
@@ -66,7 +66,7 @@ namespace Facebook.Yoga
         private MeasureFunction _measureFunction;
         private BaselineFunction _baselineFunction;
         private object _data;
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+#if (UNITY_IOS && !UNITY_EDITOR) || ENABLE_IL2CPP || __IOS__
         private static YogaMeasureFunc _managedMeasure;
         private static YogaBaselineFunc _managedBaseline;
 #else
@@ -109,7 +109,7 @@ namespace Facebook.Yoga
             _data = null;
 
             Native.YGNodeReset(_ygNode);
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+#if (UNITY_IOS && !UNITY_EDITOR) || ENABLE_IL2CPP || __IOS__
             _ygNode.ReleaseManaged();
 #endif
         }
@@ -622,7 +622,7 @@ namespace Facebook.Yoga
             _measureFunction = measureFunction;
             if (measureFunction != null)
             {
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+#if (UNITY_IOS && !UNITY_EDITOR) || ENABLE_IL2CPP || __IOS__
                 _managedMeasure = MeasureInternalAOT;
                 _ygNode.SetContext(this);
 #else
@@ -641,7 +641,7 @@ namespace Facebook.Yoga
             _baselineFunction = baselineFunction;
             if (baselineFunction != null)
             {
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+#if (UNITY_IOS && !UNITY_EDITOR) || ENABLE_IL2CPP || __IOS__
                 _managedBaseline = BaselineInternalAOT;
                 _ygNode.SetContext(this);
 #else
@@ -664,7 +664,7 @@ namespace Facebook.Yoga
                 Native.YGNodeStyleGetDirection(_ygNode));
         }
 
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+#if (UNITY_IOS && !UNITY_EDITOR) || ENABLE_IL2CPP || __IOS__
         [MonoPInvokeCallback(typeof(YogaMeasureFunc))]
         private static YogaSize MeasureInternalAOT(
             IntPtr ygNodePtr,
@@ -693,7 +693,7 @@ namespace Facebook.Yoga
             return _measureFunction(this, width, widthMode, height, heightMode);
         }
 
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+#if (UNITY_IOS && !UNITY_EDITOR) || ENABLE_IL2CPP || __IOS__
         [MonoPInvokeCallback(typeof(YogaBaselineFunc))]
         private static float BaselineInternalAOT(
             IntPtr ygNodePtr,

--- a/csharp/Facebook.Yoga/YogaNode.cs
+++ b/csharp/Facebook.Yoga/YogaNode.cs
@@ -12,11 +12,14 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
+#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
 using System.Runtime.InteropServices;
 #endif
 #if __IOS__
 using ObjCRuntime;
+#endif
+#if ENABLE_IL2CPP
+using AOT;
 #endif
 
 namespace Facebook.Yoga
@@ -63,7 +66,7 @@ namespace Facebook.Yoga
         private MeasureFunction _measureFunction;
         private BaselineFunction _baselineFunction;
         private object _data;
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
+#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
         private static YogaMeasureFunc _managedMeasure;
         private static YogaBaselineFunc _managedBaseline;
 #else
@@ -106,6 +109,9 @@ namespace Facebook.Yoga
             _data = null;
 
             Native.YGNodeReset(_ygNode);
+#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+            _ygNode.ReleaseManaged();
+#endif
         }
 
         public bool IsDirty
@@ -616,8 +622,8 @@ namespace Facebook.Yoga
             _measureFunction = measureFunction;
             if (measureFunction != null)
             {
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
-                _managedMeasure = MeasureInternalIOS;
+#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+                _managedMeasure = MeasureInternalAOT;
                 _ygNode.SetContext(this);
 #else
                 _managedMeasure = MeasureInternal;
@@ -635,8 +641,8 @@ namespace Facebook.Yoga
             _baselineFunction = baselineFunction;
             if (baselineFunction != null)
             {
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
-                _managedBaseline = BaselineInternalIOS;
+#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
+                _managedBaseline = BaselineInternalAOT;
                 _ygNode.SetContext(this);
 #else
                 _managedBaseline = BaselineInternal;
@@ -658,9 +664,9 @@ namespace Facebook.Yoga
                 Native.YGNodeStyleGetDirection(_ygNode));
         }
 
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
+#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
         [MonoPInvokeCallback(typeof(YogaMeasureFunc))]
-        private static YogaSize MeasureInternalIOS(
+        private static YogaSize MeasureInternalAOT(
             IntPtr ygNodePtr,
             float width,
             YogaMeasureMode widthMode,
@@ -687,9 +693,9 @@ namespace Facebook.Yoga
             return _measureFunction(this, width, widthMode, height, heightMode);
         }
 
-#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__
+#if (UNITY_IOS && !UNITY_EDITOR) || __IOS__ || ENABLE_IL2CPP
         [MonoPInvokeCallback(typeof(YogaBaselineFunc))]
-        private static float BaselineInternalIOS(
+        private static float BaselineInternalAOT(
             IntPtr ygNodePtr,
             float width,
             float height)


### PR DESCRIPTION
- Unity IL2CPP (ENABLE_IL2CPP) requires the same code path with AOT compile.
- Clean up unneeded code in YGConfigHandle.
- YogaNode.Reset makes YGNodeHandle stale. Unmanaged side was reset by YGNodeReset, but YGNodeHandle keeps to retain the old managed handle. Release it.