### PR TITLE
Android - Fix subview display wrong order

### DIFF
--- a/android/src/main/java/com/facebook/yoga/android/VirtualYogaLayout.java
+++ b/android/src/main/java/com/facebook/yoga/android/VirtualYogaLayout.java
@@ -70,7 +70,7 @@ public class VirtualYogaLayout extends ViewGroup {
       ((VirtualYogaLayout) child).transferChildren(this);
 
       final YogaNode childNode = ((VirtualYogaLayout) child).getYogaNode();
-      mYogaNode.addChildAt(childNode, mYogaNode.getChildCount());
+      mYogaNode.addChildAt(childNode, index);
 
       return;
     }
@@ -81,7 +81,7 @@ public class VirtualYogaLayout extends ViewGroup {
     node.setData(child);
     node.setMeasureFunction(new YogaLayout.ViewMeasureFunction());
 
-    mYogaNode.addChildAt(node, mYogaNode.getChildCount());
+    mYogaNode.addChildAt(node, index);
 
     addView(child, node);
   }

--- a/android/src/main/java/com/facebook/yoga/android/YogaLayout.java
+++ b/android/src/main/java/com/facebook/yoga/android/YogaLayout.java
@@ -140,7 +140,7 @@ public class YogaLayout extends ViewGroup {
       ((VirtualYogaLayout) child).transferChildren(this);
       final YogaNode childNode = ((VirtualYogaLayout) child).getYogaNode();
 
-      mYogaNode.addChildAt(childNode, mYogaNode.getChildCount());
+      mYogaNode.addChildAt(childNode, index);
 
       return;
     }
@@ -173,7 +173,7 @@ public class YogaLayout extends ViewGroup {
     applyLayoutParams(lp, childNode, child);
 
     mYogaNodes.put(child, childNode);
-    mYogaNode.addChildAt(childNode, mYogaNode.getChildCount());
+    mYogaNode.addChildAt(childNode, index);
   }
 
   /**


### PR DESCRIPTION
`YogaLayout` and `VirtualYogaLayout` always add new node at the end of list, it causes subview display wrong order.
