### PR TITLE
Use delete instead of free in YGConfigFree

### DIFF
--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -361,7 +361,7 @@ YGConfigRef YGConfigNew(void) {
 }
 
 void YGConfigFree(const YGConfigRef config) {
-  free(config);
+  delete config;
   gConfigInstanceCount--;
 }
 


### PR DESCRIPTION
Since a `YGConfigRef` is created with `new`, it needs to be deleted using `delete` instead of `free`. Related to https://github.com/facebook/yoga/pull/705.