### PR TITLE
Fix compilation on MSVC by moving YGConfig to C++

### DIFF
--- a/csharp/Yoga/Yoga.vcxproj
+++ b/csharp/Yoga/Yoga.vcxproj
@@ -227,19 +227,31 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\yoga\Yoga.h" />
+    <ClInclude Include="..\..\yoga\Utils.h" />
+    <ClInclude Include="..\..\yoga\YGConfig.h" />
     <ClInclude Include="..\..\yoga\YGEnums.h" />
+    <ClInclude Include="..\..\yoga\YGFloatOptional.h" />
+    <ClInclude Include="..\..\yoga\YGLayout.h" />
     <ClInclude Include="..\..\yoga\YGMacros.h" />
-    <ClInclude Include="..\..\yoga\YGNodeList.h" />
+    <ClInclude Include="..\..\yoga\YGNode.h" />
+    <ClInclude Include="..\..\yoga\YGNodePrint.h" />
+    <ClInclude Include="..\..\yoga\YGStyle.h" />
+    <ClInclude Include="..\..\yoga\Yoga-internal.h" />
+    <ClInclude Include="..\..\yoga\Yoga.h" />
     <ClInclude Include="resource.h" />
-    <ClInclude Include="YGInterop.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\yoga\Yoga.c" />
-    <ClCompile Include="..\..\yoga\YGEnums.c" />
-    <ClCompile Include="..\..\yoga\YGNodeList.c" />
+    <ClCompile Include="..\..\yoga\Utils.cpp" />
+    <ClCompile Include="..\..\yoga\YGConfig.cpp" />
+    <ClCompile Include="..\..\yoga\YGEnums.cpp" />
+    <ClCompile Include="..\..\yoga\YGFloatOptional.cpp" />
+    <ClCompile Include="..\..\yoga\YGLayout.cpp" />
+    <ClCompile Include="..\..\yoga\YGNode.cpp" />
+    <ClCompile Include="..\..\yoga\YGNodePrint.cpp" />
+    <ClCompile Include="..\..\yoga\YGStyle.cpp" />
+    <ClCompile Include="..\..\yoga\Yoga.cpp" />
     <ClCompile Include="YGInterop.cpp" />
     <ClCompile Include="dllmain.cpp">
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsManaged>

--- a/csharp/Yoga/Yoga.vcxproj.filters
+++ b/csharp/Yoga/Yoga.vcxproj.filters
@@ -21,19 +21,40 @@
     <ClInclude Include="targetver.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\yoga\Yoga.h">
+    <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\yoga\Utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\yoga\YGEnums.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\yoga\YGFloatOptional.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\yoga\YGLayout.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\yoga\YGMacros.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\yoga\YGNodeList.h">
+    <ClInclude Include="..\..\yoga\YGNode.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="YGInterop.h">
+    <ClInclude Include="..\..\yoga\YGNodePrint.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="resource.h">
+    <ClInclude Include="..\..\yoga\YGStyle.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\yoga\Yoga.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\yoga\Yoga-internal.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\yoga\YGConfig.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -44,13 +65,34 @@
     <ClCompile Include="dllmain.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\yoga\Yoga.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\yoga\YGNodeList.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="YGInterop.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\yoga\Utils.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\yoga\YGEnums.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\yoga\YGFloatOptional.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\yoga\YGLayout.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\yoga\YGNode.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\yoga\YGNodePrint.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\yoga\YGStyle.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\yoga\Yoga.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\yoga\YGConfig.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/yoga/YGConfig.cpp
+++ b/yoga/YGConfig.cpp
@@ -1,0 +1,23 @@
+
+/**
+* Copyright (c) 2014-present, Facebook, Inc.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+#pragma once
+#include "YGConfig.h"
+
+const std::array<bool, YGExperimentalFeatureCount>
+    kYGDefaultExperimentalFeatures = {{false}};
+
+YGConfig::YGConfig(YGLogger logger)
+    : useWebDefaults(false),
+      experimentalFeatures(kYGDefaultExperimentalFeatures),
+      useLegacyStretchBehaviour(false),
+      shouldDiffLayoutWithoutLegacyStretchBehaviour(false),
+      pointScaleFactor(1.0f), logger(logger), cloneNodeCallback(nullptr),
+      context(nullptr) {}
+
+YGConfig::~YGConfig() {}

--- a/yoga/YGConfig.h
+++ b/yoga/YGConfig.h
@@ -1,0 +1,24 @@
+/**
+* Copyright (c) 2014-present, Facebook, Inc.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+#pragma once
+#include "Yoga-internal.h"
+#include "Yoga.h"
+
+struct YGConfig {
+  std::array<bool, YGExperimentalFeatureCount> experimentalFeatures;
+  bool useWebDefaults;
+  bool useLegacyStretchBehaviour;
+  bool shouldDiffLayoutWithoutLegacyStretchBehaviour;
+  float pointScaleFactor;
+  YGLogger logger;
+  YGCloneNodeFunc cloneNodeCallback;
+  void *context;
+
+  YGConfig(YGLogger logger);
+  ~YGConfig();
+};

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include "YGLayout.h"
 #include "YGStyle.h"
+#include "YGConfig.h"
 #include "Yoga-internal.h"
 
 struct YGNode {

--- a/yoga/Yoga-internal.h
+++ b/yoga/Yoga-internal.h
@@ -87,16 +87,6 @@ struct YGCachedMeasurement {
 // layouts should not require more than 16 entries to fit within the cache.
 #define YG_MAX_CACHED_RESULT_COUNT 16
 
-struct YGConfig {
-  bool experimentalFeatures[YGExperimentalFeatureCount + 1];
-  bool useWebDefaults;
-  bool useLegacyStretchBehaviour;
-  bool shouldDiffLayoutWithoutLegacyStretchBehaviour;
-  float pointScaleFactor;
-  YGLogger logger;
-  YGCloneNodeFunc cloneNodeCallback;
-  void* context;
-};
 
 static const float kDefaultFlexGrow = 0.0f;
 static const float kDefaultFlexShrink = 0.0f;


### PR DESCRIPTION
This PR fixes the compilation on MSVC. I moved the `YGConfig` creation to a C++ constructor. 

Addionally it removes the "dot" notation on `YGValue`, I didn't want to change that type to a C++ constructor, because I think this will break the ABI.