### PR TITLE
Add YGEnums to visual studio solutions

### DIFF
--- a/csharp/Yoga/Yoga.Universal.vcxproj
+++ b/csharp/Yoga/Yoga.Universal.vcxproj
@@ -243,6 +243,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\yoga\Yoga.h" />
+    <ClInclude Include="..\..\yoga\YGEnums.c" />
     <ClInclude Include="..\..\yoga\YGMacros.h" />
     <ClInclude Include="..\..\yoga\YGNodeList.h" />
     <ClInclude Include="resource.h" />
@@ -252,6 +253,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\yoga\Yoga.c" />
+    <ClCompile Include="..\..\yoga\YGEnums.c" />
     <ClCompile Include="..\..\yoga\YGNodeList.c" />
     <ClCompile Include="YGInterop.cpp" />
     <ClCompile Include="dllmain.cpp">

--- a/csharp/Yoga/Yoga.vcxproj
+++ b/csharp/Yoga/Yoga.vcxproj
@@ -228,6 +228,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\yoga\Yoga.h" />
+    <ClInclude Include="..\..\yoga\YGEnums.h" />
     <ClInclude Include="..\..\yoga\YGMacros.h" />
     <ClInclude Include="..\..\yoga\YGNodeList.h" />
     <ClInclude Include="resource.h" />
@@ -237,6 +238,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\yoga\Yoga.c" />
+    <ClCompile Include="..\..\yoga\YGEnums.c" />
     <ClCompile Include="..\..\yoga\YGNodeList.c" />
     <ClCompile Include="YGInterop.cpp" />
     <ClCompile Include="dllmain.cpp">


### PR DESCRIPTION
As stated in 152074935 by @rmarinho the Visual Studio solution didn't compile as ```YGEnums.c/YGEnums.h``` hasn't been added to them. This fixes this problem.