### PR TITLE
Reset the hadOverflow flag at the beginning of the algorithm

### DIFF
--- a/tests/YGHadOverflowTest.cpp
+++ b/tests/YGHadOverflowTest.cpp
@@ -80,6 +80,30 @@ TEST_F(YogaTest_HadOverflowTests, no_overflow_no_wrap_and_flex_children) {
   ASSERT_FALSE(YGNodeLayoutGetHadOverflow(root));
 }
 
+TEST_F(YogaTest_HadOverflowTests, hadOverflow_gets_reset_if_not_logger_valid) {
+  const YGNodeRef child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(child0, 80);
+  YGNodeStyleSetHeight(child0, 40);
+  YGNodeStyleSetMargin(child0, YGEdgeTop, 10);
+  YGNodeStyleSetMargin(child0, YGEdgeBottom, 10);
+  YGNodeInsertChild(root, child0, 0);
+  const YGNodeRef child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(child1, 80);
+  YGNodeStyleSetHeight(child1, 40);
+  YGNodeStyleSetMargin(child1, YGEdgeBottom, 5);
+  YGNodeInsertChild(root, child1, 1);
+
+  YGNodeCalculateLayout(root, 200, 100, YGDirectionLTR);
+
+  ASSERT_TRUE(YGNodeLayoutGetHadOverflow(root));
+
+  YGNodeStyleSetFlexShrink(child1, 1);
+
+  YGNodeCalculateLayout(root, 200, 100, YGDirectionLTR);
+
+  ASSERT_FALSE(YGNodeLayoutGetHadOverflow(root));
+}
+
 TEST_F(YogaTest_HadOverflowTests, spacing_overflow_in_nested_nodes) {
   const YGNodeRef child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetWidth(child0, 80);

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -2041,6 +2041,9 @@ static void YGNodelayoutImpl(const YGNodeRef node,
     return;
   }
 
+  // Reset layout flags, as they could have changed.
+  node->layout.hadOverflow = false;
+
   // STEP 1: CALCULATE VALUES FOR REMAINDER OF ALGORITHM
   const YGFlexDirection mainAxis = YGResolveFlexDirection(node->style.flexDirection, direction);
   const YGFlexDirection crossAxis = YGFlexDirectionCross(mainAxis, direction);
@@ -2577,14 +2580,14 @@ static void YGNodelayoutImpl(const YGNodeRef node,
                              performLayout && !requiresStretchLayout,
                              "flex",
                              config);
-        node->layout.hadOverflow = node->layout.hadOverflow || currentRelativeChild->layout.hadOverflow;
+        node->layout.hadOverflow |= currentRelativeChild->layout.hadOverflow;
 
         currentRelativeChild = currentRelativeChild->nextChild;
       }
     }
 
     remainingFreeSpace = originalRemainingFreeSpace + deltaFreeSpace;
-    node->layout.hadOverflow = node->layout.hadOverflow || (remainingFreeSpace < 0);
+    node->layout.hadOverflow |= (remainingFreeSpace < 0);
 
     // STEP 6: MAIN-AXIS JUSTIFICATION & CROSS-AXIS SIZE DETERMINATION
 


### PR DESCRIPTION
This fixes the case where we change the layout, so that it doesn't overflow anymore.

This also improves the readability by using `|=` instead of referencing the value twice.