### PR TITLE
Fix float type mismatch on endOfLineIndex and inside rounding

### DIFF
--- a/yoga/Utils.h
+++ b/yoga/Utils.h
@@ -40,7 +40,7 @@ struct YGCollectFlexItemsRowValues {
   float sizeConsumedOnCurrentLine;
   float totalFlexGrowFactors;
   float totalFlexShrinkScaledFactors;
-  float endOfLineIndex;
+  uint32_t endOfLineIndex;
   std::vector<YGNodeRef> relativeChildren;
   float remainingFreeSpace;
   // The size of the mainDim for the row after considering size, padding, margin

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -3346,12 +3346,12 @@ float YGRoundValueToPixelGrid(const float value,
                               const bool forceCeil,
                               const bool forceFloor) {
   float scaledValue = value * pointScaleFactor;
-  float fractial = fmodf(scaledValue, 1.0);
+  float fractial = fmodf(scaledValue, 1.0f);
   if (YGFloatsEqual(fractial, 0)) {
     // First we check if the value is already rounded
     scaledValue = scaledValue - fractial;
-  } else if (YGFloatsEqual(fractial, 1.0)) {
-    scaledValue = scaledValue - fractial + 1.0;
+  } else if (YGFloatsEqual(fractial, 1.0f)) {
+    scaledValue = scaledValue - fractial + 1.0f;
   } else if (forceCeil) {
     // Next we check if we need to use forced rounding
     scaledValue = scaledValue - fractial + 1.0f;


### PR DESCRIPTION
This PR fixes a type mismatch on `endOfLineIndex` where it should be of type `uint32_t` while it is of type `float`

Additonally it fixes some `double` casting in the rounding methods.