### PR TITLE
Change android minimum SDK version to 14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
 }
 
 ext {
-    minSdkVersion = 15
+    minSdkVersion = 14
     targetSdkVersion = 25
     compileSdkVersion = 25
     buildToolsVersion = '25.0.2'


### PR DESCRIPTION
The library(yoga) has no dependency on android framework. As a matter of
fact this version can change to a lower number which will make yoga
support more old systems.    

According to I/O 17, support library has change its minimum SDK version   
 to 14, so I think 14 is a reasonable min support version for yoga as well.

See
https://developer.android.com/topic/libraries/support-library/revisions.html