### PR TITLE
Avoid using UIView::frame in favor of bounds/center

### DIFF
--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -451,15 +451,26 @@ static void YGApplyLayoutToViewHierarchy(UIView *view, BOOL preserveOrigin)
     topLeft.y + YGNodeLayoutGetHeight(node),
   };
 
-  const CGPoint origin = preserveOrigin ? view.frame.origin : CGPointZero;
-  view.frame = (CGRect) {
-    .origin = {
-      .x = YGRoundPixelValue(topLeft.x + origin.x),
-      .y = YGRoundPixelValue(topLeft.y + origin.y),
-    },
+  const CGPoint origin = preserveOrigin ? (CGPoint){
+    .x = view.center.x - (view.bounds.size.width / 2),
+    .y = view.center.y - (view.bounds.size.height / 2),
+  } : CGPointZero;
+
+  CGFloat x = topLeft.x + origin.x;
+  CGFloat y = topLeft.y + origin.y;
+  CGFloat width = bottomRight.x - topLeft.x;
+  CGFloat height = bottomRight.y - topLeft.y;
+
+  view.center = (CGPoint) {
+    .x = YGRoundPixelValue(x + (width / 2)),
+    .y = YGRoundPixelValue(y + (height / 2)),
+  };
+
+  view.bounds = (CGRect) {
+    .origin = CGPointZero,
     .size = {
-      .width = YGRoundPixelValue(bottomRight.x) - YGRoundPixelValue(topLeft.x),
-      .height = YGRoundPixelValue(bottomRight.y) - YGRoundPixelValue(topLeft.y),
+      .width = YGRoundPixelValue(width),
+      .height = YGRoundPixelValue(height),
     },
   };
 


### PR DESCRIPTION
Currently YogaKit sets UIView's `frame` property directly, which is actually a computed property. This works fine when the `UIView` doesnt have a `transform` property set, but when it does then UIKit will invert the transform, set the center/bounds then reapply the transform in such a way that the transformed view's frame will be the frame that was set. This is not usually what you want... you usually want to set the frame of the non-transformed view, and then apply the transform on that frame without affecting layout.

I believe this will improve performance since `bounds` and `center` are not calculated properties, but I have not measured/verified.

For people not using transforms, this should be a non-breaking change. If someone is using transforms with YogaKit, this may change the behavior, although I would argue this will produce the expected results (ie, transforms not being affected/altered by layout).