### PR TITLE
[C#] Rename StyleAspectRatio to AspectRatio to be more consistent

### DIFF
--- a/csharp/Facebook.Yoga/YogaNode.cs
+++ b/csharp/Facebook.Yoga/YogaNode.cs
@@ -447,7 +447,7 @@ namespace Facebook.Yoga
             }
         }
 
-        public float StyleAspectRatio
+        public float AspectRatio
         {
             get
             {


### PR DESCRIPTION
Rename ```StyleAspectRatio``` to ```AspectRatio``` to be consistent with the other getters and setters.