### PR TITLE
solves the Android pixel bug

### DIFF
--- a/android/src/main/java/com/facebook/yoga/android/YogaLayout.java
+++ b/android/src/main/java/com/facebook/yoga/android/YogaLayout.java
@@ -293,6 +293,8 @@ public class YogaLayout extends ViewGroup {
       if (view.getVisibility() == GONE) {
         return;
       }
+      int left = Math.round(xOffset + node.getLayoutX());
+      int top = Math.round(yOffset + node.getLayoutY());
       view.measure(
           View.MeasureSpec.makeMeasureSpec(
               Math.round(node.getLayoutWidth()),
@@ -301,10 +303,10 @@ public class YogaLayout extends ViewGroup {
               Math.round(node.getLayoutHeight()),
               View.MeasureSpec.EXACTLY));
       view.layout(
-          Math.round(xOffset + node.getLayoutX()),
-          Math.round(yOffset + node.getLayoutY()),
-          Math.round(xOffset + node.getLayoutX() + node.getLayoutWidth()),
-          Math.round(yOffset + node.getLayoutY() + node.getLayoutHeight()));
+          left,
+          top,
+          left + view.getMeasuredWidth(),
+          top + view.getMeasuredHeight());
     }
 
     final int childrenCount = node.getChildCount();


### PR DESCRIPTION
@emilsjolander hi,
this PR solves the following common and probable layout pixel scenario:
the older code is presented for reference:

```java
view.measure(
    View.MeasureSpec.makeMeasureSpec(
        Math.round(node.getLayoutWidth()),
        View.MeasureSpec.EXACTLY),
    View.MeasureSpec.makeMeasureSpec(
        Math.round(node.getLayoutHeight()),
        View.MeasureSpec.EXACTLY));
view.layout(
    Math.round(xOffset + node.getLayoutX()),
    Math.round(yOffset + node.getLayoutY()),
    Math.round(xOffset + node.getLayoutX() + node.getLayoutWidth()),
    Math.round(yOffset + node.getLayoutY() + node.getLayoutHeight()));

```

suppose now the following:
- `xOffset + node.getLayoutX() = 2.2`
- `node.getLayoutWidth() = 0.4` ==> `Math.round(node.getLayoutWidth()) = 0`
- `Math.round(xOffset + node.getLayoutX() + node.getLayoutWidth()) = Math.round(2.2 + 0.4) = 3`

this induces, the following measurements:
```java
view.measure(
    View.MeasureSpec.makeMeasureSpec(
        0,
        View.MeasureSpec.EXACTLY),
    View.MeasureSpec.makeMeasureSpec(
        Math.round(node.getLayoutHeight()),
        View.MeasureSpec.EXACTLY));
view.layout(
    2,
    Math.round(yOffset + node.getLayoutY()),
    3,
    Math.round(yOffset + node.getLayoutY() + node.getLayoutHeight()));

```

the width measurement of the view is 0, while the layout is `(3 - 2 = 1)`.  
my proposed solution is to measure the view the way it is now, but when layouting
I use the `#getMeasuredWidth/Height()` methods, this will stop this problem
from happening.  

I also want to note that this bug happens with high probability.