### PR TITLE
If a view is first excluded from layout and later added, the layout is not correctly computed

### DIFF
--- a/YogaKit/YogaKitSample/YogaKitSample/ViewControllers/LayoutInclusionViewController.swift
+++ b/YogaKit/YogaKitSample/YogaKitSample/ViewControllers/LayoutInclusionViewController.swift
@@ -46,14 +46,16 @@ final class LayoutInclusionViewController: UIViewController {
         contentView.addSubview(redView)
 
         disappearingView.backgroundColor = .blue
+        disappearingView.isHidden = true
         disappearingView.configureLayout { (layout) in
             layout.isEnabled = true
             layout.flexGrow = 1
+            layout.isIncludedInLayout = false
         }
         contentView.addSubview(disappearingView)
 
-        button.setTitle("Add Blue View", for: UIControlState.selected)
-        button.setTitle("Remove Blue View", for: UIControlState.normal)
+        button.setTitle("Remove Blue View", for: UIControlState.selected)
+        button.setTitle("Add Blue View", for: UIControlState.normal)
         button.addTarget(self, action: #selector(buttonWasTapped), for: UIControlEvents.touchUpInside)
         button.configureLayout { (layout) in
             layout.isEnabled = true


### PR DESCRIPTION
If a view is first excluded from layout and later added, the layout is not correctly computed.

**Result**:
![simulator screen shot jul 17 2017 9 01 11 am](https://user-images.githubusercontent.com/14981341/28269078-b5ac538c-6ace-11e7-8651-480336ea4a0a.png)

**Expected result**:
![simulator screen shot jul 17 2017 9 01 52 am](https://user-images.githubusercontent.com/14981341/28269070-af2c2d84-6ace-11e7-8804-4e058b3b5420.png)

