### PR TITLE
Expose calculateLayoutWithSize in YogaKit

### DIFF
--- a/YogaKit/Source/YGLayout.h
+++ b/YogaKit/Source/YGLayout.h
@@ -121,6 +121,12 @@ typedef NS_OPTIONS(NSInteger, YGDimensionFlexibility) {
 @property (nonatomic, readonly, assign) CGSize intrinsicSize;
 
 /**
+  Returns the size of the view based on provided constraints. Pass NaN for an unconstrained dimension.
+ */
+- (CGSize)calculateLayoutWithSize:(CGSize)size
+    NS_SWIFT_NAME(calculateLayout(with:));
+
+/**
  Returns the number of children that are using Flexbox.
  */
 @property (nonatomic, readonly, assign) NSUInteger numberOfChildren;

--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -271,8 +271,6 @@ YG_PROPERTY(CGFloat, aspectRatio, AspectRatio)
   return [self calculateLayoutWithSize:constrainedSize];
 }
 
-#pragma mark - Private
-
 - (CGSize)calculateLayoutWithSize:(CGSize)size
 {
   NSAssert([NSThread isMainThread], @"Yoga calculation must be done on main.");
@@ -292,6 +290,8 @@ YG_PROPERTY(CGFloat, aspectRatio, AspectRatio)
     .height = YGNodeLayoutGetHeight(node),
   };
 }
+
+#pragma mark - Private
 
 static YGSize YGMeasureView(
   YGNodeRef node,


### PR DESCRIPTION
# Why?

calculateLayoutWithSize: can be useful when calculating table/collection view sizes before the views are fully laid out by UIKit.