### PR TITLE
Fixes #606

### DIFF
--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -304,10 +304,14 @@ static YGSize YGMeasureView(
   const CGFloat constrainedHeight = (heightMode == YGMeasureModeUndefined) ? CGFLOAT_MAX: height;
 
   UIView *view = (__bridge UIView*) YGNodeGetContext(node);
-  const CGSize sizeThatFits = [view sizeThatFits:(CGSize) {
-    .width = constrainedWidth,
-    .height = constrainedHeight,
-  }];
+  CGSize sizeThatFits = CGSizeZero;
+
+  if ([view.subviews count] > 0) {
+    sizeThatFits = [view sizeThatFits:(CGSize) {
+      .width = constrainedWidth,
+      .height = constrainedHeight,
+    }];
+  }
 
   return (YGSize) {
     .width = YGSanitizeMeasurement(constrainedWidth, sizeThatFits.width, widthMode),

--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -308,7 +308,11 @@ static YGSize YGMeasureView(
   UIView *view = (__bridge UIView*) YGNodeGetContext(node);
   CGSize sizeThatFits = CGSizeZero;
 
-  // Fix for https://github.com/facebook/yoga/issues/606
+  // The default implementation of sizeThatFits: returns the existing size of the view.
+  // That means that if we want to layout an empty UIView, which already has got a frame set,
+  // its measured size should be CGSizeZero, but UIKit returns the existing size.
+  //
+  // See https://github.com/facebook/yoga/issues/606 for more information.
   if (!view.yoga.isUIView || [view.subviews count] > 0) {
     sizeThatFits = [view sizeThatFits:(CGSize) {
       .width = constrainedWidth,

--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -102,6 +102,7 @@ static YGConfigRef globalConfig;
 @interface YGLayout ()
 
 @property (nonatomic, weak, readonly) UIView *view;
+@property (nonatomic, assign, readonly) BOOL isUIView;
 
 @end
 
@@ -126,6 +127,7 @@ static YGConfigRef globalConfig;
     YGNodeSetContext(_node, (__bridge void *) view);
     _isEnabled = NO;
     _isIncludedInLayout = YES;
+    _isUIView = [view isMemberOfClass:[UIView class]];
   }
 
   return self;
@@ -307,7 +309,7 @@ static YGSize YGMeasureView(
   CGSize sizeThatFits = CGSizeZero;
 
   // Fix for https://github.com/facebook/yoga/issues/606
-  if (![view isMemberOfClass:[UIView class]] || [view.subviews count] > 0) {
+  if (!view.yoga.isUIView || [view.subviews count] > 0) {
     sizeThatFits = [view sizeThatFits:(CGSize) {
       .width = constrainedWidth,
       .height = constrainedHeight,

--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -306,7 +306,8 @@ static YGSize YGMeasureView(
   UIView *view = (__bridge UIView*) YGNodeGetContext(node);
   CGSize sizeThatFits = CGSizeZero;
 
-  if ([view.subviews count] > 0) {
+  // Fix for https://github.com/facebook/yoga/issues/606
+  if (![view isMemberOfClass:[UIView class]] || [view.subviews count] > 0) {
     sizeThatFits = [view sizeThatFits:(CGSize) {
       .width = constrainedWidth,
       .height = constrainedHeight,

--- a/YogaKit/Tests/YogaKitTests.m
+++ b/YogaKit/Tests/YogaKitTests.m
@@ -129,6 +129,16 @@
   XCTAssertEqual(longTextLabelSize.width + textBadgeView.yoga.intrinsicSize.width, containerSize.width);
 }
 
+- (void)testSizeThatFitsEmptyView
+{
+  UIView *view = [[UIView alloc] initWithFrame:CGRectMake(10, 10, 200, 200)];
+  view.yoga.isEnabled = YES;
+
+  const CGSize viewSize = view.yoga.intrinsicSize;
+  XCTAssertEqual(viewSize.height, 0);
+  XCTAssertEqual(viewSize.width, 0);
+}
+
 - (void)testPreservingOrigin
 {
   UIView *container = [[UIView alloc] initWithFrame:CGRectMake(0,0,50,75)];


### PR DESCRIPTION
Fixes #606. 

If there are no subviews in `UIView`, yoga assumes that `sizeThatFits:` returns `CGSizeZero`. However, according to [the documentation](https://developer.apple.com/documentation/uikit/uiview/1622625-sizethatfits), `UIView` returns current size if there are no subviews. 

This diff adds a check - if there are no subviews, `sizeThatFits:` doesn't get called, and CGSizeZero is returned.