### PR TITLE
Fix a typo in YogaKit, 

### DIFF
--- a/YogaKit/Source/YGLayout.h
+++ b/YogaKit/Source/YGLayout.h
@@ -23,7 +23,7 @@ YG_EXTERN_C_END
 
 typedef NS_OPTIONS(NSInteger, YGDimensionFlexibility) {
   YGDimensionFlexibilityFlexibleWidth = 1 << 0,
-  YGDimensionFlexibilityFlexibleHeigth = 1 << 1,
+  YGDimensionFlexibilityFlexibleHeight = 1 << 1,
 };
 
 @interface YGLayout : NSObject

--- a/YogaKit/Source/YGLayout.h
+++ b/YogaKit/Source/YGLayout.h
@@ -22,7 +22,7 @@ extern YGValue YGPercentValue(CGFloat value)
 YG_EXTERN_C_END
 
 typedef NS_OPTIONS(NSInteger, YGDimensionFlexibility) {
-  YGDimensionFlexibilityFlexibleWidth = 1 << 0, 
+  YGDimensionFlexibilityFlexibleWidth = 1 << 0,
   YGDimensionFlexibilityFlexibleHeight = 1 << 1,
 };
 

--- a/YogaKit/Source/YGLayout.h
+++ b/YogaKit/Source/YGLayout.h
@@ -22,7 +22,7 @@ extern YGValue YGPercentValue(CGFloat value)
 YG_EXTERN_C_END
 
 typedef NS_OPTIONS(NSInteger, YGDimensionFlexibility) {
-  YGDimensionFlexibilityFlexibleWidth = 1 << 0,
+  YGDimensionFlexibilityFlexibleWidth = 1 << 0, 
   YGDimensionFlexibilityFlexibleHeight = 1 << 1,
 };
 

--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -254,7 +254,7 @@ YG_PROPERTY(CGFloat, aspectRatio, AspectRatio)
   if (dimensionFlexibility & YGDimensionFlexibilityFlexibleWidth) {
     size.width = YGUndefined;
   }
-  if (dimensionFlexibility & YGDimensionFlexibilityFlexibleHeigth) {
+  if (dimensionFlexibility & YGDimensionFlexibilityFlexibleHeight) {
     size.height = YGUndefined;
   }
   [self calculateLayoutWithSize:size];

--- a/YogaKit/Tests/YogaKitTests.m
+++ b/YogaKit/Tests/YogaKitTests.m
@@ -181,7 +181,7 @@
   view.yoga.height = YGPointValue(100);
   [container addSubview:view];
 
-  [container.yoga applyLayoutPreservingOrigin:YES dimensionFlexibility:YGDimensionFlexibilityFlexibleHeigth];
+  [container.yoga applyLayoutPreservingOrigin:YES dimensionFlexibility:YGDimensionFlexibilityFlexibleHeight];
   XCTAssertEqual(200, container.frame.size.width);
   XCTAssertEqual(100, container.frame.size.height);
 }
@@ -197,7 +197,7 @@
   view.yoga.height = YGPointValue(100);
   [container addSubview:view];
 
-  [container.yoga applyLayoutPreservingOrigin:YES dimensionFlexibility:YGDimensionFlexibilityFlexibleWidth | YGDimensionFlexibilityFlexibleHeigth];
+  [container.yoga applyLayoutPreservingOrigin:YES dimensionFlexibility:YGDimensionFlexibilityFlexibleWidth | YGDimensionFlexibilityFlexibleHeight];
   XCTAssertEqual(100, container.frame.size.width);
   XCTAssertEqual(100, container.frame.size.height);
 }


### PR DESCRIPTION
`YGDimensionFlexibilityFlexibleHeight` it was wrongly spelled `YGDimensionFlexibilityFlexibleHeigth`.

[X] Test suite passes
[X] Contributor License Agreement