### PR TITLE
Allow UIView+Yoga to be used without -ObjC

### DIFF
--- a/YogaKit/Source/UIView+Yoga.h
+++ b/YogaKit/Source/UIView+Yoga.h
@@ -9,10 +9,17 @@
 
 #import "YGLayout.h"
 #import <UIKit/UIKit.h>
+#include <os/base.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^YGLayoutConfigurationBlock)(YGLayout *);
+
+// Allow this category to be used without requiring -ObjC.
+// Any file that imports this header will have a link time dependency on UIView+Yoga.m
+extern const char YGCategoryUIViewYoga;
+extern const void * const OS_WEAK YGLinkRequire;
+const void * const OS_WEAK YGLinkRequire = &YGCategoryUIViewYoga;
 
 @interface UIView (Yoga)
 

--- a/YogaKit/Source/UIView+Yoga.m
+++ b/YogaKit/Source/UIView+Yoga.m
@@ -13,6 +13,10 @@
 
 static const void *kYGYogaAssociatedKey = &kYGYogaAssociatedKey;
 
+// Allow this category to be used without requiring -ObjC.
+// Any file that imports UIView+Yoga.h will have a link time dependency on this implementation.
+const char YGCategoryUIViewYoga = 'Y';
+
 @implementation UIView (YogaKit)
 
 - (YGLayout *)yoga


### PR DESCRIPTION
The `-ObjC` linker flag is used to work around a mismatch between how Mach-O files are linked, and how the Objective-C runtime operates.

With this change, Yoga can be used without forcing the `-ObjC` flag.

If more categories are added, this boilerplate addition could become a macro, but it's better to not introduce any more categories.

See "What causes those exceptions?" in https://developer.apple.com/library/content/qa/qa1490/_index.html