### PR TITLE
Fractial leftover

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,8 @@ before_install:
     if [[ $TARGET = "js" ]]; then
       wget -O /tmp/emsdk-portable.tar.gz https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz &&
       tar xf /tmp/emsdk-portable.tar.gz -C /tmp/ &&
-      /tmp/emsdk_portable/emsdk install latest >& /dev/null &&
-      /tmp/emsdk_portable/emsdk activate latest
+      /tmp/emsdk-portable/emsdk install latest 2>&1 | grep -v '^x ' &&
+      /tmp/emsdk-portable/emsdk activate latest
     fi
 
   # Android
@@ -77,7 +77,7 @@ before_install:
       cd javascript &&
       npm install &&
       unset CC && unset CXX && unset LINK &&
-      source /tmp/emsdk_portable/emsdk_env.sh &&
+      source /tmp/emsdk-portable/emsdk_env.sh &&
       npm run build:browser
     ) fi
 

--- a/csharp/tests/Facebook.Yoga/YGRoundingTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGRoundingTest.cs
@@ -654,9 +654,9 @@ namespace Facebook.Yoga
             config.SetExperimentalFeatureEnabled(YogaExperimentalFeature.Rounding, true);
 
             YogaNode root = new YogaNode(config);
-            root.Top = 0.3f;
+            root.Top = 0.1f;
             root.Width = 100;
-            root.Height = 113.4f;
+            root.Height = 113.1f;
 
             YogaNode root_child0 = new YogaNode(config);
             root_child0.FlexGrow = 1;
@@ -679,7 +679,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(0f, root.LayoutX);
             Assert.AreEqual(0f, root.LayoutY);
             Assert.AreEqual(100f, root.LayoutWidth);
-            Assert.AreEqual(114f, root.LayoutHeight);
+            Assert.AreEqual(113f, root.LayoutHeight);
 
             Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
@@ -702,7 +702,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(0f, root.LayoutX);
             Assert.AreEqual(0f, root.LayoutY);
             Assert.AreEqual(100f, root.LayoutWidth);
-            Assert.AreEqual(114f, root.LayoutHeight);
+            Assert.AreEqual(113f, root.LayoutHeight);
 
             Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
@@ -791,6 +791,151 @@ namespace Facebook.Yoga
             Assert.AreEqual(89f, root_child2.LayoutY);
             Assert.AreEqual(100f, root_child2.LayoutWidth);
             Assert.AreEqual(24f, root_child2.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_rounding_fractial_input_5_x()
+        {
+            YogaConfig config = new YogaConfig();
+            config.SetExperimentalFeatureEnabled(YogaExperimentalFeature.Rounding, true);
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.Top = 0.4f;
+            root.Width = 100;
+            root.Height = 100.4f;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 10;
+            root_child0.Height = 100.Percent();
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.Width = 10;
+            root_child1.Height = 100.Percent();
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode(config);
+            root_child2.Width = 10;
+            root_child2.Height = 100.Percent();
+            root.Insert(2, root_child2);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(101f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(10f, root_child0.LayoutWidth);
+            Assert.AreEqual(101f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(10f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(10f, root_child1.LayoutWidth);
+            Assert.AreEqual(101f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(20f, root_child2.LayoutX);
+            Assert.AreEqual(0f, root_child2.LayoutY);
+            Assert.AreEqual(10f, root_child2.LayoutWidth);
+            Assert.AreEqual(101f, root_child2.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(101f, root.LayoutHeight);
+
+            Assert.AreEqual(90f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(10f, root_child0.LayoutWidth);
+            Assert.AreEqual(101f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(80f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(10f, root_child1.LayoutWidth);
+            Assert.AreEqual(101f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(70f, root_child2.LayoutX);
+            Assert.AreEqual(0f, root_child2.LayoutY);
+            Assert.AreEqual(10f, root_child2.LayoutWidth);
+            Assert.AreEqual(101f, root_child2.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_rounding_fractial_input_5_y()
+        {
+            YogaConfig config = new YogaConfig();
+            config.SetExperimentalFeatureEnabled(YogaExperimentalFeature.Rounding, true);
+
+            YogaNode root = new YogaNode(config);
+            root.MarginLeft = 0.4f;
+            root.Width = 100.4f;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 100.Percent();
+            root_child0.Height = 10;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.Width = 100.Percent();
+            root_child1.Height = 10;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode(config);
+            root_child2.Width = 100.Percent();
+            root_child2.Height = 10;
+            root.Insert(2, root_child2);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(101f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(101f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(10f, root_child1.LayoutY);
+            Assert.AreEqual(101f, root_child1.LayoutWidth);
+            Assert.AreEqual(10f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child2.LayoutX);
+            Assert.AreEqual(20f, root_child2.LayoutY);
+            Assert.AreEqual(101f, root_child2.LayoutWidth);
+            Assert.AreEqual(10f, root_child2.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(101f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(101f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(10f, root_child1.LayoutY);
+            Assert.AreEqual(101f, root_child1.LayoutWidth);
+            Assert.AreEqual(10f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child2.LayoutX);
+            Assert.AreEqual(20f, root_child2.LayoutY);
+            Assert.AreEqual(101f, root_child2.LayoutWidth);
+            Assert.AreEqual(10f, root_child2.LayoutHeight);
         }
 
     }

--- a/gentest/fixtures/YGRoundingTest.html
+++ b/gentest/fixtures/YGRoundingTest.html
@@ -51,7 +51,7 @@
   <div style="height: 10px; flex-grow:1;"></div>
 </div>
 
-<div id="rounding_fractial_input_3" experiments="Rounding" style="top: 0.3px; height: 113.4px; width: 100px;">
+<div id="rounding_fractial_input_3" experiments="Rounding" style="top: 0.1px; height: 113.1px; width: 100px;">
   <div style="height: 20px; flex-grow:1; flex-basis:50px;"></div>
   <div style="height: 10px; flex-grow:1;"></div>
   <div style="height: 10px; flex-grow:1;"></div>
@@ -61,4 +61,16 @@
   <div style="height: 20px; flex-grow:1; flex-basis:50px;"></div>
   <div style="height: 10px; flex-grow:1;"></div>
   <div style="height: 10px; flex-grow:1;"></div>
+</div>
+
+<div id="rounding_fractial_input_5_x" experiments="Rounding" style="margin-top: .4px; height: 100.4px; width: 100px; flex-direction: row;">
+  <div style="height: 100%; width: 10px;" expect-height="101 instead of 100"></div>
+  <div style="height: 100%; width: 10px;" expect-height="101 instead of 100"></div>
+  <div style="height: 100%; width: 10px;" expect-height="101 instead of 100"></div>
+</div>
+
+<div id="rounding_fractial_input_5_y" experiments="Rounding" style="margin-left: .4px; width: 100.4px; height: 100px; flex-direction: column;">
+  <div style="width: 100%; height: 10px;" expect-width="101 instead of 100"></div>
+  <div style="width: 100%; height: 10px;" expect-width="101 instead of 100"></div>
+  <div style="width: 100%; height: 10px;" expect-width="101 instead of 100"></div>
 </div>

--- a/gentest/gentest.js
+++ b/gentest/gentest.js
@@ -420,17 +420,33 @@ function getDefaultStyleValue(style) {
   return getComputedStyle(node, null).getPropertyValue(style);
 }
 
+function getExpectation(child, name, nativeValue) {
+  if (!child.hasAttribute('expect-' + name))
+    return nativeValue;
+
+  var match = child.getAttribute('expect-' + name).match(/^([0-9.]+) instead of ([0-9.]+)/);
+
+  if (!match)
+    throw new Error('Invalid syntax for expect-' + name);
+
+  if (nativeValue !== Number(match[2]))
+    throw new Error('Native value doesn\'t match the expectations for expect-' + name + ' (got ' + nativeValue + ' instead of ' + match[2] + ')');
+
+  return Number(match[1]);
+}
+
 function calculateTree(root) {
   var rootLayout = [];
 
   for (var i = 0; i < root.children.length; i++) {
     var child = root.children[i];
+
     rootLayout.push({
       name: child.id !== '' ? child.id : 'INSERT_NAME_HERE',
-      left: child.offsetLeft + child.parentNode.clientLeft,
-      top: child.offsetTop + child.parentNode.clientTop,
-      width: child.offsetWidth,
-      height: child.offsetHeight,
+      left: getExpectation(child, `left`, child.offsetLeft + child.parentNode.clientLeft),
+      top: getExpectation(child, `top`, child.offsetTop + child.parentNode.clientTop),
+      width: getExpectation(child, `width`, child.offsetWidth),
+      height: getExpectation(child, `height`, child.offsetHeight),
       children: calculateTree(child),
       style: getYogaStyle(child),
       declaredStyle: child.style,

--- a/gentest/gentest.rb
+++ b/gentest/gentest.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'watir-webdriver'
+require 'watir'
 require 'fileutils'
 
 caps = Selenium::WebDriver::Remote::Capabilities.chrome(
@@ -47,8 +47,6 @@ Dir['fixtures/*.html'].each do |file|
   f = File.open("../csharp/tests/Facebook.Yoga/#{name}.cs", 'w')
   f.write eval(logs[2].message.sub(/^[^"]*/, '')).sub('YogaTest', name)
   f.close
-
-  print logs[4]
 
   f = File.open("../javascript/tests/Facebook.Yoga/#{name}.js", 'w')
   f.write eval(logs[3].message.sub(/^[^"]*/, '')).sub('YogaTest', name)

--- a/java/tests/com/facebook/yoga/YGRoundingTest.java
+++ b/java/tests/com/facebook/yoga/YGRoundingTest.java
@@ -644,9 +644,9 @@ public class YGRoundingTest {
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ROUNDING, true);
 
     final YogaNode root = new YogaNode(config);
-    root.setPosition(YogaEdge.TOP, 0.3f);
+    root.setPosition(YogaEdge.TOP, 0.1f);
     root.setWidth(100f);
-    root.setHeight(113.4f);
+    root.setHeight(113.1f);
 
     final YogaNode root_child0 = new YogaNode(config);
     root_child0.setFlexGrow(1f);
@@ -669,7 +669,7 @@ public class YGRoundingTest {
     assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
-    assertEquals(114f, root.getLayoutHeight(), 0.0f);
+    assertEquals(113f, root.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
@@ -692,7 +692,7 @@ public class YGRoundingTest {
     assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
-    assertEquals(114f, root.getLayoutHeight(), 0.0f);
+    assertEquals(113f, root.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
@@ -780,6 +780,149 @@ public class YGRoundingTest {
     assertEquals(89f, root_child2.getLayoutY(), 0.0f);
     assertEquals(100f, root_child2.getLayoutWidth(), 0.0f);
     assertEquals(24f, root_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_rounding_fractial_input_5_x() {
+    YogaConfig config = new YogaConfig();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ROUNDING, true);
+
+    final YogaNode root = new YogaNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setPosition(YogaEdge.TOP, 0.4f);
+    root.setWidth(100f);
+    root.setHeight(100.4f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setWidth(10f);
+    root_child0.setHeightPercent(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode(config);
+    root_child1.setWidth(10f);
+    root_child1.setHeightPercent(100f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = new YogaNode(config);
+    root_child2.setWidth(10f);
+    root_child2.setHeightPercent(100f);
+    root.addChildAt(root_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(101f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(101f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(101f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(101f, root_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(101f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(101f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(101f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(70f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(101f, root_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_rounding_fractial_input_5_y() {
+    YogaConfig config = new YogaConfig();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ROUNDING, true);
+
+    final YogaNode root = new YogaNode(config);
+    root.setMargin(YogaEdge.LEFT, 0.4f);
+    root.setWidth(100.4f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setWidthPercent(100f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode(config);
+    root_child1.setWidthPercent(100f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = new YogaNode(config);
+    root_child2.setWidthPercent(100f);
+    root_child2.setHeight(10f);
+    root.addChildAt(root_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(101f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(101f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(101f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(101f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(101f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(101f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(101f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(101f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
   }
 
 }

--- a/javascript/tests/Facebook.Yoga/YGRoundingTest.js
+++ b/javascript/tests/Facebook.Yoga/YGRoundingTest.js
@@ -680,9 +680,9 @@ it("rounding_fractial_input_3", function () {
 
   try {
     var root = Yoga.Node.create(config);
-    root.setPosition(Yoga.EDGE_TOP, 0.3);
+    root.setPosition(Yoga.EDGE_TOP, 0.1);
     root.setWidth(100);
-    root.setHeight(113.4);
+    root.setHeight(113.1);
 
     var root_child0 = Yoga.Node.create(config);
     root_child0.setFlexGrow(1);
@@ -704,7 +704,7 @@ it("rounding_fractial_input_3", function () {
     console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
     console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
-    console.assert(114 === root.getComputedHeight(), "114 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+    console.assert(113 === root.getComputedHeight(), "113 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
     console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
@@ -726,7 +726,7 @@ it("rounding_fractial_input_3", function () {
     console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
     console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
-    console.assert(114 === root.getComputedHeight(), "114 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+    console.assert(113 === root.getComputedHeight(), "113 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
     console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
@@ -819,6 +819,159 @@ it("rounding_fractial_input_4", function () {
     console.assert(89 === root_child2.getComputedTop(), "89 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
     console.assert(100 === root_child2.getComputedWidth(), "100 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
     console.assert(24 === root_child2.getComputedHeight(), "24 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("rounding_fractial_input_5_x", function () {
+  var config = Yoga.Config.create();
+
+  config.setExperimentalFeatureEnabled(Yoga.EXPERIMENTAL_FEATURE_ROUNDING, true);
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setPosition(Yoga.EDGE_TOP, 0.4);
+    root.setWidth(100);
+    root.setHeight(100.4);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(10);
+    root_child0.setHeight("100%");
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(10);
+    root_child1.setHeight("100%");
+    root.insertChild(root_child1, 1);
+
+    var root_child2 = Yoga.Node.create(config);
+    root_child2.setWidth(10);
+    root_child2.setHeight("100%");
+    root.insertChild(root_child2, 2);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(101 === root.getComputedHeight(), "101 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(101 === root_child0.getComputedHeight(), "101 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(10 === root_child1.getComputedLeft(), "10 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(10 === root_child1.getComputedWidth(), "10 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(101 === root_child1.getComputedHeight(), "101 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(20 === root_child2.getComputedLeft(), "20 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(10 === root_child2.getComputedWidth(), "10 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(101 === root_child2.getComputedHeight(), "101 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(101 === root.getComputedHeight(), "101 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(90 === root_child0.getComputedLeft(), "90 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(101 === root_child0.getComputedHeight(), "101 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(80 === root_child1.getComputedLeft(), "80 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(10 === root_child1.getComputedWidth(), "10 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(101 === root_child1.getComputedHeight(), "101 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(70 === root_child2.getComputedLeft(), "70 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(10 === root_child2.getComputedWidth(), "10 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(101 === root_child2.getComputedHeight(), "101 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("rounding_fractial_input_5_y", function () {
+  var config = Yoga.Config.create();
+
+  config.setExperimentalFeatureEnabled(Yoga.EXPERIMENTAL_FEATURE_ROUNDING, true);
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setMargin(Yoga.EDGE_LEFT, 0.4);
+    root.setWidth(100.4);
+    root.setHeight(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth("100%");
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth("100%");
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+
+    var root_child2 = Yoga.Node.create(config);
+    root_child2.setWidth("100%");
+    root_child2.setHeight(10);
+    root.insertChild(root_child2, 2);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(101 === root.getComputedWidth(), "101 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(101 === root_child0.getComputedWidth(), "101 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(10 === root_child1.getComputedTop(), "10 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(101 === root_child1.getComputedWidth(), "101 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(10 === root_child1.getComputedHeight(), "10 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child2.getComputedLeft(), "0 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(20 === root_child2.getComputedTop(), "20 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(101 === root_child2.getComputedWidth(), "101 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(10 === root_child2.getComputedHeight(), "10 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(101 === root.getComputedWidth(), "101 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(101 === root_child0.getComputedWidth(), "101 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(10 === root_child1.getComputedTop(), "10 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(101 === root_child1.getComputedWidth(), "101 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(10 === root_child1.getComputedHeight(), "10 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child2.getComputedLeft(), "0 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(20 === root_child2.getComputedTop(), "20 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(101 === root_child2.getComputedWidth(), "101 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(10 === root_child2.getComputedHeight(), "10 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
   } finally {
     if (typeof root !== "undefined") {
       root.freeRecursive();

--- a/tests/YGRoundingTest.cpp
+++ b/tests/YGRoundingTest.cpp
@@ -647,9 +647,9 @@ TEST(YogaTest, rounding_fractial_input_3) {
   YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureRounding, true);
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPosition(root, YGEdgeTop, 0.3f);
+  YGNodeStyleSetPosition(root, YGEdgeTop, 0.1f);
   YGNodeStyleSetWidth(root, 100);
-  YGNodeStyleSetHeight(root, 113.4f);
+  YGNodeStyleSetHeight(root, 113.1f);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexGrow(root_child0, 1);
@@ -671,7 +671,7 @@ TEST(YogaTest, rounding_fractial_input_3) {
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(114, YGNodeLayoutGetHeight(root));
+  ASSERT_FLOAT_EQ(113, YGNodeLayoutGetHeight(root));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
@@ -693,7 +693,7 @@ TEST(YogaTest, rounding_fractial_input_3) {
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(114, YGNodeLayoutGetHeight(root));
+  ASSERT_FLOAT_EQ(113, YGNodeLayoutGetHeight(root));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
@@ -782,6 +782,151 @@ TEST(YogaTest, rounding_fractial_input_4) {
   ASSERT_FLOAT_EQ(89, YGNodeLayoutGetTop(root_child2));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child2));
   ASSERT_FLOAT_EQ(24, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, rounding_fractial_input_5_x) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureRounding, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetPosition(root, YGEdgeTop, 0.4f);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100.4f);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 10);
+  YGNodeStyleSetHeightPercent(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 10);
+  YGNodeStyleSetHeightPercent(root_child1, 100);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child2, 10);
+  YGNodeStyleSetHeightPercent(root_child2, 100);
+  YGNodeInsertChild(root, root_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, rounding_fractial_input_5_y) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureRounding, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMargin(root, YGEdgeLeft, 0.4f);
+  YGNodeStyleSetWidth(root, 100.4f);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child1, 100);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child2, 100);
+  YGNodeStyleSetHeight(root_child2, 10);
+  YGNodeInsertChild(root, root_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(101, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
 
   YGNodeFreeRecursive(root);
 

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -3298,7 +3298,7 @@ static void YGRoundToPixelGrid(const YGNodeRef node, const float pointScaleFacto
     float fractial = fmodf(node##Name, pointScaleFactor); \
     rounded##Name = node##Name - fractial;                \
                                                           \
-    if (fractial >= pointScaleFactor / 2.0f) {            \
+    if (fractial >= pointScaleFactor / 2.0f) {       \
       rounded##Name += pointScaleFactor;                  \
     }                                                     \
   }

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -3283,49 +3283,41 @@ void YGConfigSetPointScaleFactor(const YGConfigRef config, const float pixelsInP
   }
 }
 
-static void YGRoundToPixelGrid(const YGNodeRef node, const float pointScaleFactor) {
+static void YGRoundToPixelGrid(const YGNodeRef node, const float pointScaleFactor, const float parentNodeLeft, const float parentNodeTop, const float parentRoundedLeft, const float parentRoundedTop) {
   if (pointScaleFactor == 0.0f) {
     return;
   }
-  const float nodeLeft = node->layout.position[YGEdgeLeft];
-  const float nodeTop = node->layout.position[YGEdgeTop];
 
-  // To round correctly to the pixel grid, first we calculate left and top coordinates
-  float fractialLeft = fmodf(nodeLeft, pointScaleFactor);
-  float fractialTop = fmodf(nodeTop, pointScaleFactor);
-  float roundedLeft = nodeLeft - fractialLeft;
-  float roundedTop = nodeTop - fractialTop;
+  const float nodeLeft = parentNodeLeft + node->layout.position[YGEdgeLeft];
+  const float nodeTop = parentNodeTop + node->layout.position[YGEdgeTop];
 
-  // To do the actual rounding we check if leftover fraction is bigger or equal than half of the grid step
-  if (fractialLeft >= pointScaleFactor / 2.0f) {
-    roundedLeft += pointScaleFactor;
-    fractialLeft -= pointScaleFactor;
-  }
-  if (fractialTop >= pointScaleFactor / 2.0f) {
-    roundedTop += pointScaleFactor;
-    fractialTop -= pointScaleFactor;
-  }
-  node->layout.position[YGEdgeLeft] = roundedLeft;
-  node->layout.position[YGEdgeTop] = roundedTop;
+  const float nodeRight = nodeLeft + node->layout.dimensions[YGDimensionWidth];
+  const float nodeBottom = nodeTop + node->layout.dimensions[YGDimensionHeight];
 
-  // Now we round width and height in the same way accounting for fractial leftovers from rounding position
-  const float adjustedWidth = fractialLeft + node->layout.dimensions[YGDimensionWidth];
-  const float adjustedHeight = fractialTop + node->layout.dimensions[YGDimensionHeight];
-  float roundedWidth = adjustedWidth - fmodf(adjustedWidth, pointScaleFactor);
-  float roundedHeight = adjustedHeight - fmodf(adjustedHeight, pointScaleFactor);
+  #define YG_FRACTIAL(Name) float rounded##Name = 0.0; {  \
+    float fractial = fmodf(node##Name, pointScaleFactor); \
+    rounded##Name = node##Name - fractial;                \
+                                                          \
+    if (fractial >= pointScaleFactor / 2.0f) {            \
+      rounded##Name += pointScaleFactor;                  \
+    }                                                     \
+  }
 
-  if (adjustedWidth - roundedWidth >= pointScaleFactor / 2.0f) {
-    roundedWidth += pointScaleFactor;
-  }
-  if (adjustedHeight - roundedHeight >= pointScaleFactor / 2.0f) {
-    roundedHeight += pointScaleFactor;
-  }
-  node->layout.dimensions[YGDimensionWidth] = roundedWidth;
-  node->layout.dimensions[YGDimensionHeight] = roundedHeight;
+  YG_FRACTIAL(Left);
+  YG_FRACTIAL(Top);
+
+  YG_FRACTIAL(Right);
+  YG_FRACTIAL(Bottom);
+
+  node->layout.position[YGEdgeLeft] = roundedLeft - parentRoundedLeft;
+  node->layout.position[YGEdgeTop] = roundedTop - parentRoundedTop;
+
+  node->layout.dimensions[YGDimensionWidth] = roundedRight - roundedLeft;
+  node->layout.dimensions[YGDimensionHeight] = roundedBottom - roundedTop;
 
   const uint32_t childCount = YGNodeListCount(node->children);
   for (uint32_t i = 0; i < childCount; i++) {
-    YGRoundToPixelGrid(YGNodeGetChild(node, i), pointScaleFactor);
+    YGRoundToPixelGrid(YGNodeGetChild(node, i), pointScaleFactor, nodeLeft, nodeTop, roundedLeft, roundedTop);
   }
 }
 
@@ -3385,7 +3377,7 @@ void YGNodeCalculateLayout(const YGNodeRef node,
     YGNodeSetPosition(node, node->layout.direction, parentWidth, parentHeight, parentWidth);
 
     if (YGConfigIsExperimentalFeatureEnabled(node->config, YGExperimentalFeatureRounding)) {
-      YGRoundToPixelGrid(node, node->config->pointScaleFactor);
+        YGRoundToPixelGrid(node, node->config->pointScaleFactor, 0.0, 0.0, 0.0, 0.0);
     }
 
     if (gPrintTree) {


### PR DESCRIPTION
This PR fixes #490 

- Coordinates are now rounded depending on their position on the world pixel grid instead of the local grid, which means that they are now properly rounded relatively to their parents.

- Because this change is an improvement over the Chrome implementation which suffer from the same bug that we do, I've implemented new `expect-*` attributes for html fixtures. They can be used to override the generated assertion that we must match, and also validate that Chrome's behaviour is the one we expect. You can see them in action [here](https://github.com/facebook/yoga/pull/508/files#diff-054aae1dfb4ca4e6f76130952274dcdaR66).