### PR TITLE
Fix main size calculation from the aspect ratio

### DIFF
--- a/tests/YGAspectRatioTest.cpp
+++ b/tests/YGAspectRatioTest.cpp
@@ -781,6 +781,31 @@ TEST(YogaTest, aspect_ratio_defined_cross_with_margin) {
   YGNodeFreeRecursive(root);
 }
 
+TEST(YogaTest, aspect_ratio_defined_cross_with_main_margin) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetAspectRatio(root_child0, 1);
+  YGNodeStyleSetMargin(root_child0, YGEdgeTop, 10);
+  YGNodeStyleSetMargin(root_child0, YGEdgeBottom, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+}
+
 TEST(YogaTest, aspect_ratio_should_prefer_explicit_height) {
   const YGConfigRef config = YGConfigNew();
   YGConfigSetUseWebDefaults(config, true);

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -1076,10 +1076,11 @@ static void YGNodeComputeFlexBasisForChild(const YGNodeRef node,
 
     if (!YGFloatIsUndefined(child->getStyle().aspectRatio)) {
       if (!isMainAxisRow && childWidthMeasureMode == YGMeasureModeExactly) {
-        childHeight = (childWidth - marginRow) / child->getStyle().aspectRatio;
+        childHeight = marginColumn +
+            (childWidth - marginRow) / child->getStyle().aspectRatio;
         childHeightMeasureMode = YGMeasureModeExactly;
       } else if (isMainAxisRow && childHeightMeasureMode == YGMeasureModeExactly) {
-        childWidth =
+        childWidth = marginRow +
             (childHeight - marginColumn) * child->getStyle().aspectRatio;
         childWidthMeasureMode = YGMeasureModeExactly;
       }


### PR DESCRIPTION
When the following conditions are met, the main size become smaller by the margins in the main axis.
* The aspect ratio is defined
* The main size is not defined
* The cross size is defined
* The main margin is defined

This is because the main margin size is not included when calculating the main size from the aspect ratio. 