### PR TITLE
[C#] Mark enum with [Flags] where they are used as flags

### DIFF
--- a/csharp/Facebook.Yoga/YogaPrintOptions.cs
+++ b/csharp/Facebook.Yoga/YogaPrintOptions.cs
@@ -9,6 +9,7 @@
 
 namespace Facebook.Yoga
 {
+    [Flags]
     public enum YogaPrintOptions
     {
         Layout = 1,

--- a/enums.py
+++ b/enums.py
@@ -223,6 +223,8 @@ for name, values in sorted(ENUMS.items()):
     with open(root + '/csharp/Facebook.Yoga/Yoga%s.cs' % name, 'w') as f:
         f.write(LICENSE)
         f.write('namespace Facebook.Yoga\n{\n')
+        if isinstance(next(iter(values or []), None), tuple):
+            f.write('    [Flags]\n')
         f.write('    public enum Yoga%s\n    {\n' % name)
         for value in values:
             if isinstance(value, tuple):


### PR DESCRIPTION
Marks enum with ```[Flags]``` attribute, where they are used as flags.