### PR TITLE
Set data for YogaLayout child in case of removed by its parent before

### DIFF
--- a/android/src/main/java/com/facebook/yoga/android/YogaLayout.java
+++ b/android/src/main/java/com/facebook/yoga/android/YogaLayout.java
@@ -164,7 +164,9 @@ public class YogaLayout extends ViewGroup {
       } else {
         childNode = new YogaNode();
       }
+    }
 
+    if (childNode != null) {
       childNode.setData(child);
       childNode.setMeasureFunction(new ViewMeasureFunction());
     }


### PR DESCRIPTION
Set data for YogaLayout child in case of removed by its parent before and will never have a chance to set data automatically again, or it needs to set data by itself manually. It may cause incorrect layout in {@code applyLayoutRecursive} accidentally.