### PR TITLE
Release alloced memory for subviewsToInclude 

### DIFF
--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -376,6 +376,8 @@ static void YGAttachNodesFromViewHierachy(UIView *const view)
     for (UIView *const subview in subviewsToInclude) {
       YGAttachNodesFromViewHierachy(subview);
     }
+
+    [subviewsToInclude release];
   }
 }
 


### PR DESCRIPTION
As we create the `subviewsToInclude` array with `alloc` we need to manually release it at the end of the scope.