### PR TITLE
Configure YogaKit with main screen scale factor

### DIFF
--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -103,6 +103,7 @@ static YGConfigRef globalConfig;
 {
   globalConfig = YGConfigNew();
   YGConfigSetExperimentalFeatureEnabled(globalConfig, YGExperimentalFeatureWebFlexBasis, true);
+  YGConfigSetPointScaleFactor(globalConfig, [UIScreen mainScreen].scale);
 }
 
 - (instancetype)initWithView:(UIView*)view


### PR DESCRIPTION
Hi! After merging https://github.com/facebook/yoga/commit/3db38f2a80cd331bb757eba65baa2d10c9b41f39 the rounding algorithm become broken in YogaKit because it doesn't configure scale factor.