### PR TITLE
Recalculate free space after forcing aspect ratio constraints

### DIFF
--- a/tests/YGAspectRatioTest.cpp
+++ b/tests/YGAspectRatioTest.cpp
@@ -747,3 +747,53 @@ TEST(YogaTest, aspect_ratio_defined_cross_with_margin) {
 
   YGNodeFreeRecursive(root);
 }
+
+TEST(YogaTest, aspect_ratio_centered_growing_block_justify_content) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionColumn);
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetHeight(root_child0, 50);
+  YGNodeStyleSetAspectRatio(root_child0, 1.5);
+  YGNodeStyleSetFlexGrow(root_child0, 1);
+  YGNodeStyleSetFlexShrink(root_child0, 1);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_EQ(17, YGNodeLayoutGetTop(root_child0));
+  ASSERT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_EQ(66, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, aspect_ratio_centered_growing_block_align_items) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionColumn);
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetHeight(root_child0, 50);
+  YGNodeStyleSetAspectRatio(root_child0, 0.5);
+  YGNodeStyleSetFlexGrow(root_child0, 1);
+  YGNodeStyleSetFlexShrink(root_child0, 1);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_EQ(25, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+}

--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -2532,11 +2532,13 @@ static void YGNodelayoutImpl(const YGNodeRef node,
 
           // Parent size constraint should have higher priority than flex
           if (YGNodeIsFlex(currentRelativeChild)) {
+            const float previousChildMainSize = childMainSize;
             childCrossSize = fminf(childCrossSize - marginCross, availableInnerCrossDim);
             childMainSize =
                 marginMain + (isMainAxisRow
                                   ? childCrossSize * currentRelativeChild->style.aspectRatio
                                   : childCrossSize / currentRelativeChild->style.aspectRatio);
+            deltaFreeSpace += previousChildMainSize - childMainSize;
           }
 
           childCrossSize += marginCross;


### PR DESCRIPTION
We need to recalculate the available space after we clamp the aspect ratio into it's constraints.
This fixes `justify-content` alignments.

Fixes facebook/yoga#489