### PR TITLE
Fix assertion preventing YGNodeLayoutGet* with YGEdgeEnd

### DIFF
--- a/yoga/Yoga.c
+++ b/yoga/Yoga.c
@@ -719,7 +719,7 @@ static inline const YGValue *YGNodeResolveFlexBasisPtr(const YGNodeRef node) {
 #define YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(type, name, instanceName)        \
   type YGNodeLayoutGet##name(const YGNodeRef node, const YGEdge edge) {        \
     YGAssertWithNode(node,                                                     \
-                     edge < YGEdgeEnd,                                         \
+                     edge <= YGEdgeEnd,                                        \
                      "Cannot get layout properties of multi-edge shorthands"); \
                                                                                \
     if (edge == YGEdgeLeft) {                                                  \


### PR DESCRIPTION
Expected to be able to call `YGNodeLayoutGetMargin(node, YGEdgeEnd)`, but instead, the program aborts with `"Cannot get layout properties of multi-edge shorthands"`.

This bug seems to incorrectly prevent properties from YGEdgeEnd for all Layout properties.