### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.
+
 ## Pull Requests
 We actively welcome your pull requests.
 1. Fork the repo and create your branch from `master`.


### PR DESCRIPTION
**what is the change?:**
Adding a document linking to the Facebook Open Source Code of Conduct,
for visibility and to meet Github community standards.

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will complete [Yoga's Community Profile](https://github.com/facebook/yoga/community)
checklist and increase the visibility of our COC.

We also added a link to the COC in the CONTRIBUTING doc because folks may miss the separate CODE_OF_CONDUCT document.

**test plan:**
Viewing it on my branch -
![screen shot 2017-11-20 at 6 02 25 pm](https://user-images.githubusercontent.com/1114467/33051133-4dc293e6-ce1d-11e7-9b0a-776cad6211f5.png)
![screen shot 2017-11-20 at 6 02 33 pm](https://user-images.githubusercontent.com/1114467/33051135-4dee35fa-ce1d-11e7-9077-a2d6d6f2ed3e.png)


**issue:**
internal task t23481323