### PR TITLE
Fix text node rounding with fractional dimensions matching the rounding factor

### DIFF
--- a/tests/YGRoundingMeasureFuncTest.cpp
+++ b/tests/YGRoundingMeasureFuncTest.cpp
@@ -26,7 +26,17 @@ static YGSize _measureCeil(YGNodeRef node,
                            float height,
                            YGMeasureMode heightMode) {
   return YGSize{
-      width = 10.5, height = 10.5,
+      width = 10.5f, height = 10.5f,
+  };
+}
+
+static YGSize _measureFractial(YGNodeRef node,
+  float width,
+  YGMeasureMode widthMode,
+  float height,
+  YGMeasureMode heightMode) {
+  return YGSize{
+    width = 0.5f, height = 0.5f,
   };
 }
 
@@ -92,6 +102,28 @@ TEST(YogaTest, rounding_feature_with_custom_measure_func_ceil) {
 
   ASSERT_FLOAT_EQ(11, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(11, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, rounding_feature_with_custom_measure_and_fractial_matching_scale) {
+  const YGConfigRef config = YGConfigNew();
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPosition(root_child0, YGEdgeLeft, 73.625);
+  YGNodeSetMeasureFunc(root_child0, _measureFractial);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  YGConfigSetPointScaleFactor(config, 2.0f);
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0.5, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(0.5, YGNodeLayoutGetHeight(root_child0));
+  ASSERT_FLOAT_EQ(73.5, YGNodeLayoutGetLeft(root_child0));
 
   YGNodeFreeRecursive(root);
 

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -3466,8 +3466,8 @@ static void YGRoundToPixelGrid(const YGNodeRef node,
   node->layout.position[YGEdgeTop] =
       YGRoundValueToPixelGrid(nodeTop, pointScaleFactor, false, textRounding);
 
-  const bool hasFractionalWidth = !YGFloatsEqual(fmodf(nodeWidth, 1.0), 0);
-  const bool hasFractionalHeight = !YGFloatsEqual(fmodf(nodeHeight, 1.0), 0);
+  const bool hasFractionalWidth = !YGFloatsEqual(fmodf(nodeWidth, 1 / pointScaleFactor), 0);
+  const bool hasFractionalHeight = !YGFloatsEqual(fmodf(nodeHeight, 1 / pointScaleFactor), 0);
 
   node->layout.dimensions[YGDimensionWidth] =
       YGRoundValueToPixelGrid(


### PR DESCRIPTION
If we have a fractional measure output which matches the subpixel rounding factor, we still should round both dimension into the same direction.

Fixes facebook/yoga#580.