### PR TITLE
Fix const declaration mismatch and double/float mix

### DIFF
--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -3168,11 +3168,11 @@ static float YGRoundValueToPixelGrid(const float value,
     // Still remove fractial as fractial could be  extremely small.
     scaledValue = scaledValue - fractial;
   } else if (forceCeil) {
-    scaledValue = scaledValue - fractial + 1.0;
+    scaledValue = scaledValue - fractial + 1.0f;
   } else if (forceFloor) {
     scaledValue = scaledValue - fractial;
   } else {
-    scaledValue = scaledValue - fractial + (fractial >= 0.5f ? 1.0 : 0);
+    scaledValue = scaledValue - fractial + (fractial >= 0.5f ? 1.0f : 0.0f);
   }
   return scaledValue / pointScaleFactor;
 }

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -112,7 +112,7 @@ WIN_EXPORT bool YGNodeCanUseCachedMeasurement(const YGMeasureMode widthMode,
                                               const float lastComputedHeight,
                                               const float marginRow,
                                               const float marginColumn,
-                                              YGConfigRef config);
+                                              const YGConfigRef config);
 
 WIN_EXPORT void YGNodeCopyStyle(const YGNodeRef dstNode, const YGNodeRef srcNode);
 


### PR DESCRIPTION
This PR fixes a declaration mismatch for `YGNodeCanUseCachedMeasurement` where the last argument is declared non `const` in `.h` and `const` in `.c`.

Additionally it uses explicit `float` for fraction calculation do avoid usage of `double` assignment.