### PR TITLE
Fix use of free() when deleting YGNode

### DIFF
--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -256,7 +256,7 @@ void YGNodeFree(const YGNodeRef node) {
   }
 
   node->clearChildren();
-  free(node);
+  delete node;
   gNodeInstanceCount--;
 }
 


### PR DESCRIPTION
Nodes are allocated using operator new, but released using free() instead of operator delete.