### PR TITLE
Don't transfer layout outputs to java for nodes which don't have a new layout

### DIFF
--- a/java/com/facebook/yoga/YogaNode.java
+++ b/java/com/facebook/yoga/YogaNode.java
@@ -82,7 +82,7 @@ public class YogaNode implements YogaNodeAPI<YogaNode> {
   @DoNotStrip
   private int mLayoutDirection = 0;
   @DoNotStrip
-  private bool mHasNewLayout = true;
+  private boolean mHasNewLayout = true;
 
   private native long jni_YGNodeNew();
   public YogaNode() {

--- a/java/com/facebook/yoga/YogaNode.java
+++ b/java/com/facebook/yoga/YogaNode.java
@@ -81,6 +81,8 @@ public class YogaNode implements YogaNodeAPI<YogaNode> {
   private float mBorderBottom = 0;
   @DoNotStrip
   private int mLayoutDirection = 0;
+  @DoNotStrip
+  private bool mHasNewLayout = true;
 
   private native long jni_YGNodeNew();
   public YogaNode() {
@@ -115,6 +117,7 @@ public class YogaNode implements YogaNodeAPI<YogaNode> {
     mHasSetMargin = false;
     mHasSetBorder = false;
     mHasSetPosition = false;
+    mHasNewLayout = true;
 
     mWidth = YogaConstants.UNDEFINED;
     mHeight = YogaConstants.UNDEFINED;
@@ -180,10 +183,9 @@ public class YogaNode implements YogaNodeAPI<YogaNode> {
     jni_YGNodeCalculateLayout(mNativePointer, width, height);
   }
 
-  private native boolean jni_YGNodeHasNewLayout(long nativePointer);
   @Override
   public boolean hasNewLayout() {
-    return jni_YGNodeHasNewLayout(mNativePointer);
+    return mHasNewLayout;
   }
 
   private native void jni_YGNodeMarkDirty(long nativePointer);
@@ -198,16 +200,15 @@ public class YogaNode implements YogaNodeAPI<YogaNode> {
     return jni_YGNodeIsDirty(mNativePointer);
   }
 
-  private native void jni_YGNodeMarkLayoutSeen(long nativePointer);
-  @Override
-  public void markLayoutSeen() {
-    jni_YGNodeMarkLayoutSeen(mNativePointer);
-  }
-
   private native void jni_YGNodeCopyStyle(long dstNativePointer, long srcNativePointer);
   @Override
   public void copyStyle(YogaNode srcNode) {
     jni_YGNodeCopyStyle(mNativePointer, srcNode.mNativePointer);
+  }
+
+  @Override
+  public void markLayoutSeen() {
+    mHasNewLayout = false;
   }
 
   private native int jni_YGNodeStyleGetDirection(long nativePointer);

--- a/java/jni/YGJNI.cpp
+++ b/java/jni/YGJNI.cpp
@@ -24,6 +24,7 @@ static void YGTransferLayoutDirection(YGNodeRef node, alias_ref<jobject> javaNod
 }
 
 static void YGTransferLayoutOutputsRecursive(YGNodeRef root) {
+  if(YGNodeGetHasNewLayout(root)){
   if (auto obj = YGNodeJobject(root)->lockLocal()) {
     static auto widthField = obj->getClass()->getField<jfloat>("mWidth");
     static auto heightField = obj->getClass()->getField<jfloat>("mHeight");
@@ -45,6 +46,8 @@ static void YGTransferLayoutOutputsRecursive(YGNodeRef root) {
     static auto borderRightField = obj->getClass()->getField<jfloat>("mBorderRight");
     static auto borderBottomField = obj->getClass()->getField<jfloat>("mBorderBottom");
 
+    static auto hasNewLayoutField = obj->getClass()->getField<jboolean>("mHasNewLayout");
+
     obj->setFieldValue(widthField, YGNodeLayoutGetWidth(root));
     obj->setFieldValue(heightField, YGNodeLayoutGetHeight(root));
     obj->setFieldValue(leftField, YGNodeLayoutGetLeft(root));
@@ -65,13 +68,15 @@ static void YGTransferLayoutOutputsRecursive(YGNodeRef root) {
     obj->setFieldValue(borderRightField, YGNodeLayoutGetBorder(root, YGEdgeRight));
     obj->setFieldValue(borderBottomField, YGNodeLayoutGetBorder(root, YGEdgeBottom));
 
+    obj->setFieldValue<jboolean>(hasNewLayoutField, true);
     YGTransferLayoutDirection(root, obj);
-
+    YGNodeSetHasNewLayout(root, false);
     for (uint32_t i = 0; i < YGNodeGetChildCount(root); i++) {
       YGTransferLayoutOutputsRecursive(YGNodeGetChild(root, i));
     }
   } else {
     YGLog(YGLogLevelError, "Java YGNode was GCed during layout calculation\n");
+  }
   }
 }
 
@@ -242,14 +247,6 @@ void jni_YGNodeSetHasBaselineFunc(alias_ref<jobject>,
                         hasBaselineFunc ? YGJNIBaselineFunc : NULL);
 }
 
-jboolean jni_YGNodeHasNewLayout(alias_ref<jobject>, jlong nativePointer) {
-  return (jboolean) YGNodeGetHasNewLayout(_jlong2YGNodeRef(nativePointer));
-}
-
-void jni_YGNodeMarkLayoutSeen(alias_ref<jobject>, jlong nativePointer) {
-  YGNodeSetHasNewLayout(_jlong2YGNodeRef(nativePointer), false);
-}
-
 void jni_YGNodeCopyStyle(alias_ref<jobject>, jlong dstNativePointer, jlong srcNativePointer) {
   YGNodeCopyStyle(_jlong2YGNodeRef(dstNativePointer), _jlong2YGNodeRef(srcNativePointer));
 }
@@ -398,10 +395,8 @@ jint JNI_OnLoad(JavaVM *vm, void *) {
                         YGMakeNativeMethod(jni_YGNodeInsertChild),
                         YGMakeNativeMethod(jni_YGNodeRemoveChild),
                         YGMakeNativeMethod(jni_YGNodeCalculateLayout),
-                        YGMakeNativeMethod(jni_YGNodeHasNewLayout),
                         YGMakeNativeMethod(jni_YGNodeMarkDirty),
                         YGMakeNativeMethod(jni_YGNodeIsDirty),
-                        YGMakeNativeMethod(jni_YGNodeMarkLayoutSeen),
                         YGMakeNativeMethod(jni_YGNodeSetHasMeasureFunc),
                         YGMakeNativeMethod(jni_YGNodeSetHasBaselineFunc),
                         YGMakeNativeMethod(jni_YGNodeCopyStyle),


### PR DESCRIPTION
As suggested in facebook/yoga#484. This is the PR which only adds the part of using a local bool field for storing the hasLayoutFlag, to be able to pass the layout only if it has really changed.