### PR TITLE
Fix invalid value check for entry-common.js

### DIFF
--- a/javascript/sources/entry-common.js
+++ b/javascript/sources/entry-common.js
@@ -156,8 +156,8 @@ module.exports = function (bind, lib) {
 
             }
 
-            if (!Object.prototype.hasOwnProperty.call(methods, unit))
-                throw new Error(`Failed to execute "${fnName}": Unsupported unit.`);
+            if (!methods[unit])
+                throw new Error(`Failed to execute "${fnName}": Unsupported unit '${value}'`);
 
             if (asNumber !== undefined) {
                 return methods[unit].call(this, ... args, asNumber);


### PR DESCRIPTION
# Overview

`!Object.prototype.hasOwnProperty.call(methods, unit))` doesn't correctly return `true` when an unsupported value is passed into `setMaxWidth` within an Automator (macOS) javascript/cocoascript environment.

This PR fixes the issue and also adds the `value` information to the returned error to help with debugging