### PR TITLE
Update c# docs to use object initializer

### DIFF
--- a/docs/_docs/api/csharp.md
+++ b/docs/_docs/api/csharp.md
@@ -8,36 +8,11 @@ permalink: /docs/api/csharp/
 
 ### Lifecycle
 
-Create a `YogaNode` via its default constructor or the static `Create()` builder method and use `Reset` if you want to pool and re-use nodes. The native memory of a `YogaNode` will automatically be freed when the node is garbage collected.
+Create a `YogaNode` via its default constructor and use `Reset` if you want to pool and re-use nodes. The native memory of a `YogaNode` will automatically be freed when the node is garbage collected.
 
 ```csharp
 YogaNode();
 void Reset();
-
-static YogaNode Create(
-  YogaDirection? styleDirection = null,
-  YogaFlexDirection? flexDirection = null,
-  YogaJustify? justifyContent = null,
-  YogaAlign? alignContent = null,
-  YogaAlign? alignItems = null,
-  YogaAlign? alignSelf = null,
-  YogaPositionType? positionType = null,
-  YogaWrap? wrap = null,
-  YogaOverflow? overflow = null,
-  float? flex = null,
-  float? flexGrow = null,
-  float? flexShrink = null,
-  float? flexBasis = null,
-  Spacing position = null,
-  Spacing margin = null,
-  Spacing padding = null,
-  Spacing border = null,
-  float? Width = null,
-  float? Height = null,
-  float? MaxWidth = null,
-  float? MaxHeight = null,
-  float? MinWidth = null,
-  float? MinHeight = null);
 ```
 
 ### Children
@@ -95,6 +70,9 @@ enum YogaAlign
   Center,
   FlexEnd,
   Stretch,
+  Baseline,
+  SpaceBetween,
+  SpaceAround
 }
 
 YogaAlign AlignItems {get, set};
@@ -113,6 +91,7 @@ enum YogaWrap
 {
   NoWrap,
   Wrap,
+  WrapReverse
 }
 
 YogaWrap Wrap {get, set};
@@ -197,17 +176,12 @@ enum YogaMeasureMode
   AtMost,
 }
 
-public delegate long MeasureFunction(
+public delegate YogaSize MeasureFunction(
   YogaNode node,
   float width,
   YogaMeasureMode widthMode,
   float height,
   YogaMeasureMode heightMode);
-
-class MeasureOutput
-{
-  public static long Make(int width, int height);
-}
 
 void SetMeasureFunction(MeasureFunction measureFunction);
 bool IsMeasureDefined();

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,18 +124,20 @@ root.addChildAt(image, 1);
     <div class="blockContent">
 <div markdown="1" style="width: 700px; max-width: 100%;">
 ```csharp
-YogaNode root = YogaNode.Create(
-  width: 500,
-  height: 300,
-);
+YogaNode root = new YogaNode {
+  Width = 500,
+  Height = 300
+};
 
-YogaNode image = YogaNode.Create(flexGrow: 1);
+YogaNode image = new YogaNode { 
+  FlexGrow = 1 
+};
 
-YogaNode text = YogaNode.Create(
-  width: 300,
-  height: 25,
-  margin: new Spacing(left: 20, top: 20, right: 20, bottom: 20),
-);
+YogaNode text = new YogaNode {
+  Width = 300,
+  Height = 25,
+  Margin = 20
+};
 
 root.Insert(image, 0);
 root.Insert(text, 1);


### PR DESCRIPTION
Updates the C# docs to use the object initializer instead of `Create` which doesn't exist anymore.

Fixes facebook/yoga#550.