### PR TITLE
Attempt to fix Travis emcc setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,10 +78,10 @@ before_install:
   # JavaScript
   - |
     if [[ $TARGET = "js" ]]; then (
+      source /tmp/emsdk-portable/emsdk_env.sh &&
       cd javascript &&
       npm install &&
       unset CC && unset CXX && unset LINK &&
-      source /tmp/emsdk-portable/emsdk_env.sh &&
       npm run build:browser
     ) fi
 


### PR DESCRIPTION
Triggering Travis for this one - will import this internally if it should pass.

The reason is that we're seeing `emcc` not being found during `npm install` which is set by the emsdk-portable env script.

cc @emilsjolander 