### PR TITLE
Fix minor grammar issue on documentation index page

### DIFF
--- a/website/src/pages/docs/index.js
+++ b/website/src/pages/docs/index.js
@@ -33,8 +33,8 @@ export default ({data}) => (
             documentation covering all the features of the library. Each page
             comes with an interactive playground for you to explore that
             feature. The examples section showcases some of the most common
-            layouts and how to build them. This is a community projects and
-            contributions within documentation, code, and tests are more then
+            layouts and how to build them. This is a community project and
+            contributions within documentation, code, and tests are more than
             welcome. The contributing section below covers how to get started.
           </p>
         </Col>


### PR DESCRIPTION
I noticed these and figured I'd open a quick PR.