### PR TITLE
[C#] Update YogaConfig

### DIFF
--- a/csharp/Facebook.Yoga/Facebook.Yoga.Shared.projitems
+++ b/csharp/Facebook.Yoga/Facebook.Yoga.Shared.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Native.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)YogaAlign.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)YogaBaselineFunc.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)YogaConfig.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)YogaConstants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)YogaDimension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)YogaDirection.cs" />

--- a/csharp/Facebook.Yoga/Native.cs
+++ b/csharp/Facebook.Yoga/Native.cs
@@ -150,6 +150,19 @@ namespace Facebook.Yoga
             YogaExperimentalFeature feature);
 
         [DllImport(DllName, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void YGConfigSetUseWebDefaults(
+            YGConfigHandle config,
+            bool useWebDefaults);
+
+        [DllImport(DllName, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern bool YGConfigGetUseWebDefaults(YGConfigHandle config);
+
+        [DllImport(DllName, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void YGConfigSetPointScaleFactor(
+            YGConfigHandle config,
+            float pixelsInPoint);
+
+        [DllImport(DllName, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         public static extern void YGNodeInsertChild(
             YGNodeHandle node,
             YGNodeHandle child,

--- a/csharp/Facebook.Yoga/YogaConfig.cs
+++ b/csharp/Facebook.Yoga/YogaConfig.cs
@@ -1,0 +1,67 @@
+﻿/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+using System;
+
+namespace Facebook.Yoga
+{
+    public class YogaConfig
+    {
+        private Native.YGConfigHandle _ygConfig;
+
+        public YogaConfig()
+        {
+            _ygConfig = Native.YGConfigNew();
+            if (_ygConfig.IsInvalid)
+            {
+                throw new InvalidOperationException("Failed to allocate native memory");
+            }
+        }
+
+        internal Native.YGConfigHandle Handle
+        {
+            get {
+                return _ygConfig;
+            }
+        }
+
+        public void SetExperimentalFeatureEnabled(
+            YogaExperimentalFeature feature,
+            bool enabled)
+        {
+            Native.YGConfigSetExperimentalFeatureEnabled(_ygConfig, feature, enabled);
+        }
+
+        public bool IsExperimentalFeatureEnabled(YogaExperimentalFeature feature)
+        {
+            return Native.YGConfigIsExperimentalFeatureEnabled(_ygConfig, feature);
+        }
+
+        public bool UseWebDefaults
+        {
+            get
+            {
+                return Native.YGConfigGetUseWebDefaults(_ygConfig);
+            }
+
+            set
+            {
+                Native.YGConfigSetUseWebDefaults(_ygConfig, value);
+            }
+        }
+
+        public float PointScaleFactor
+        {
+            set
+            {
+                Native.YGConfigSetPointScaleFactor(_ygConfig, value);
+            }
+        }
+    }
+}

--- a/csharp/Facebook.Yoga/YogaNode.cs
+++ b/csharp/Facebook.Yoga/YogaNode.cs
@@ -24,43 +24,10 @@ using AOT;
 
 namespace Facebook.Yoga
 {
-    public class YogaConfig
-    {
-
-        private Native.YGConfigHandle _ygConfig;
-
-        public YogaConfig()
-        {
-            _ygConfig = Native.YGConfigNew();
-            if (_ygConfig.IsInvalid)
-            {
-                throw new InvalidOperationException("Failed to allocate native memory");
-            }
-        }
-
-        internal Native.YGConfigHandle Handle {
-            get {
-                return _ygConfig;
-            }
-        }
-
-        public void SetExperimentalFeatureEnabled(
-            YogaExperimentalFeature feature,
-            bool enabled)
-        {
-            Native.YGConfigSetExperimentalFeatureEnabled(_ygConfig, feature, enabled);
-        }
-
-        public bool IsExperimentalFeatureEnabled(YogaExperimentalFeature feature)
-        {
-            return Native.YGConfigIsExperimentalFeatureEnabled(_ygConfig, feature);
-        }
-
-    }
-
     public partial class YogaNode : IEnumerable<YogaNode>
     {
         private Native.YGNodeHandle _ygNode;
+        private YogaConfig _config;
         private WeakReference _parent;
         private List<YogaNode> _children;
         private MeasureFunction _measureFunction;
@@ -89,7 +56,15 @@ namespace Facebook.Yoga
         {
             YogaLogger.Initialize();
 
-            _ygNode = Native.YGNodeNewWithConfig(config.Handle);
+            if (config != null)
+            {
+                _config = config;
+                _ygNode = Native.YGNodeNewWithConfig(_config.Handle);
+            }
+            else
+            {
+                _ygNode = Native.YGNodeNew();
+            }
             if (_ygNode.IsInvalid)
             {
                 throw new InvalidOperationException("Failed to allocate native memory");
@@ -97,7 +72,7 @@ namespace Facebook.Yoga
         }
 
         public YogaNode(YogaNode srcNode)
-            : this()
+            : this(srcNode._config)
         {
             CopyStyle(srcNode);
         }


### PR DESCRIPTION
- Bugfix: Retain managed YogaConfig to prevent releasing unmanaged YogaConfig
- Use the same YogaConfig in the copy constructor
- Expose Set/GetUseWebDefaults APIs
- Split YogaConfig out from YogaNode.cs