### PR TITLE
Downgrade deployment target to ios 7

### DIFF
--- a/YogaKit.podspec
+++ b/YogaKit.podspec
@@ -15,7 +15,7 @@ podspec = Pod::Spec.new do |spec|
   }
 
   spec.platform = :ios
-  spec.ios.deployment_target = '8.0'
+  spec.ios.deployment_target = '7.0'
   spec.ios.frameworks = 'UIKit'
 
   spec.dependency 'Yoga', '~> 1.3'


### PR DESCRIPTION
Hey there, lets downgrade deployment target of YogaKit pod to iOS7. This days there is a lot of apps that still have support of ios7 (and  i'm working on one of them :)). And I didnt't find any reason why it couldn't be done.

Thanks