### PR TITLE
YogaKit UIScrollview crash, exception : CALayer position contains NaN: [nan nan]

### DIFF
--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -411,28 +411,30 @@ static void YGApplyLayoutToViewHierarchy(UIView *view, BOOL preserveOrigin)
      return;
   }
 
-  YGNodeRef node = yoga.node;
-  const CGPoint topLeft = {
-    YGNodeLayoutGetLeft(node),
-    YGNodeLayoutGetTop(node),
-  };
-
-  const CGPoint bottomRight = {
-    topLeft.x + YGNodeLayoutGetWidth(node),
-    topLeft.y + YGNodeLayoutGetHeight(node),
-  };
-
-  const CGPoint origin = preserveOrigin ? view.frame.origin : CGPointZero;
-  view.frame = (CGRect) {
-    .origin = {
-      .x = YGRoundPixelValue(topLeft.x + origin.x),
-      .y = YGRoundPixelValue(topLeft.y + origin.y),
-    },
-    .size = {
-      .width = YGRoundPixelValue(bottomRight.x) - YGRoundPixelValue(topLeft.x),
-      .height = YGRoundPixelValue(bottomRight.y) - YGRoundPixelValue(topLeft.y),
-    },
-  };
+  if (yoga.isEnabled) {
+      YGNodeRef node = yoga.node;
+      const CGPoint topLeft = {
+          YGNodeLayoutGetLeft(node),
+          YGNodeLayoutGetTop(node),
+      };
+      
+      const CGPoint bottomRight = {
+          topLeft.x + YGNodeLayoutGetWidth(node),
+          topLeft.y + YGNodeLayoutGetHeight(node),
+      };
+      
+      const CGPoint origin = preserveOrigin ? view.frame.origin : CGPointZero;
+      view.frame = (CGRect) {
+          .origin = {
+              .x = YGRoundPixelValue(topLeft.x + origin.x),
+              .y = YGRoundPixelValue(topLeft.y + origin.y),
+          },
+          .size = {
+              .width = YGRoundPixelValue(bottomRight.x) - YGRoundPixelValue(topLeft.x),
+              .height = YGRoundPixelValue(bottomRight.y) - YGRoundPixelValue(topLeft.y),
+          },
+      };
+  }
 
   if (!yoga.isLeaf) {
     for (NSUInteger i=0; i<view.subviews.count; i++) {


### PR DESCRIPTION
applyLayout(preservingOrigin: false) function getting crash if uiscrollview has subview

# Sample ViewController

```swift
import UIKit
import YogaKit

final class LayoutInclusionViewController: UIViewController {
    private let button: UIButton = UIButton(type: .system)
    private let scroll = UIScrollView(frame: .zero)
    private var root = UIView(frame: .zero)
    
    override func viewDidLoad() {
        root = self.view!
        root.backgroundColor = .white
        root.configureLayout { (layout) in
            layout.isEnabled = true
            layout.flexDirection = .column
            layout.justifyContent = .spaceAround
        }

        button.setTitle("Add Blue View", for: UIControlState.selected)
        button.setTitle("Remove Blue View", for: UIControlState.normal)
        button.addTarget(self, action: #selector(buttonWasTapped), for: UIControlEvents.touchUpInside)
        button.configureLayout { (layout) in
            layout.isEnabled = true
            layout.height = 50
            layout.width = 300
            layout.alignSelf = .center
        }
        root.addSubview(button)

        scroll.backgroundColor = .yellow
        scroll.contentSize = CGSize(width: 1000, height: 10)
        
        scroll.configureLayout { (layout) in
            layout.isEnabled = true
            layout.flexGrow = 1
            layout.flexBasis = YGValue(value: 1, unit: .point)
        }
        root.addSubview(scroll)
        
        let view1 = UIView(frame: .zero)
        view1.backgroundColor = .green
        view1.configureLayout { (layout) in
            layout.isEnabled = true
            layout.flexGrow = 1
            layout.flexBasis = YGValue(value: 1, unit: .point)
        }
        scroll.addSubview(view1)
        
        root.yoga.applyLayout(preservingOrigin: false)
    }

    // MARK - UIButton Action
    func buttonWasTapped() {
        //Crash
        root.yoga.applyLayout(preservingOrigin: false)
    }
}
```

# Crash Log

`2017-11-24 11:22:49.074910+0300 YogaKitSample[6762:2298539] refreshPreferences: HangTracerEnabled: 0
2017-11-24 11:22:49.074946+0300 YogaKitSample[6762:2298539] refreshPreferences: HangTracerDuration: 500
2017-11-24 11:22:49.074958+0300 YogaKitSample[6762:2298539] refreshPreferences: ActivationLoggingEnabled: 0 ActivationLoggingTaskedOffByDA:0
2017-11-24 11:22:51.145455+0300 YogaKitSample[6762:2298539] *** Terminating app due to uncaught exception 'CALayerInvalidGeometry', reason: 'CALayer position contains NaN: [nan nan]'
*** First throw call stack:
(0x182299d04 0x1814e8528 0x182299c4c 0x186290484 0x1862825c0 0x186282c20 0x18b6caae4 0x18b6de3ec 0x1007cec60 0x1007ced38 0x1007ced38 0x1007cee74 0x100783728 0x100783770 0x18b705608 0x18b705588 0x18b6f02f0 0x18b704e7c 0x18b70499c 0x18b6ffe6c 0x18b6d1378 0x18c01e85c 0x18c020de8 0x18c019d04 0x1822422e8 0x182242268 0x182241af0 0x18223f6c8 0x18215ffb8 0x183ff7f84 0x18b7342e8 0x100785c14 0x181c8256c)
libc++abi.dylib: terminating with uncaught exception of type NSException
`