### PR TITLE
Fix the height of node which contains baseline items

### DIFF
--- a/csharp/tests/Facebook.Yoga/YGAlignItemsTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGAlignItemsTest.cs
@@ -1234,6 +1234,766 @@ namespace Facebook.Yoga
         }
 
         [Test]
+        public void Test_align_baseline_without_root_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignItems = YogaAlign.Baseline;
+            root.Width = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 50;
+            root_child0.Height = 50;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.Width = 50;
+            root_child1.Height = 20;
+            root.Insert(1, root_child1);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(50f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child1.LayoutX);
+            Assert.AreEqual(30f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(50f, root.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(30f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_baseline_child_multiline_without_root_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignItems = YogaAlign.Baseline;
+            root.Width = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 50;
+            root_child0.Height = 60;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.FlexDirection = YogaFlexDirection.Row;
+            root_child1.Wrap = YogaWrap.Wrap;
+            root_child1.Width = 50;
+            root_child1.Height = 25;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child1_child0 = new YogaNode(config);
+            root_child1_child0.Width = 25;
+            root_child1_child0.Height = 20;
+            root_child1.Insert(0, root_child1_child0);
+
+            YogaNode root_child1_child1 = new YogaNode(config);
+            root_child1_child1.Width = 25;
+            root_child1_child1.Height = 10;
+            root_child1.Insert(1, root_child1_child1);
+
+            YogaNode root_child1_child2 = new YogaNode(config);
+            root_child1_child2.Width = 25;
+            root_child1_child2.Height = 20;
+            root_child1.Insert(2, root_child1_child2);
+
+            YogaNode root_child1_child3 = new YogaNode(config);
+            root_child1_child3.Width = 25;
+            root_child1_child3.Height = 10;
+            root_child1.Insert(3, root_child1_child3);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(65f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(60f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child1.LayoutX);
+            Assert.AreEqual(40f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(25f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(25f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(20f, root_child1_child0.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child1_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1_child1.LayoutY);
+            Assert.AreEqual(25f, root_child1_child1.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child2.LayoutX);
+            Assert.AreEqual(20f, root_child1_child2.LayoutY);
+            Assert.AreEqual(25f, root_child1_child2.LayoutWidth);
+            Assert.AreEqual(20f, root_child1_child2.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child1_child3.LayoutX);
+            Assert.AreEqual(20f, root_child1_child3.LayoutY);
+            Assert.AreEqual(25f, root_child1_child3.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child3.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(65f, root.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(60f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(40f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(25f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(25f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(20f, root_child1_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1_child1.LayoutY);
+            Assert.AreEqual(25f, root_child1_child1.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child1.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child1_child2.LayoutX);
+            Assert.AreEqual(20f, root_child1_child2.LayoutY);
+            Assert.AreEqual(25f, root_child1_child2.LayoutWidth);
+            Assert.AreEqual(20f, root_child1_child2.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child3.LayoutX);
+            Assert.AreEqual(20f, root_child1_child3.LayoutY);
+            Assert.AreEqual(25f, root_child1_child3.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child3.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_baseline_child_multiline_override_without_root_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignItems = YogaAlign.Baseline;
+            root.Width = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 50;
+            root_child0.Height = 60;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.FlexDirection = YogaFlexDirection.Row;
+            root_child1.Wrap = YogaWrap.Wrap;
+            root_child1.Width = 50;
+            root_child1.Height = 25;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child1_child0 = new YogaNode(config);
+            root_child1_child0.Width = 25;
+            root_child1_child0.Height = 20;
+            root_child1.Insert(0, root_child1_child0);
+
+            YogaNode root_child1_child1 = new YogaNode(config);
+            root_child1_child1.AlignSelf = YogaAlign.Baseline;
+            root_child1_child1.Width = 25;
+            root_child1_child1.Height = 10;
+            root_child1.Insert(1, root_child1_child1);
+
+            YogaNode root_child1_child2 = new YogaNode(config);
+            root_child1_child2.Width = 25;
+            root_child1_child2.Height = 20;
+            root_child1.Insert(2, root_child1_child2);
+
+            YogaNode root_child1_child3 = new YogaNode(config);
+            root_child1_child3.AlignSelf = YogaAlign.Baseline;
+            root_child1_child3.Width = 25;
+            root_child1_child3.Height = 10;
+            root_child1.Insert(3, root_child1_child3);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(75f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(60f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child1.LayoutX);
+            Assert.AreEqual(50f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(25f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(25f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(20f, root_child1_child0.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child1_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1_child1.LayoutY);
+            Assert.AreEqual(25f, root_child1_child1.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child2.LayoutX);
+            Assert.AreEqual(20f, root_child1_child2.LayoutY);
+            Assert.AreEqual(25f, root_child1_child2.LayoutWidth);
+            Assert.AreEqual(20f, root_child1_child2.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child1_child3.LayoutX);
+            Assert.AreEqual(20f, root_child1_child3.LayoutY);
+            Assert.AreEqual(25f, root_child1_child3.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child3.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(75f, root.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(60f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(50f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(25f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(25f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(20f, root_child1_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1_child1.LayoutY);
+            Assert.AreEqual(25f, root_child1_child1.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child1.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child1_child2.LayoutX);
+            Assert.AreEqual(20f, root_child1_child2.LayoutY);
+            Assert.AreEqual(25f, root_child1_child2.LayoutWidth);
+            Assert.AreEqual(20f, root_child1_child2.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child3.LayoutX);
+            Assert.AreEqual(20f, root_child1_child3.LayoutY);
+            Assert.AreEqual(25f, root_child1_child3.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child3.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_baseline_child_multiline_no_override_on_secondline_without_root_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignItems = YogaAlign.Baseline;
+            root.Width = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 50;
+            root_child0.Height = 60;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.FlexDirection = YogaFlexDirection.Row;
+            root_child1.Wrap = YogaWrap.Wrap;
+            root_child1.Width = 50;
+            root_child1.Height = 25;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child1_child0 = new YogaNode(config);
+            root_child1_child0.Width = 25;
+            root_child1_child0.Height = 20;
+            root_child1.Insert(0, root_child1_child0);
+
+            YogaNode root_child1_child1 = new YogaNode(config);
+            root_child1_child1.Width = 25;
+            root_child1_child1.Height = 10;
+            root_child1.Insert(1, root_child1_child1);
+
+            YogaNode root_child1_child2 = new YogaNode(config);
+            root_child1_child2.Width = 25;
+            root_child1_child2.Height = 20;
+            root_child1.Insert(2, root_child1_child2);
+
+            YogaNode root_child1_child3 = new YogaNode(config);
+            root_child1_child3.AlignSelf = YogaAlign.Baseline;
+            root_child1_child3.Width = 25;
+            root_child1_child3.Height = 10;
+            root_child1.Insert(3, root_child1_child3);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(65f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(60f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child1.LayoutX);
+            Assert.AreEqual(40f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(25f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(25f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(20f, root_child1_child0.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child1_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1_child1.LayoutY);
+            Assert.AreEqual(25f, root_child1_child1.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child2.LayoutX);
+            Assert.AreEqual(20f, root_child1_child2.LayoutY);
+            Assert.AreEqual(25f, root_child1_child2.LayoutWidth);
+            Assert.AreEqual(20f, root_child1_child2.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child1_child3.LayoutX);
+            Assert.AreEqual(20f, root_child1_child3.LayoutY);
+            Assert.AreEqual(25f, root_child1_child3.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child3.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(65f, root.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(60f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(40f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(25f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(25f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(20f, root_child1_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1_child1.LayoutY);
+            Assert.AreEqual(25f, root_child1_child1.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child1.LayoutHeight);
+
+            Assert.AreEqual(25f, root_child1_child2.LayoutX);
+            Assert.AreEqual(20f, root_child1_child2.LayoutY);
+            Assert.AreEqual(25f, root_child1_child2.LayoutWidth);
+            Assert.AreEqual(20f, root_child1_child2.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child3.LayoutX);
+            Assert.AreEqual(20f, root_child1_child3.LayoutY);
+            Assert.AreEqual(25f, root_child1_child3.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child3.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_baseline_child_top_without_root_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignItems = YogaAlign.Baseline;
+            root.Width = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Top = 10;
+            root_child0.Width = 50;
+            root_child0.Height = 50;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.Width = 50;
+            root_child1.Height = 20;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child1_child0 = new YogaNode(config);
+            root_child1_child0.Width = 50;
+            root_child1_child0.Height = 10;
+            root_child1.Insert(0, root_child1_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(60f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(10f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child1.LayoutX);
+            Assert.AreEqual(40f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(60f, root.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child0.LayoutX);
+            Assert.AreEqual(10f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(40f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_baseline_child_margin_without_root_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignItems = YogaAlign.Baseline;
+            root.Width = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.MarginLeft = 5;
+            root_child0.MarginTop = 5;
+            root_child0.MarginRight = 5;
+            root_child0.MarginBottom = 5;
+            root_child0.Width = 50;
+            root_child0.Height = 50;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.Width = 50;
+            root_child1.Height = 20;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child1_child0 = new YogaNode(config);
+            root_child1_child0.MarginLeft = 1;
+            root_child1_child0.MarginTop = 1;
+            root_child1_child0.MarginRight = 1;
+            root_child1_child0.MarginBottom = 1;
+            root_child1_child0.Width = 50;
+            root_child1_child0.Height = 10;
+            root_child1.Insert(0, root_child1_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(64f, root.LayoutHeight);
+
+            Assert.AreEqual(5f, root_child0.LayoutX);
+            Assert.AreEqual(5f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(60f, root_child1.LayoutX);
+            Assert.AreEqual(44f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(1f, root_child1_child0.LayoutX);
+            Assert.AreEqual(1f, root_child1_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(64f, root.LayoutHeight);
+
+            Assert.AreEqual(45f, root_child0.LayoutX);
+            Assert.AreEqual(5f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(-10f, root_child1.LayoutX);
+            Assert.AreEqual(44f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(-1f, root_child1_child0.LayoutX);
+            Assert.AreEqual(1f, root_child1_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_baseline_child_padding_without_root_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignItems = YogaAlign.Baseline;
+            root.PaddingLeft = 5;
+            root.PaddingTop = 5;
+            root.PaddingRight = 5;
+            root.PaddingBottom = 5;
+            root.Width = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 50;
+            root_child0.Height = 50;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.PaddingLeft = 5;
+            root_child1.PaddingTop = 5;
+            root_child1.PaddingRight = 5;
+            root_child1.PaddingBottom = 5;
+            root_child1.Width = 50;
+            root_child1.Height = 20;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child1_child0 = new YogaNode(config);
+            root_child1_child0.Width = 50;
+            root_child1_child0.Height = 10;
+            root_child1.Insert(0, root_child1_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(65f, root.LayoutHeight);
+
+            Assert.AreEqual(5f, root_child0.LayoutX);
+            Assert.AreEqual(5f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(55f, root_child1.LayoutX);
+            Assert.AreEqual(40f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(5f, root_child1_child0.LayoutX);
+            Assert.AreEqual(5f, root_child1_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(65f, root.LayoutHeight);
+
+            Assert.AreEqual(45f, root_child0.LayoutX);
+            Assert.AreEqual(5f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(-5f, root_child1.LayoutX);
+            Assert.AreEqual(40f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(-5f, root_child1_child0.LayoutX);
+            Assert.AreEqual(5f, root_child1_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_baseline_multiline_without_root_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignItems = YogaAlign.Baseline;
+            root.Wrap = YogaWrap.Wrap;
+            root.Width = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 50;
+            root_child0.Height = 50;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.Width = 50;
+            root_child1.Height = 20;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child1_child0 = new YogaNode(config);
+            root_child1_child0.Width = 50;
+            root_child1_child0.Height = 10;
+            root_child1.Insert(0, root_child1_child0);
+
+            YogaNode root_child2 = new YogaNode(config);
+            root_child2.Width = 50;
+            root_child2.Height = 20;
+            root.Insert(2, root_child2);
+
+            YogaNode root_child2_child0 = new YogaNode(config);
+            root_child2_child0.Width = 50;
+            root_child2_child0.Height = 10;
+            root_child2.Insert(0, root_child2_child0);
+
+            YogaNode root_child3 = new YogaNode(config);
+            root_child3.Width = 50;
+            root_child3.Height = 50;
+            root.Insert(3, root_child3);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(120f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child1.LayoutX);
+            Assert.AreEqual(40f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child2.LayoutX);
+            Assert.AreEqual(100f, root_child2.LayoutY);
+            Assert.AreEqual(50f, root_child2.LayoutWidth);
+            Assert.AreEqual(20f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child2_child0.LayoutX);
+            Assert.AreEqual(0f, root_child2_child0.LayoutY);
+            Assert.AreEqual(50f, root_child2_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child2_child0.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child3.LayoutX);
+            Assert.AreEqual(60f, root_child3.LayoutY);
+            Assert.AreEqual(50f, root_child3.LayoutWidth);
+            Assert.AreEqual(50f, root_child3.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(120f, root.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(40f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child0.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child2.LayoutX);
+            Assert.AreEqual(100f, root_child2.LayoutY);
+            Assert.AreEqual(50f, root_child2.LayoutWidth);
+            Assert.AreEqual(20f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child2_child0.LayoutX);
+            Assert.AreEqual(0f, root_child2_child0.LayoutY);
+            Assert.AreEqual(50f, root_child2_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child2_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child3.LayoutX);
+            Assert.AreEqual(60f, root_child3.LayoutY);
+            Assert.AreEqual(50f, root_child3.LayoutWidth);
+            Assert.AreEqual(50f, root_child3.LayoutHeight);
+        }
+
+        [Test]
         public void Test_align_baseline_multiline_column()
         {
             YogaConfig config = new YogaConfig();

--- a/gentest/fixtures/YGAlignItemsTest.html
+++ b/gentest/fixtures/YGAlignItemsTest.html
@@ -111,6 +111,73 @@
   <div style="width: 50px; height: 50px;"></div>
 </div>
 
+<div id="align_baseline_without_root_height" style="width: 100px; flex-direction:row; align-items: baseline;">
+  <div style="width: 50px; height: 50px;"></div>
+  <div style="width: 50px; height: 20px;"></div>
+</div>
+
+<div id="align_baseline_child_multiline_without_root_height" style="width: 100px; flex-direction:row; align-items: baseline;">
+  <div style="width: 50px; height: 60px;"></div>
+  <div style="width: 50px; height: 25px;flex-wrap:wrap;flex-direction:row;">
+    <div style="width: 25px; height: 20px;"></div>
+    <div style="width: 25px; height: 10px;"></div>
+    <div style="width: 25px; height: 20px;"></div>
+    <div style="width: 25px; height: 10px;"></div>
+  </div>
+</div>
+
+<div id="align_baseline_child_multiline_override_without_root_height" style="width: 100px; flex-direction:row; align-items: baseline;">
+  <div style="width: 50px; height: 60px;"></div>
+  <div style="width: 50px; height: 25px;flex-wrap:wrap;flex-direction:row;">
+    <div style="width: 25px; height: 20px;"></div>
+    <div style="width: 25px; height: 10px;align-self:baseline;"></div>
+    <div style="width: 25px; height: 20px;"></div>
+    <div style="width: 25px; height: 10px;align-self:baseline;"></div>
+  </div>
+</div>
+
+<div id="align_baseline_child_multiline_no_override_on_secondline_without_root_height" style="width: 100px; flex-direction:row; align-items: baseline;">
+  <div style="width: 50px; height: 60px;"></div>
+  <div style="width: 50px; height: 25px;flex-wrap:wrap;flex-direction:row;">
+    <div style="width: 25px; height: 20px;"></div>
+    <div style="width: 25px; height: 10px;"></div>
+    <div style="width: 25px; height: 20px;"></div>
+    <div style="width: 25px; height: 10px;align-self:baseline;"></div>
+  </div>
+</div>
+
+<div id="align_baseline_child_top_without_root_height" style="width: 100px; flex-direction:row; align-items: baseline;">
+  <div style="width: 50px; height: 50px;top:10px;"></div>
+  <div style="width: 50px; height: 20px;">
+    <div style="width: 50px; height: 10px;"></div>
+  </div>
+</div>
+
+<div id="align_baseline_child_margin_without_root_height" style="width: 100px; flex-direction:row; align-items: baseline;">
+  <div style="width: 50px; height: 50px;margin: 5px;"></div>
+  <div style="width: 50px; height: 20px;">
+    <div style="width: 50px; height: 10px;margin: 1px;"></div>
+  </div>
+</div>
+
+<div id="align_baseline_child_padding_without_root_height" style="width: 100px; padding:5px; flex-direction:row; align-items: baseline;">
+  <div style="width: 50px; height: 50px;"></div>
+  <div style="width: 50px; height: 20px;padding:5px;">
+    <div style="width: 50px; height: 10px;"></div>
+  </div>
+</div>
+
+<div id="align_baseline_multiline_without_root_height" style="width: 100px; flex-direction:row; align-items: baseline;flex-wrap:wrap;">
+  <div style="width: 50px; height: 50px;"></div>
+  <div style="width: 50px; height: 20px;">
+    <div style="width: 50px; height: 10px;"></div>
+  </div>
+  <div style="width: 50px; height: 20px;">
+    <div style="width: 50px; height: 10px;"></div>
+  </div>
+  <div style="width: 50px; height: 50px;"></div>
+</div>
+
 <div id="align_baseline_multiline_column" style="width: 100px; height: 100px; flex-direction:column; align-items: baseline;flex-wrap:wrap;">
   <div style="width: 50px; height: 50px;"></div>
   <div style="width: 30px; height: 50px;">

--- a/java/tests/com/facebook/yoga/YGAlignItemsTest.java
+++ b/java/tests/com/facebook/yoga/YGAlignItemsTest.java
@@ -1217,6 +1217,758 @@ public class YGAlignItemsTest {
   }
 
   @Test
+  public void test_align_baseline_without_root_height() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignItems(YogaAlign.BASELINE);
+    root.setWidth(100f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(50f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(20f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_baseline_child_multiline_without_root_height() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignItems(YogaAlign.BASELINE);
+    root.setWidth(100f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(60f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode(config);
+    root_child1.setFlexDirection(YogaFlexDirection.ROW);
+    root_child1.setWrap(YogaWrap.WRAP);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(25f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child1_child0 = new YogaNode(config);
+    root_child1_child0.setWidth(25f);
+    root_child1_child0.setHeight(20f);
+    root_child1.addChildAt(root_child1_child0, 0);
+
+    final YogaNode root_child1_child1 = new YogaNode(config);
+    root_child1_child1.setWidth(25f);
+    root_child1_child1.setHeight(10f);
+    root_child1.addChildAt(root_child1_child1, 1);
+
+    final YogaNode root_child1_child2 = new YogaNode(config);
+    root_child1_child2.setWidth(25f);
+    root_child1_child2.setHeight(20f);
+    root_child1.addChildAt(root_child1_child2, 2);
+
+    final YogaNode root_child1_child3 = new YogaNode(config);
+    root_child1_child3.setWidth(25f);
+    root_child1_child3.setHeight(10f);
+    root_child1.addChildAt(root_child1_child3, 3);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(65f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(25f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child1_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child1.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child2.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child1_child2.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child1_child3.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child1_child3.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child3.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child3.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(65f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(25f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child1.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child1_child2.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child1_child2.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child3.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child1_child3.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child3.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child3.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_baseline_child_multiline_override_without_root_height() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignItems(YogaAlign.BASELINE);
+    root.setWidth(100f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(60f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode(config);
+    root_child1.setFlexDirection(YogaFlexDirection.ROW);
+    root_child1.setWrap(YogaWrap.WRAP);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(25f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child1_child0 = new YogaNode(config);
+    root_child1_child0.setWidth(25f);
+    root_child1_child0.setHeight(20f);
+    root_child1.addChildAt(root_child1_child0, 0);
+
+    final YogaNode root_child1_child1 = new YogaNode(config);
+    root_child1_child1.setAlignSelf(YogaAlign.BASELINE);
+    root_child1_child1.setWidth(25f);
+    root_child1_child1.setHeight(10f);
+    root_child1.addChildAt(root_child1_child1, 1);
+
+    final YogaNode root_child1_child2 = new YogaNode(config);
+    root_child1_child2.setWidth(25f);
+    root_child1_child2.setHeight(20f);
+    root_child1.addChildAt(root_child1_child2, 2);
+
+    final YogaNode root_child1_child3 = new YogaNode(config);
+    root_child1_child3.setAlignSelf(YogaAlign.BASELINE);
+    root_child1_child3.setWidth(25f);
+    root_child1_child3.setHeight(10f);
+    root_child1.addChildAt(root_child1_child3, 3);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(75f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(25f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child1_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child1.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child2.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child1_child2.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child1_child3.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child1_child3.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child3.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child3.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(75f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(25f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child1.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child1_child2.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child1_child2.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child3.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child1_child3.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child3.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child3.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_baseline_child_multiline_no_override_on_secondline_without_root_height() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignItems(YogaAlign.BASELINE);
+    root.setWidth(100f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(60f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode(config);
+    root_child1.setFlexDirection(YogaFlexDirection.ROW);
+    root_child1.setWrap(YogaWrap.WRAP);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(25f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child1_child0 = new YogaNode(config);
+    root_child1_child0.setWidth(25f);
+    root_child1_child0.setHeight(20f);
+    root_child1.addChildAt(root_child1_child0, 0);
+
+    final YogaNode root_child1_child1 = new YogaNode(config);
+    root_child1_child1.setWidth(25f);
+    root_child1_child1.setHeight(10f);
+    root_child1.addChildAt(root_child1_child1, 1);
+
+    final YogaNode root_child1_child2 = new YogaNode(config);
+    root_child1_child2.setWidth(25f);
+    root_child1_child2.setHeight(20f);
+    root_child1.addChildAt(root_child1_child2, 2);
+
+    final YogaNode root_child1_child3 = new YogaNode(config);
+    root_child1_child3.setAlignSelf(YogaAlign.BASELINE);
+    root_child1_child3.setWidth(25f);
+    root_child1_child3.setHeight(10f);
+    root_child1.addChildAt(root_child1_child3, 3);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(65f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(25f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child1_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child1.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child2.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child1_child2.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child1_child3.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child1_child3.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child3.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child3.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(65f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(25f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child1.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(25f, root_child1_child2.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child1_child2.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child3.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child1_child3.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child1_child3.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child3.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_baseline_child_top_without_root_height() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignItems(YogaAlign.BASELINE);
+    root.setWidth(100f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setPosition(YogaEdge.TOP, 10f);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(50f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(20f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child1_child0 = new YogaNode(config);
+    root_child1_child0.setWidth(50f);
+    root_child1_child0.setHeight(10f);
+    root_child1.addChildAt(root_child1_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(60f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(60f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_baseline_child_margin_without_root_height() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignItems(YogaAlign.BASELINE);
+    root.setWidth(100f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setMargin(YogaEdge.LEFT, 5f);
+    root_child0.setMargin(YogaEdge.TOP, 5f);
+    root_child0.setMargin(YogaEdge.RIGHT, 5f);
+    root_child0.setMargin(YogaEdge.BOTTOM, 5f);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(50f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(20f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child1_child0 = new YogaNode(config);
+    root_child1_child0.setMargin(YogaEdge.LEFT, 1f);
+    root_child1_child0.setMargin(YogaEdge.TOP, 1f);
+    root_child1_child0.setMargin(YogaEdge.RIGHT, 1f);
+    root_child1_child0.setMargin(YogaEdge.BOTTOM, 1f);
+    root_child1_child0.setWidth(50f);
+    root_child1_child0.setHeight(10f);
+    root_child1.addChildAt(root_child1_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(64f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(5f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(5f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(44f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(1f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(1f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(64f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(45f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(5f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(-10f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(44f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(-1f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(1f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_baseline_child_padding_without_root_height() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignItems(YogaAlign.BASELINE);
+    root.setPadding(YogaEdge.LEFT, 5);
+    root.setPadding(YogaEdge.TOP, 5);
+    root.setPadding(YogaEdge.RIGHT, 5);
+    root.setPadding(YogaEdge.BOTTOM, 5);
+    root.setWidth(100f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(50f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode(config);
+    root_child1.setPadding(YogaEdge.LEFT, 5);
+    root_child1.setPadding(YogaEdge.TOP, 5);
+    root_child1.setPadding(YogaEdge.RIGHT, 5);
+    root_child1.setPadding(YogaEdge.BOTTOM, 5);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(20f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child1_child0 = new YogaNode(config);
+    root_child1_child0.setWidth(50f);
+    root_child1_child0.setHeight(10f);
+    root_child1.addChildAt(root_child1_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(65f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(5f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(5f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(55f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(5f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(5f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(65f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(45f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(5f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(-5f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(-5f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(5f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_baseline_multiline_without_root_height() {
+    YogaConfig config = new YogaConfig();
+
+    final YogaNode root = new YogaNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignItems(YogaAlign.BASELINE);
+    root.setWrap(YogaWrap.WRAP);
+    root.setWidth(100f);
+
+    final YogaNode root_child0 = new YogaNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(50f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = new YogaNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(20f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child1_child0 = new YogaNode(config);
+    root_child1_child0.setWidth(50f);
+    root_child1_child0.setHeight(10f);
+    root_child1.addChildAt(root_child1_child0, 0);
+
+    final YogaNode root_child2 = new YogaNode(config);
+    root_child2.setWidth(50f);
+    root_child2.setHeight(20f);
+    root.addChildAt(root_child2, 2);
+
+    final YogaNode root_child2_child0 = new YogaNode(config);
+    root_child2_child0.setWidth(50f);
+    root_child2_child0.setHeight(10f);
+    root_child2.addChildAt(root_child2_child0, 0);
+
+    final YogaNode root_child3 = new YogaNode(config);
+    root_child3.setWidth(50f);
+    root_child3.setHeight(50f);
+    root.addChildAt(root_child3, 3);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child2_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child2_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child3.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child2_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child2_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child3.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
   public void test_align_baseline_multiline_column() {
     YogaConfig config = new YogaConfig();
 

--- a/javascript/tests/Facebook.Yoga/YGAlignItemsTest.js
+++ b/javascript/tests/Facebook.Yoga/YGAlignItemsTest.js
@@ -1275,6 +1275,790 @@ it("align_baseline_multiline", function () {
     config.free();
   }
 });
+it("align_baseline_without_root_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setAlignItems(Yoga.ALIGN_BASELINE);
+    root.setWidth(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(50);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(20);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(50 === root.getComputedHeight(), "50 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(50 === root_child1.getComputedLeft(), "50 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(30 === root_child1.getComputedTop(), "30 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(50 === root.getComputedHeight(), "50 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(30 === root_child1.getComputedTop(), "30 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("align_baseline_child_multiline_without_root_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setAlignItems(Yoga.ALIGN_BASELINE);
+    root.setWidth(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(60);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root_child1.setFlexWrap(Yoga.WRAP_WRAP);
+    root_child1.setWidth(50);
+    root_child1.setHeight(25);
+    root.insertChild(root_child1, 1);
+
+    var root_child1_child0 = Yoga.Node.create(config);
+    root_child1_child0.setWidth(25);
+    root_child1_child0.setHeight(20);
+    root_child1.insertChild(root_child1_child0, 0);
+
+    var root_child1_child1 = Yoga.Node.create(config);
+    root_child1_child1.setWidth(25);
+    root_child1_child1.setHeight(10);
+    root_child1.insertChild(root_child1_child1, 1);
+
+    var root_child1_child2 = Yoga.Node.create(config);
+    root_child1_child2.setWidth(25);
+    root_child1_child2.setHeight(20);
+    root_child1.insertChild(root_child1_child2, 2);
+
+    var root_child1_child3 = Yoga.Node.create(config);
+    root_child1_child3.setWidth(25);
+    root_child1_child3.setHeight(10);
+    root_child1.insertChild(root_child1_child3, 3);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(65 === root.getComputedHeight(), "65 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(60 === root_child0.getComputedHeight(), "60 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(50 === root_child1.getComputedLeft(), "50 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(40 === root_child1.getComputedTop(), "40 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(25 === root_child1.getComputedHeight(), "25 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(25 === root_child1_child0.getComputedWidth(), "25 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(20 === root_child1_child0.getComputedHeight(), "20 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    console.assert(25 === root_child1_child1.getComputedLeft(), "25 === root_child1_child1.getComputedLeft() (" + root_child1_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child1.getComputedTop(), "0 === root_child1_child1.getComputedTop() (" + root_child1_child1.getComputedTop() + ")");
+    console.assert(25 === root_child1_child1.getComputedWidth(), "25 === root_child1_child1.getComputedWidth() (" + root_child1_child1.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child1.getComputedHeight(), "10 === root_child1_child1.getComputedHeight() (" + root_child1_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child2.getComputedLeft(), "0 === root_child1_child2.getComputedLeft() (" + root_child1_child2.getComputedLeft() + ")");
+    console.assert(20 === root_child1_child2.getComputedTop(), "20 === root_child1_child2.getComputedTop() (" + root_child1_child2.getComputedTop() + ")");
+    console.assert(25 === root_child1_child2.getComputedWidth(), "25 === root_child1_child2.getComputedWidth() (" + root_child1_child2.getComputedWidth() + ")");
+    console.assert(20 === root_child1_child2.getComputedHeight(), "20 === root_child1_child2.getComputedHeight() (" + root_child1_child2.getComputedHeight() + ")");
+
+    console.assert(25 === root_child1_child3.getComputedLeft(), "25 === root_child1_child3.getComputedLeft() (" + root_child1_child3.getComputedLeft() + ")");
+    console.assert(20 === root_child1_child3.getComputedTop(), "20 === root_child1_child3.getComputedTop() (" + root_child1_child3.getComputedTop() + ")");
+    console.assert(25 === root_child1_child3.getComputedWidth(), "25 === root_child1_child3.getComputedWidth() (" + root_child1_child3.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child3.getComputedHeight(), "10 === root_child1_child3.getComputedHeight() (" + root_child1_child3.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(65 === root.getComputedHeight(), "65 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(60 === root_child0.getComputedHeight(), "60 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(40 === root_child1.getComputedTop(), "40 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(25 === root_child1.getComputedHeight(), "25 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(25 === root_child1_child0.getComputedLeft(), "25 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(25 === root_child1_child0.getComputedWidth(), "25 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(20 === root_child1_child0.getComputedHeight(), "20 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child1.getComputedLeft(), "0 === root_child1_child1.getComputedLeft() (" + root_child1_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child1.getComputedTop(), "0 === root_child1_child1.getComputedTop() (" + root_child1_child1.getComputedTop() + ")");
+    console.assert(25 === root_child1_child1.getComputedWidth(), "25 === root_child1_child1.getComputedWidth() (" + root_child1_child1.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child1.getComputedHeight(), "10 === root_child1_child1.getComputedHeight() (" + root_child1_child1.getComputedHeight() + ")");
+
+    console.assert(25 === root_child1_child2.getComputedLeft(), "25 === root_child1_child2.getComputedLeft() (" + root_child1_child2.getComputedLeft() + ")");
+    console.assert(20 === root_child1_child2.getComputedTop(), "20 === root_child1_child2.getComputedTop() (" + root_child1_child2.getComputedTop() + ")");
+    console.assert(25 === root_child1_child2.getComputedWidth(), "25 === root_child1_child2.getComputedWidth() (" + root_child1_child2.getComputedWidth() + ")");
+    console.assert(20 === root_child1_child2.getComputedHeight(), "20 === root_child1_child2.getComputedHeight() (" + root_child1_child2.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child3.getComputedLeft(), "0 === root_child1_child3.getComputedLeft() (" + root_child1_child3.getComputedLeft() + ")");
+    console.assert(20 === root_child1_child3.getComputedTop(), "20 === root_child1_child3.getComputedTop() (" + root_child1_child3.getComputedTop() + ")");
+    console.assert(25 === root_child1_child3.getComputedWidth(), "25 === root_child1_child3.getComputedWidth() (" + root_child1_child3.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child3.getComputedHeight(), "10 === root_child1_child3.getComputedHeight() (" + root_child1_child3.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("align_baseline_child_multiline_override_without_root_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setAlignItems(Yoga.ALIGN_BASELINE);
+    root.setWidth(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(60);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root_child1.setFlexWrap(Yoga.WRAP_WRAP);
+    root_child1.setWidth(50);
+    root_child1.setHeight(25);
+    root.insertChild(root_child1, 1);
+
+    var root_child1_child0 = Yoga.Node.create(config);
+    root_child1_child0.setWidth(25);
+    root_child1_child0.setHeight(20);
+    root_child1.insertChild(root_child1_child0, 0);
+
+    var root_child1_child1 = Yoga.Node.create(config);
+    root_child1_child1.setAlignSelf(Yoga.ALIGN_BASELINE);
+    root_child1_child1.setWidth(25);
+    root_child1_child1.setHeight(10);
+    root_child1.insertChild(root_child1_child1, 1);
+
+    var root_child1_child2 = Yoga.Node.create(config);
+    root_child1_child2.setWidth(25);
+    root_child1_child2.setHeight(20);
+    root_child1.insertChild(root_child1_child2, 2);
+
+    var root_child1_child3 = Yoga.Node.create(config);
+    root_child1_child3.setAlignSelf(Yoga.ALIGN_BASELINE);
+    root_child1_child3.setWidth(25);
+    root_child1_child3.setHeight(10);
+    root_child1.insertChild(root_child1_child3, 3);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(75 === root.getComputedHeight(), "75 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(60 === root_child0.getComputedHeight(), "60 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(50 === root_child1.getComputedLeft(), "50 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(50 === root_child1.getComputedTop(), "50 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(25 === root_child1.getComputedHeight(), "25 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(25 === root_child1_child0.getComputedWidth(), "25 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(20 === root_child1_child0.getComputedHeight(), "20 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    console.assert(25 === root_child1_child1.getComputedLeft(), "25 === root_child1_child1.getComputedLeft() (" + root_child1_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child1.getComputedTop(), "0 === root_child1_child1.getComputedTop() (" + root_child1_child1.getComputedTop() + ")");
+    console.assert(25 === root_child1_child1.getComputedWidth(), "25 === root_child1_child1.getComputedWidth() (" + root_child1_child1.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child1.getComputedHeight(), "10 === root_child1_child1.getComputedHeight() (" + root_child1_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child2.getComputedLeft(), "0 === root_child1_child2.getComputedLeft() (" + root_child1_child2.getComputedLeft() + ")");
+    console.assert(20 === root_child1_child2.getComputedTop(), "20 === root_child1_child2.getComputedTop() (" + root_child1_child2.getComputedTop() + ")");
+    console.assert(25 === root_child1_child2.getComputedWidth(), "25 === root_child1_child2.getComputedWidth() (" + root_child1_child2.getComputedWidth() + ")");
+    console.assert(20 === root_child1_child2.getComputedHeight(), "20 === root_child1_child2.getComputedHeight() (" + root_child1_child2.getComputedHeight() + ")");
+
+    console.assert(25 === root_child1_child3.getComputedLeft(), "25 === root_child1_child3.getComputedLeft() (" + root_child1_child3.getComputedLeft() + ")");
+    console.assert(20 === root_child1_child3.getComputedTop(), "20 === root_child1_child3.getComputedTop() (" + root_child1_child3.getComputedTop() + ")");
+    console.assert(25 === root_child1_child3.getComputedWidth(), "25 === root_child1_child3.getComputedWidth() (" + root_child1_child3.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child3.getComputedHeight(), "10 === root_child1_child3.getComputedHeight() (" + root_child1_child3.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(75 === root.getComputedHeight(), "75 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(60 === root_child0.getComputedHeight(), "60 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(50 === root_child1.getComputedTop(), "50 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(25 === root_child1.getComputedHeight(), "25 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(25 === root_child1_child0.getComputedLeft(), "25 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(25 === root_child1_child0.getComputedWidth(), "25 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(20 === root_child1_child0.getComputedHeight(), "20 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child1.getComputedLeft(), "0 === root_child1_child1.getComputedLeft() (" + root_child1_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child1.getComputedTop(), "0 === root_child1_child1.getComputedTop() (" + root_child1_child1.getComputedTop() + ")");
+    console.assert(25 === root_child1_child1.getComputedWidth(), "25 === root_child1_child1.getComputedWidth() (" + root_child1_child1.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child1.getComputedHeight(), "10 === root_child1_child1.getComputedHeight() (" + root_child1_child1.getComputedHeight() + ")");
+
+    console.assert(25 === root_child1_child2.getComputedLeft(), "25 === root_child1_child2.getComputedLeft() (" + root_child1_child2.getComputedLeft() + ")");
+    console.assert(20 === root_child1_child2.getComputedTop(), "20 === root_child1_child2.getComputedTop() (" + root_child1_child2.getComputedTop() + ")");
+    console.assert(25 === root_child1_child2.getComputedWidth(), "25 === root_child1_child2.getComputedWidth() (" + root_child1_child2.getComputedWidth() + ")");
+    console.assert(20 === root_child1_child2.getComputedHeight(), "20 === root_child1_child2.getComputedHeight() (" + root_child1_child2.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child3.getComputedLeft(), "0 === root_child1_child3.getComputedLeft() (" + root_child1_child3.getComputedLeft() + ")");
+    console.assert(20 === root_child1_child3.getComputedTop(), "20 === root_child1_child3.getComputedTop() (" + root_child1_child3.getComputedTop() + ")");
+    console.assert(25 === root_child1_child3.getComputedWidth(), "25 === root_child1_child3.getComputedWidth() (" + root_child1_child3.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child3.getComputedHeight(), "10 === root_child1_child3.getComputedHeight() (" + root_child1_child3.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("align_baseline_child_multiline_no_override_on_secondline_without_root_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setAlignItems(Yoga.ALIGN_BASELINE);
+    root.setWidth(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(60);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root_child1.setFlexWrap(Yoga.WRAP_WRAP);
+    root_child1.setWidth(50);
+    root_child1.setHeight(25);
+    root.insertChild(root_child1, 1);
+
+    var root_child1_child0 = Yoga.Node.create(config);
+    root_child1_child0.setWidth(25);
+    root_child1_child0.setHeight(20);
+    root_child1.insertChild(root_child1_child0, 0);
+
+    var root_child1_child1 = Yoga.Node.create(config);
+    root_child1_child1.setWidth(25);
+    root_child1_child1.setHeight(10);
+    root_child1.insertChild(root_child1_child1, 1);
+
+    var root_child1_child2 = Yoga.Node.create(config);
+    root_child1_child2.setWidth(25);
+    root_child1_child2.setHeight(20);
+    root_child1.insertChild(root_child1_child2, 2);
+
+    var root_child1_child3 = Yoga.Node.create(config);
+    root_child1_child3.setAlignSelf(Yoga.ALIGN_BASELINE);
+    root_child1_child3.setWidth(25);
+    root_child1_child3.setHeight(10);
+    root_child1.insertChild(root_child1_child3, 3);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(65 === root.getComputedHeight(), "65 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(60 === root_child0.getComputedHeight(), "60 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(50 === root_child1.getComputedLeft(), "50 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(40 === root_child1.getComputedTop(), "40 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(25 === root_child1.getComputedHeight(), "25 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(25 === root_child1_child0.getComputedWidth(), "25 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(20 === root_child1_child0.getComputedHeight(), "20 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    console.assert(25 === root_child1_child1.getComputedLeft(), "25 === root_child1_child1.getComputedLeft() (" + root_child1_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child1.getComputedTop(), "0 === root_child1_child1.getComputedTop() (" + root_child1_child1.getComputedTop() + ")");
+    console.assert(25 === root_child1_child1.getComputedWidth(), "25 === root_child1_child1.getComputedWidth() (" + root_child1_child1.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child1.getComputedHeight(), "10 === root_child1_child1.getComputedHeight() (" + root_child1_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child2.getComputedLeft(), "0 === root_child1_child2.getComputedLeft() (" + root_child1_child2.getComputedLeft() + ")");
+    console.assert(20 === root_child1_child2.getComputedTop(), "20 === root_child1_child2.getComputedTop() (" + root_child1_child2.getComputedTop() + ")");
+    console.assert(25 === root_child1_child2.getComputedWidth(), "25 === root_child1_child2.getComputedWidth() (" + root_child1_child2.getComputedWidth() + ")");
+    console.assert(20 === root_child1_child2.getComputedHeight(), "20 === root_child1_child2.getComputedHeight() (" + root_child1_child2.getComputedHeight() + ")");
+
+    console.assert(25 === root_child1_child3.getComputedLeft(), "25 === root_child1_child3.getComputedLeft() (" + root_child1_child3.getComputedLeft() + ")");
+    console.assert(20 === root_child1_child3.getComputedTop(), "20 === root_child1_child3.getComputedTop() (" + root_child1_child3.getComputedTop() + ")");
+    console.assert(25 === root_child1_child3.getComputedWidth(), "25 === root_child1_child3.getComputedWidth() (" + root_child1_child3.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child3.getComputedHeight(), "10 === root_child1_child3.getComputedHeight() (" + root_child1_child3.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(65 === root.getComputedHeight(), "65 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(60 === root_child0.getComputedHeight(), "60 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(40 === root_child1.getComputedTop(), "40 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(25 === root_child1.getComputedHeight(), "25 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(25 === root_child1_child0.getComputedLeft(), "25 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(25 === root_child1_child0.getComputedWidth(), "25 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(20 === root_child1_child0.getComputedHeight(), "20 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child1.getComputedLeft(), "0 === root_child1_child1.getComputedLeft() (" + root_child1_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child1.getComputedTop(), "0 === root_child1_child1.getComputedTop() (" + root_child1_child1.getComputedTop() + ")");
+    console.assert(25 === root_child1_child1.getComputedWidth(), "25 === root_child1_child1.getComputedWidth() (" + root_child1_child1.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child1.getComputedHeight(), "10 === root_child1_child1.getComputedHeight() (" + root_child1_child1.getComputedHeight() + ")");
+
+    console.assert(25 === root_child1_child2.getComputedLeft(), "25 === root_child1_child2.getComputedLeft() (" + root_child1_child2.getComputedLeft() + ")");
+    console.assert(20 === root_child1_child2.getComputedTop(), "20 === root_child1_child2.getComputedTop() (" + root_child1_child2.getComputedTop() + ")");
+    console.assert(25 === root_child1_child2.getComputedWidth(), "25 === root_child1_child2.getComputedWidth() (" + root_child1_child2.getComputedWidth() + ")");
+    console.assert(20 === root_child1_child2.getComputedHeight(), "20 === root_child1_child2.getComputedHeight() (" + root_child1_child2.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child3.getComputedLeft(), "0 === root_child1_child3.getComputedLeft() (" + root_child1_child3.getComputedLeft() + ")");
+    console.assert(20 === root_child1_child3.getComputedTop(), "20 === root_child1_child3.getComputedTop() (" + root_child1_child3.getComputedTop() + ")");
+    console.assert(25 === root_child1_child3.getComputedWidth(), "25 === root_child1_child3.getComputedWidth() (" + root_child1_child3.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child3.getComputedHeight(), "10 === root_child1_child3.getComputedHeight() (" + root_child1_child3.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("align_baseline_child_top_without_root_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setAlignItems(Yoga.ALIGN_BASELINE);
+    root.setWidth(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setPosition(Yoga.EDGE_TOP, 10);
+    root_child0.setWidth(50);
+    root_child0.setHeight(50);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(20);
+    root.insertChild(root_child1, 1);
+
+    var root_child1_child0 = Yoga.Node.create(config);
+    root_child1_child0.setWidth(50);
+    root_child1_child0.setHeight(10);
+    root_child1.insertChild(root_child1_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(60 === root.getComputedHeight(), "60 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(10 === root_child0.getComputedTop(), "10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(50 === root_child1.getComputedLeft(), "50 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(40 === root_child1.getComputedTop(), "40 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0.getComputedWidth(), "50 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child0.getComputedHeight(), "10 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(60 === root.getComputedHeight(), "60 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(10 === root_child0.getComputedTop(), "10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(40 === root_child1.getComputedTop(), "40 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0.getComputedWidth(), "50 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child0.getComputedHeight(), "10 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("align_baseline_child_margin_without_root_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setAlignItems(Yoga.ALIGN_BASELINE);
+    root.setWidth(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setMargin(Yoga.EDGE_LEFT, 5);
+    root_child0.setMargin(Yoga.EDGE_TOP, 5);
+    root_child0.setMargin(Yoga.EDGE_RIGHT, 5);
+    root_child0.setMargin(Yoga.EDGE_BOTTOM, 5);
+    root_child0.setWidth(50);
+    root_child0.setHeight(50);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(20);
+    root.insertChild(root_child1, 1);
+
+    var root_child1_child0 = Yoga.Node.create(config);
+    root_child1_child0.setMargin(Yoga.EDGE_LEFT, 1);
+    root_child1_child0.setMargin(Yoga.EDGE_TOP, 1);
+    root_child1_child0.setMargin(Yoga.EDGE_RIGHT, 1);
+    root_child1_child0.setMargin(Yoga.EDGE_BOTTOM, 1);
+    root_child1_child0.setWidth(50);
+    root_child1_child0.setHeight(10);
+    root_child1.insertChild(root_child1_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(64 === root.getComputedHeight(), "64 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(5 === root_child0.getComputedLeft(), "5 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(5 === root_child0.getComputedTop(), "5 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(60 === root_child1.getComputedLeft(), "60 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(44 === root_child1.getComputedTop(), "44 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(1 === root_child1_child0.getComputedLeft(), "1 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(1 === root_child1_child0.getComputedTop(), "1 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0.getComputedWidth(), "50 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child0.getComputedHeight(), "10 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(64 === root.getComputedHeight(), "64 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(45 === root_child0.getComputedLeft(), "45 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(5 === root_child0.getComputedTop(), "5 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(-10 === root_child1.getComputedLeft(), "-10 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(44 === root_child1.getComputedTop(), "44 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(-1 === root_child1_child0.getComputedLeft(), "-1 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(1 === root_child1_child0.getComputedTop(), "1 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0.getComputedWidth(), "50 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child0.getComputedHeight(), "10 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("align_baseline_child_padding_without_root_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setAlignItems(Yoga.ALIGN_BASELINE);
+    root.setPadding(Yoga.EDGE_LEFT, 5);
+    root.setPadding(Yoga.EDGE_TOP, 5);
+    root.setPadding(Yoga.EDGE_RIGHT, 5);
+    root.setPadding(Yoga.EDGE_BOTTOM, 5);
+    root.setWidth(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(50);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setPadding(Yoga.EDGE_LEFT, 5);
+    root_child1.setPadding(Yoga.EDGE_TOP, 5);
+    root_child1.setPadding(Yoga.EDGE_RIGHT, 5);
+    root_child1.setPadding(Yoga.EDGE_BOTTOM, 5);
+    root_child1.setWidth(50);
+    root_child1.setHeight(20);
+    root.insertChild(root_child1, 1);
+
+    var root_child1_child0 = Yoga.Node.create(config);
+    root_child1_child0.setWidth(50);
+    root_child1_child0.setHeight(10);
+    root_child1.insertChild(root_child1_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(65 === root.getComputedHeight(), "65 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(5 === root_child0.getComputedLeft(), "5 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(5 === root_child0.getComputedTop(), "5 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(55 === root_child1.getComputedLeft(), "55 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(40 === root_child1.getComputedTop(), "40 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(5 === root_child1_child0.getComputedLeft(), "5 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(5 === root_child1_child0.getComputedTop(), "5 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0.getComputedWidth(), "50 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child0.getComputedHeight(), "10 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(65 === root.getComputedHeight(), "65 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(45 === root_child0.getComputedLeft(), "45 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(5 === root_child0.getComputedTop(), "5 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(-5 === root_child1.getComputedLeft(), "-5 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(40 === root_child1.getComputedTop(), "40 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(-5 === root_child1_child0.getComputedLeft(), "-5 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(5 === root_child1_child0.getComputedTop(), "5 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0.getComputedWidth(), "50 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child0.getComputedHeight(), "10 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("align_baseline_multiline_without_root_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setAlignItems(Yoga.ALIGN_BASELINE);
+    root.setFlexWrap(Yoga.WRAP_WRAP);
+    root.setWidth(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(50);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(20);
+    root.insertChild(root_child1, 1);
+
+    var root_child1_child0 = Yoga.Node.create(config);
+    root_child1_child0.setWidth(50);
+    root_child1_child0.setHeight(10);
+    root_child1.insertChild(root_child1_child0, 0);
+
+    var root_child2 = Yoga.Node.create(config);
+    root_child2.setWidth(50);
+    root_child2.setHeight(20);
+    root.insertChild(root_child2, 2);
+
+    var root_child2_child0 = Yoga.Node.create(config);
+    root_child2_child0.setWidth(50);
+    root_child2_child0.setHeight(10);
+    root_child2.insertChild(root_child2_child0, 0);
+
+    var root_child3 = Yoga.Node.create(config);
+    root_child3.setWidth(50);
+    root_child3.setHeight(50);
+    root.insertChild(root_child3, 3);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(120 === root.getComputedHeight(), "120 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(50 === root_child1.getComputedLeft(), "50 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(40 === root_child1.getComputedTop(), "40 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0.getComputedWidth(), "50 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child0.getComputedHeight(), "10 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child2.getComputedLeft(), "0 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(100 === root_child2.getComputedTop(), "100 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(50 === root_child2.getComputedWidth(), "50 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(20 === root_child2.getComputedHeight(), "20 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+    console.assert(0 === root_child2_child0.getComputedLeft(), "0 === root_child2_child0.getComputedLeft() (" + root_child2_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child2_child0.getComputedTop(), "0 === root_child2_child0.getComputedTop() (" + root_child2_child0.getComputedTop() + ")");
+    console.assert(50 === root_child2_child0.getComputedWidth(), "50 === root_child2_child0.getComputedWidth() (" + root_child2_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child2_child0.getComputedHeight(), "10 === root_child2_child0.getComputedHeight() (" + root_child2_child0.getComputedHeight() + ")");
+
+    console.assert(50 === root_child3.getComputedLeft(), "50 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+    console.assert(60 === root_child3.getComputedTop(), "60 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+    console.assert(50 === root_child3.getComputedWidth(), "50 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+    console.assert(50 === root_child3.getComputedHeight(), "50 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(120 === root.getComputedHeight(), "120 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(40 === root_child1.getComputedTop(), "40 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0.getComputedWidth(), "50 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child0.getComputedHeight(), "10 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    console.assert(50 === root_child2.getComputedLeft(), "50 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(100 === root_child2.getComputedTop(), "100 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(50 === root_child2.getComputedWidth(), "50 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(20 === root_child2.getComputedHeight(), "20 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+    console.assert(0 === root_child2_child0.getComputedLeft(), "0 === root_child2_child0.getComputedLeft() (" + root_child2_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child2_child0.getComputedTop(), "0 === root_child2_child0.getComputedTop() (" + root_child2_child0.getComputedTop() + ")");
+    console.assert(50 === root_child2_child0.getComputedWidth(), "50 === root_child2_child0.getComputedWidth() (" + root_child2_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child2_child0.getComputedHeight(), "10 === root_child2_child0.getComputedHeight() (" + root_child2_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child3.getComputedLeft(), "0 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+    console.assert(60 === root_child3.getComputedTop(), "60 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+    console.assert(50 === root_child3.getComputedWidth(), "50 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+    console.assert(50 === root_child3.getComputedHeight(), "50 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
 it("align_baseline_multiline_column", function () {
   var config = Yoga.Config.create();
 

--- a/tests/YGAlignItemsTest.cpp
+++ b/tests/YGAlignItemsTest.cpp
@@ -1228,6 +1228,766 @@ TEST(YogaTest, align_baseline_multiline) {
   YGConfigFree(config);
 }
 
+TEST(YogaTest, align_baseline_without_root_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignBaseline);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 50);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_baseline_child_multiline_without_root_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignBaseline);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 60);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child1, YGFlexDirectionRow);
+  YGNodeStyleSetFlexWrap(root_child1, YGWrapWrap);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 25);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child0, 25);
+  YGNodeStyleSetHeight(root_child1_child0, 20);
+  YGNodeInsertChild(root_child1, root_child1_child0, 0);
+
+  const YGNodeRef root_child1_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child1, 25);
+  YGNodeStyleSetHeight(root_child1_child1, 10);
+  YGNodeInsertChild(root_child1, root_child1_child1, 1);
+
+  const YGNodeRef root_child1_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child2, 25);
+  YGNodeStyleSetHeight(root_child1_child2, 20);
+  YGNodeInsertChild(root_child1, root_child1_child2, 2);
+
+  const YGNodeRef root_child1_child3 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child3, 25);
+  YGNodeStyleSetHeight(root_child1_child3, 10);
+  YGNodeInsertChild(root_child1, root_child1_child3, 3);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(65, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child0));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child1));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child1_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child2));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child1_child3));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child1_child3));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child3));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(65, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child1));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child1));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child1_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child1_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child2));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child3));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child1_child3));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child3));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_baseline_child_multiline_override_without_root_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignBaseline);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 60);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child1, YGFlexDirectionRow);
+  YGNodeStyleSetFlexWrap(root_child1, YGWrapWrap);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 25);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child0, 25);
+  YGNodeStyleSetHeight(root_child1_child0, 20);
+  YGNodeInsertChild(root_child1, root_child1_child0, 0);
+
+  const YGNodeRef root_child1_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignSelf(root_child1_child1, YGAlignBaseline);
+  YGNodeStyleSetWidth(root_child1_child1, 25);
+  YGNodeStyleSetHeight(root_child1_child1, 10);
+  YGNodeInsertChild(root_child1, root_child1_child1, 1);
+
+  const YGNodeRef root_child1_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child2, 25);
+  YGNodeStyleSetHeight(root_child1_child2, 20);
+  YGNodeInsertChild(root_child1, root_child1_child2, 2);
+
+  const YGNodeRef root_child1_child3 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignSelf(root_child1_child3, YGAlignBaseline);
+  YGNodeStyleSetWidth(root_child1_child3, 25);
+  YGNodeStyleSetHeight(root_child1_child3, 10);
+  YGNodeInsertChild(root_child1, root_child1_child3, 3);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(75, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child0));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child1));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child1_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child2));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child1_child3));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child1_child3));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child3));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(75, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child1));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child1));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child1_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child1_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child2));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child3));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child1_child3));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child3));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_baseline_child_multiline_no_override_on_secondline_without_root_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignBaseline);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 60);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child1, YGFlexDirectionRow);
+  YGNodeStyleSetFlexWrap(root_child1, YGWrapWrap);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 25);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child0, 25);
+  YGNodeStyleSetHeight(root_child1_child0, 20);
+  YGNodeInsertChild(root_child1, root_child1_child0, 0);
+
+  const YGNodeRef root_child1_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child1, 25);
+  YGNodeStyleSetHeight(root_child1_child1, 10);
+  YGNodeInsertChild(root_child1, root_child1_child1, 1);
+
+  const YGNodeRef root_child1_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child2, 25);
+  YGNodeStyleSetHeight(root_child1_child2, 20);
+  YGNodeInsertChild(root_child1, root_child1_child2, 2);
+
+  const YGNodeRef root_child1_child3 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignSelf(root_child1_child3, YGAlignBaseline);
+  YGNodeStyleSetWidth(root_child1_child3, 25);
+  YGNodeStyleSetHeight(root_child1_child3, 10);
+  YGNodeInsertChild(root_child1, root_child1_child3, 3);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(65, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child0));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child1));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child1_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child2));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child1_child3));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child1_child3));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child3));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(65, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child1));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child1));
+
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetLeft(root_child1_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child1_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child2));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child3));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child1_child3));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child1_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child3));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_baseline_child_top_without_root_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignBaseline);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPosition(root_child0, YGEdgeTop, 10);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 50);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child0, 50);
+  YGNodeStyleSetHeight(root_child1_child0, 10);
+  YGNodeInsertChild(root_child1, root_child1_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_baseline_child_margin_without_root_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignBaseline);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMargin(root_child0, YGEdgeLeft, 5);
+  YGNodeStyleSetMargin(root_child0, YGEdgeTop, 5);
+  YGNodeStyleSetMargin(root_child0, YGEdgeRight, 5);
+  YGNodeStyleSetMargin(root_child0, YGEdgeBottom, 5);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 50);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMargin(root_child1_child0, YGEdgeLeft, 1);
+  YGNodeStyleSetMargin(root_child1_child0, YGEdgeTop, 1);
+  YGNodeStyleSetMargin(root_child1_child0, YGEdgeRight, 1);
+  YGNodeStyleSetMargin(root_child1_child0, YGEdgeBottom, 1);
+  YGNodeStyleSetWidth(root_child1_child0, 50);
+  YGNodeStyleSetHeight(root_child1_child0, 10);
+  YGNodeInsertChild(root_child1, root_child1_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(64, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(44, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(1, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(1, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(64, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(44, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(-1, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(1, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_baseline_child_padding_without_root_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignBaseline);
+  YGNodeStyleSetPadding(root, YGEdgeLeft, 5);
+  YGNodeStyleSetPadding(root, YGEdgeTop, 5);
+  YGNodeStyleSetPadding(root, YGEdgeRight, 5);
+  YGNodeStyleSetPadding(root, YGEdgeBottom, 5);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 50);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPadding(root_child1, YGEdgeLeft, 5);
+  YGNodeStyleSetPadding(root_child1, YGEdgeTop, 5);
+  YGNodeStyleSetPadding(root_child1, YGEdgeRight, 5);
+  YGNodeStyleSetPadding(root_child1, YGEdgeBottom, 5);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child0, 50);
+  YGNodeStyleSetHeight(root_child1_child0, 10);
+  YGNodeInsertChild(root_child1, root_child1_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(65, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(65, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_baseline_multiline_without_root_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignBaseline);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 50);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child0, 50);
+  YGNodeStyleSetHeight(root_child1_child0, 10);
+  YGNodeInsertChild(root_child1, root_child1_child0, 0);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child2, 50);
+  YGNodeStyleSetHeight(root_child2, 20);
+  YGNodeInsertChild(root, root_child2, 2);
+
+  const YGNodeRef root_child2_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child2_child0, 50);
+  YGNodeStyleSetHeight(root_child2_child0, 10);
+  YGNodeInsertChild(root_child2, root_child2_child0, 0);
+
+  const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child3, 50);
+  YGNodeStyleSetHeight(root_child3, 50);
+  YGNodeInsertChild(root, root_child3, 3);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child3));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child3));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
 TEST(YogaTest, align_baseline_multiline_column) {
   const YGConfigRef config = YGConfigNew();
 

--- a/tests/YGBaselineFuncTest.cpp
+++ b/tests/YGBaselineFuncTest.cpp
@@ -59,4 +59,45 @@ TEST(YogaTest, align_baseline_customer_func) {
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0));
   ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child0));
+
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, align_baseline_container_height) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignBaseline);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 50);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  float baselineValue = 10;
+  const YGNodeRef root_child1 = YGNodeNew();
+  root_child1->setContext(&baselineValue);
+  root_child1->setBaseLineFunc(_baseline);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
 }

--- a/yoga/Utils.h
+++ b/yoga/Utils.h
@@ -50,6 +50,9 @@ struct YGCollectFlexItemsRowValues {
   // The size of the crossDim for the row after considering size, padding,
   // margin and border of flex items. Used for calculating containers crossSize.
   float crossDim;
+  // The position of the baseline from the top of row. This is used to calculate
+  // position of flex items which are part of baseline participants.
+  float maxBaselineAscent;
 };
 
 bool YGValueEqual(const YGValue a, const YGValue b);

--- a/yoga/YGLayout.cpp
+++ b/yoga/YGLayout.cpp
@@ -28,7 +28,8 @@ YGLayout::YGLayout()
       measuredDimensions(kYGDefaultDimensionValues),
       cachedLayout(YGCachedMeasurement()),
       didUseLegacyFlag(false),
-      doesLegacyStretchFlagAffectsLayout(false) {}
+      doesLegacyStretchFlagAffectsLayout(false),
+      cachedBaseline(YGFloatOptional()) {}
 
 bool YGLayout::operator==(YGLayout layout) const {
   bool isEqual = YGFloatArrayEqual(position, layout.position) &&

--- a/yoga/YGLayout.h
+++ b/yoga/YGLayout.h
@@ -35,6 +35,8 @@ struct YGLayout {
   bool didUseLegacyFlag;
   bool doesLegacyStretchFlagAffectsLayout;
 
+  YGFloatOptional cachedBaseline;
+
   YGLayout();
 
   bool operator==(YGLayout layout) const;

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -314,6 +314,11 @@ void YGNode::setLayoutComputedFlexBasis(
   layout_.computedFlexBasis = computedFlexBasis;
 }
 
+void YGNode::setLayoutCachedBaseline(
+  const YGFloatOptional& cachedBaseline) {
+  layout_.cachedBaseline = cachedBaseline;
+}
+
 void YGNode::setLayoutPosition(float position, int index) {
   layout_.position[index] = position;
 }

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -157,6 +157,7 @@ struct YGNode {
   void setAndPropogateUseLegacyFlag(bool useLegacyFlag);
   void setLayoutDoesLegacyFlagAffectsLayout(bool doesLegacyFlagAffectsLayout);
   void setLayoutDidUseLegacyFlag(bool didUseLegacyFlag);
+  void setLayoutCachedBaseline(const YGFloatOptional& cachedBaseline);
   void markDirtyAndPropogateDownwards();
 
   // Other methods

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -2416,7 +2416,10 @@ static void YGJustifyMainAxis(
           // The cross dimension is the max of the elements dimension since
           // there can only be one element in that cross dimension.
           if (YGNodeAlignItem(node, child) == YGAlignBaseline) {
-            const float ascent = YGBaseline(child) +
+            const float baseline = YGBaseline(child);
+            child->setLayoutCachedBaseline(YGFloatOptional(baseline));
+
+            const float ascent = baseline +
                                  YGUnwrapFloatOptional(child->getLeadingMargin(
                                          YGFlexDirectionColumn, availableInnerWidth));
             const float descent =
@@ -3003,7 +3006,7 @@ static void YGNodelayoutImpl(const YGNodeRef node,
             } else if (alignItem == YGAlignBaseline) {
               leadingCrossDim +=
                       collectedFlexItemsValues.maxBaselineAscent
-                      - YGBaseline(child)
+                      - YGUnwrapFloatOptional(child->getLayout().cachedBaseline)
                       - YGUnwrapFloatOptional(child->getLeadingMargin(
                         YGFlexDirectionColumn, availableInnerWidth));
             } else {
@@ -3090,7 +3093,8 @@ static void YGNodelayoutImpl(const YGNodeRef node,
                         crossAxis, availableInnerWidth)));
           }
           if (YGNodeAlignItem(node, child) == YGAlignBaseline) {
-            const float ascent = YGBaseline(child) +
+            const float ascent =
+                YGUnwrapFloatOptional(child->getLayout().cachedBaseline) +
                 YGUnwrapFloatOptional(child->getLeadingMargin(
                     YGFlexDirectionColumn, availableInnerWidth));
             const float descent =
@@ -3193,9 +3197,10 @@ static void YGNodelayoutImpl(const YGNodeRef node,
               }
               case YGAlignBaseline: {
                 child->setLayoutPosition(
-                    currentLead + maxAscentForCurrentLine - YGBaseline(child) +
-                        YGUnwrapFloatOptional(child->getLeadingPosition(
-                            YGFlexDirectionColumn, availableInnerCrossDim)),
+                    currentLead + maxAscentForCurrentLine -
+                    YGUnwrapFloatOptional(child->getLayout().cachedBaseline) +
+                    YGUnwrapFloatOptional(child->getLeadingPosition(
+                      YGFlexDirectionColumn, availableInnerCrossDim)),
                     YGEdgeTop);
 
                 break;


### PR DESCRIPTION
# Background

As @axl411 reported in #741, The height of baseline container is not calculated properly.

# Cause

In my understand, There are 2 points where flex line height is calculated.
* Step6 MAIN-AXIS JUSTIFICATION & CROSS-AXIS SIZE DETERMINATION (inside `YGJustifyMainAxis`)
* Step8 MULTI-LINE CONTENT ALIGNMENT

Although the baseline calculation affects the height of flex line, it is not taken into account in step6. 

# Solution

Fix `YGJustifyMainAxis` to compute flex line height with consideration of baseline calculation.

# Result

fixes #741 

## Related PR
https://github.com/facebook/yoga/pull/317 (original commit for baseline support)