### PR TITLE
Fixed rounding issues with YGRoundValueToPixelGrid and negative floats

### DIFF
--- a/tests/YGRoundingFunctionTest.cpp
+++ b/tests/YGRoundingFunctionTest.cpp
@@ -20,6 +20,14 @@ TEST(YogaTest, rounding_value) {
   ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(5.999999, 2.0, true, false));
   ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(5.999999, 2.0, false, true));
 
+  // Test with negative numbers
+  ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-6.000001, 2.0, false, false));
+  ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-6.000001, 2.0, true, false));
+  ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-6.000001, 2.0, false, true));
+  ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-5.999999, 2.0, false, false));
+  ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-5.999999, 2.0, true, false));
+  ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-5.999999, 2.0, false, true));
+
   // Test that numbers with fraction are rounded correctly accounting for ceil/floor flags
   ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(6.01, 2.0, false, false));
   ASSERT_FLOAT_EQ(6.5, YGRoundValueToPixelGrid(6.01, 2.0, true, false));
@@ -27,4 +35,45 @@ TEST(YogaTest, rounding_value) {
   ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(5.99, 2.0, false, false));
   ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(5.99, 2.0, true, false));
   ASSERT_FLOAT_EQ(5.5, YGRoundValueToPixelGrid(5.99, 2.0, false, true));
+  ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(6.49, 1.0, false, false));
+  ASSERT_FLOAT_EQ(7.0, YGRoundValueToPixelGrid(6.50, 1.0, false, false));
+  ASSERT_FLOAT_EQ(7.0, YGRoundValueToPixelGrid(6.51, 1.0, false, false));
+  ASSERT_FLOAT_EQ(7.0, YGRoundValueToPixelGrid(6.50, 1.0, true, false));
+  ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(6.50, 1.0, false, true));
+
+  // Test with negative numbers
+  ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-6.01, 2.0, false, false));
+  ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-6.01, 2.0, true, false));
+  ASSERT_FLOAT_EQ(-6.5, YGRoundValueToPixelGrid(-6.01, 2.0, false, true));
+  ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-5.99, 2.0, false, false));
+  ASSERT_FLOAT_EQ(-5.5, YGRoundValueToPixelGrid(-5.99, 2.0, true, false));
+  ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-5.99, 2.0, false, true));
+  ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-6.49, 1.0, false, false));
+  ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-6.50, 1.0, false, false));
+  ASSERT_FLOAT_EQ(-7.0, YGRoundValueToPixelGrid(-6.51, 1.0, false, false));
+  ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-6.50, 1.0, true, false));
+  ASSERT_FLOAT_EQ(-7.0, YGRoundValueToPixelGrid(-6.50, 1.0, false, true));
+
+  // Do a simple translation test to ensure that a distance between 2 values
+  // stays consistent during an animation, even after rounding them.
+  const int LAPS = 3;
+  const int LAP_CLOSEST = 0;
+  const int LAP_CEIL = 1;
+  const int LAP_FLOOR = 2;
+  for (int currentLap = LAP_CLOSEST; currentLap < LAPS; ++currentLap)
+  {
+    float left = -2.0f;
+    float right = 2.0f;
+    const float distance = right-left;
+    float totalDistance = 1.1f;
+    const float step = 0.01f;
+    while (totalDistance >= 0.0f) {
+      left += step;
+      right += step;
+      const float snappedLeft = YGRoundValueToPixelGrid(left, 1.0, currentLap==LAP_CEIL, currentLap==LAP_FLOOR);
+      const float snappedRight = YGRoundValueToPixelGrid(right, 1.0, currentLap==LAP_CEIL, currentLap==LAP_FLOOR);
+      ASSERT_FLOAT_EQ(distance, (snappedRight-snappedLeft));
+      totalDistance -= step;
+    }
+  }
 }


### PR DESCRIPTION
While implementing Yoga into a custom framework I found out that sizes of objects that had been layout with Yoga were sometimes 1px smaller/bigger than expected, causing all sorts of unexpected logic to trigger.

Turns out the culprit was YGRoundValueToPixelGrid.

It was computing values regardless of sign and thus negative inputs were outputting unexpected results (eg. if scaledValue == -0.6f closest rounding should be -1.0f but would be 0.0f instead).

I have updated the code to handle positive and negative values symmetrically in order to ensure that two values with a same offset between them will conserve the offset during animations regardless of the rounding type.

Please check the test cases to confirm the logic.