### PR TITLE
Separate the Objc and Swift sources in YogaKit.podspec.

### DIFF
--- a/YogaKit.podspec
+++ b/YogaKit.podspec
@@ -19,9 +19,17 @@ podspec = Pod::Spec.new do |spec|
   spec.ios.frameworks = 'UIKit'
 
   spec.dependency 'Yoga', '~> 1.6'
-  spec.source_files = 'YogaKit/Source/*.{h,m,swift}'
-  spec.public_header_files = 'YogaKit/Source/{YGLayout,UIView+Yoga}.h'
-  spec.private_header_files = 'YogaKit/Source/YGLayout+Private.h'
+
+  spec.subspec 'Objc' do |objc|
+    objc.source_files = 'YogaKit/Source/*.{h,m}'
+    objc.public_header_files = 'YogaKit/Source/{YGLayout,UIView+Yoga}.h'
+    objc.private_header_files = 'YogaKit/Source/YGLayout+Private.h'
+  end
+
+  spec.subspec 'Swift' do |swift|
+    swift.source_files = 'YogaKit/Source/*.{swift}'
+  end
+
 end
 
 # See https://github.com/facebook/yoga/pull/366

--- a/YogaKit/YogaKitSample/Podfile
+++ b/YogaKit/YogaKitSample/Podfile
@@ -1,6 +1,9 @@
-use_frameworks!
+platform :ios, '9.0'
 
 target 'YogaKitSample' do
+
+  use_frameworks!
   pod 'YogaKit', :path => '../../YogaKit.podspec'
   pod 'IGListKit', '~> 2.1.0'
+
 end

--- a/YogaKit/YogaKitSample/Podfile.lock
+++ b/YogaKit/YogaKitSample/Podfile.lock
@@ -7,6 +7,12 @@ PODS:
   - Yoga (1.6.0)
   - YogaKit (1.6.0):
     - Yoga (~> 1.6)
+    - YogaKit/Objc (= 1.6.0)
+    - YogaKit/Swift (= 1.6.0)
+  - YogaKit/Objc (1.6.0):
+    - Yoga (~> 1.6)
+  - YogaKit/Swift (1.6.0):
+    - Yoga (~> 1.6)
 
 DEPENDENCIES:
   - IGListKit (~> 2.1.0)
@@ -18,9 +24,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   IGListKit: b826c68ef7a4ae1626c09d4d3e1ea7a169e6c36e
-  Yoga: 2ed1d7accfef3610a67f58c0cf101a0662137f2c
-  YogaKit: 31576530e8fcae3175469719ec3212397403330b
+  Yoga: 81670877477311136b1b3f69a6307ce62e1c89cf
+  YogaKit: 53c68d327271d7ee106241471e87c22d91b1449b
 
-PODFILE CHECKSUM: 216f8e7127767709e0e43f3711208d238fa5c404
+PODFILE CHECKSUM: a45805229e541607aa53fe5f7b3ec349c275f061
 
-COCOAPODS: 1.1.1
+COCOAPODS: 1.3.1

--- a/YogaKit/YogaKitSample/YogaKitSample.xcodeproj/project.pbxproj
+++ b/YogaKit/YogaKitSample/YogaKitSample.xcodeproj/project.pbxproj
@@ -265,13 +265,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-YogaKitSample-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		6E01EB987F1564F3D71EBE5A /* [CP] Copy Pods Resources */ = {
@@ -295,9 +298,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-YogaKitSample/Pods-YogaKitSample-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/IGListKit/IGListKit.framework",
+				"${BUILT_PRODUCTS_DIR}/Yoga/yoga.framework",
+				"${BUILT_PRODUCTS_DIR}/YogaKit/YogaKit.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IGListKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/yoga.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YogaKit.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
The latest version of YogaKit must using dynamic framework with cocoapods, but my project has many static libraries, so I want only use the Objc source codes of Yogakit.

So, I create this pull request to make developer choose source codes type: 'swift', 'objc' by themselves.