### PR TITLE
Only add UIView nodes to Yoga where they are enabled

### DIFF
--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -361,7 +361,7 @@ static void YGAttachNodesFromViewHierachy(UIView *const view)
 
     NSMutableArray<UIView *> *subviewsToInclude = [[NSMutableArray alloc] initWithCapacity:view.subviews.count];
     for (UIView *subview in view.subviews) {
-      if (subview.yoga.isIncludedInLayout) {
+      if (subview.yoga.isEnabled && subview.yoga.isIncludedInLayout) {
         [subviewsToInclude addObject:subview];
       }
     }


### PR DESCRIPTION
Only add UIView nodes to Yoga where they are enabled. 

We check for it in `isLeaf` but I think we should also check for them in the check for sub views.