### PR TITLE
Fixed min-max docs typo

### DIFF
--- a/website/contents/properties/min-max.md
+++ b/website/contents/properties/min-max.md
@@ -23,6 +23,6 @@ parent's size. By default all these constraints are `undefined`.
 
 <controls prop="maxHeight"></controls>
 
-### Min Width
+### Min Height
 
 <controls prop="minHeight"></controls>


### PR DESCRIPTION
Fixed `Max / Min Width and Height` docs typo.