### PR TITLE
Update pod spec to 1.8.0, set explicit public header files

### DIFF
--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -25,4 +25,5 @@ Pod::Spec.new do |spec|
       '-fPIC'
   ]
   spec.source_files = 'yoga/**/*.{c,h,cpp}'
+  spec.public_header_files = 'yoga/{Yoga,YGEnums,YGMacros}.h'
 end

--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'Yoga'
-  spec.version = '1.7.0'
+  spec.version = '1.8.0'
   spec.license =  { :type => 'MIT', :file => "LICENSE" }
   spec.homepage = 'https://facebook.github.io/yoga/'
   spec.documentation_url = 'https://facebook.github.io/yoga/docs/api/c/'
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
   spec.authors = 'Facebook'
   spec.source = {
     :git => 'https://github.com/facebook/yoga.git',
-    :tag => '1.7.0',
+    :tag => '1.8.0',
   }
 
   spec.module_name = 'yoga'

--- a/YogaKit.podspec
+++ b/YogaKit.podspec
@@ -1,6 +1,6 @@
 podspec = Pod::Spec.new do |spec|
   spec.name = 'YogaKit'
-  spec.version = '1.7.0'
+  spec.version = '1.8.0'
   spec.license =  { :type => 'MIT', :file => "LICENSE" }
   spec.homepage = 'https://facebook.github.io/yoga/'
   spec.documentation_url = 'https://facebook.github.io/yoga/docs/api/yogakit/'
@@ -11,14 +11,14 @@ podspec = Pod::Spec.new do |spec|
   spec.authors = 'Facebook'
   spec.source = {
     :git => 'https://github.com/facebook/yoga.git',
-    :tag => '1.7.0',
+    :tag => '1.8.0',
   }
 
   spec.platform = :ios
   spec.ios.deployment_target = '8.0'
   spec.ios.frameworks = 'UIKit'
 
-  spec.dependency 'Yoga', '~> 1.7'
+  spec.dependency 'Yoga', '~> 1.8'
   spec.source_files = 'YogaKit/Source/*.{h,m,swift}'
   spec.public_header_files = 'YogaKit/Source/{YGLayout,UIView+Yoga}.h'
   spec.private_header_files = 'YogaKit/Source/YGLayout+Private.h'


### PR DESCRIPTION
- Update pod specs to version 1.8.0 (most recent tag)
- Mark `Yoga.h`, `YGEnums.h`, and `YGMacros.h` as public headers