### PR TITLE
Dividied YogaKit.podspec into Core and SwiftExtension for YogaKit.

### DIFF
--- a/YogaKit.podspec
+++ b/YogaKit.podspec
@@ -17,11 +17,19 @@ podspec = Pod::Spec.new do |spec|
   spec.platform = :ios
   spec.ios.deployment_target = '8.0'
   spec.ios.frameworks = 'UIKit'
-
+  spec.default_subspec = "Core"  
   spec.dependency 'Yoga', '~> 1.9'
-  spec.source_files = 'YogaKit/Source/*.{h,m,swift}'
-  spec.public_header_files = 'YogaKit/Source/{YGLayout,UIView+Yoga}.h'
-  spec.private_header_files = 'YogaKit/Source/YGLayout+Private.h'
+
+  spec.subspec "Core" do |ss|
+    ss.source_files = 'YogaKit/Source/*.{h,m}'
+    ss.public_header_files = 'YogaKit/Source/{YGLayout,UIView+Yoga}.h'
+    ss.private_header_files = 'YogaKit/Source/YGLayout+Private.h'
+  end
+
+  spec.subspec 'SwiftExtension' do |ss|
+    ss.source_files = 'YogaKit/Source/*.{swift}'    
+  end  
+
 end
 
 # See https://github.com/facebook/yoga/pull/366


### PR DESCRIPTION
It gives chance for projects who is not ready to bring swift into codebase still use YogaKit

Fixes: #565 
SLA completed

