### PR TITLE
expose flex property to YogaKit

### DIFF
--- a/YogaKit/Source/YGLayout.h
+++ b/YogaKit/Source/YGLayout.h
@@ -56,6 +56,7 @@ typedef NS_OPTIONS(NSInteger, YGDimensionFlexibility) {
 @property (nonatomic, readwrite, assign) YGOverflow overflow;
 @property (nonatomic, readwrite, assign) YGDisplay display;
 
+@property (nonatomic, readwrite, assign) CGFloat flex;
 @property (nonatomic, readwrite, assign) CGFloat flexGrow;
 @property (nonatomic, readwrite, assign) CGFloat flexShrink;
 @property (nonatomic, readwrite, assign) YGValue flexBasis;

--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -227,6 +227,7 @@ YG_PROPERTY(YGWrap, flexWrap, FlexWrap)
 YG_PROPERTY(YGOverflow, overflow, Overflow)
 YG_PROPERTY(YGDisplay, display, Display)
 
+YG_PROPERTY(CGFloat, flex, Flex)
 YG_PROPERTY(CGFloat, flexGrow, FlexGrow)
 YG_PROPERTY(CGFloat, flexShrink, FlexShrink)
 YG_AUTO_VALUE_PROPERTY(flexBasis, FlexBasis)


### PR DESCRIPTION
This exposes `yoga` property to `YogaKit`.

The reason why I need the property is demonstrated in https://github.com/axl411/TestYogaKit