### PR TITLE
Invalid align-items value in test fixtures

### DIFF
--- a/csharp/tests/Facebook.Yoga/YGAlignItemsTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGAlignItemsTest.cs
@@ -1886,7 +1886,7 @@ namespace Facebook.Yoga
         }
 
         [Test]
-        public void Test_align_strech_should_size_based_on_parent()
+        public void Test_align_stretch_should_size_based_on_parent()
         {
             YogaConfig config = new YogaConfig();
 

--- a/csharp/tests/Facebook.Yoga/YGMarginTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGMarginTest.cs
@@ -1236,7 +1236,7 @@ namespace Facebook.Yoga
         }
 
         [Test]
-        public void Test_margin_auto_left_and_right_strech()
+        public void Test_margin_auto_left_and_right_stretch()
         {
             YogaConfig config = new YogaConfig();
 
@@ -1294,7 +1294,7 @@ namespace Facebook.Yoga
         }
 
         [Test]
-        public void Test_margin_auto_top_and_bottom_strech()
+        public void Test_margin_auto_top_and_bottom_stretch()
         {
             YogaConfig config = new YogaConfig();
 

--- a/gentest/fixtures/YGAlignItemsTest.html
+++ b/gentest/fixtures/YGAlignItemsTest.html
@@ -176,7 +176,7 @@
   </div>
 </div>
 
-<div id="align_strech_should_size_based_on_parent" style="width: 100px; height: 100px; align-items: strech; margin-top: 20px;">
+<div id="align_stretch_should_size_based_on_parent" style="width: 100px; height: 100px; align-items: stretch; margin-top: 20px;">
   <div style="flex-grow: 0; flex-shrink: 1; justify-content: center;">
     <div style="flex-grow: 1; flex-shrink: 1;">
       <div style="width: 20px; height: 20px;"></div>
@@ -193,7 +193,7 @@
 </div>
 
 <div id="align_flex_start_with_stretching_children" style="height: 500px; width: 500px">
-  <div style="align-items: strech;">
+  <div style="align-items: stretch;">
     <div style="flex-grow: 1; flex-shrink: 1;">
       <div style="flex-grow: 1; flex-shrink: 1;"></div>
     </div>

--- a/gentest/fixtures/YGMarginTest.html
+++ b/gentest/fixtures/YGMarginTest.html
@@ -107,12 +107,12 @@
   <div style="width: 50px; height: 50px;"></div>
 </div>
 
-<div id="margin_auto_left_and_right_strech" style="width: 200px; height: 200px; flex-direction:row; align-items: stretch;">
+<div id="margin_auto_left_and_right_stretch" style="width: 200px; height: 200px; flex-direction:row; align-items: stretch;">
   <div style="width: 50px; height: 50px; margin-left:auto; margin-right:auto;"></div>
   <div style="width: 50px; height: 50px;"></div>
 </div>
 
-<div id="margin_auto_top_and_bottom_strech" style="width: 200px; height: 200px; flex-direction: column; align-items: stretch;">
+<div id="margin_auto_top_and_bottom_stretch" style="width: 200px; height: 200px; flex-direction: column; align-items: stretch;">
   <div style="width: 50px; height: 50px; margin-top:auto; margin-bottom:auto;"></div>
   <div style="width: 50px; height: 50px;"></div>
 </div>

--- a/java/tests/com/facebook/yoga/YGAlignItemsTest.java
+++ b/java/tests/com/facebook/yoga/YGAlignItemsTest.java
@@ -1861,7 +1861,7 @@ public class YGAlignItemsTest {
   }
 
   @Test
-  public void test_align_strech_should_size_based_on_parent() {
+  public void test_align_stretch_should_size_based_on_parent() {
     YogaConfig config = new YogaConfig();
 
     final YogaNode root = new YogaNode(config);

--- a/java/tests/com/facebook/yoga/YGAndroidNewsFeed.java
+++ b/java/tests/com/facebook/yoga/YGAndroidNewsFeed.java
@@ -9,9 +9,9 @@
 
 package com.facebook.yoga;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class YGAndroidNewsFeed {
   @Test
@@ -50,8 +50,7 @@ public class YGAndroidNewsFeed {
     root_child0_child0_child0_child0_child0_child0.setAlignContent(YogaAlign.STRETCH);
     root_child0_child0_child0_child0_child0_child0.setWidth(120f);
     root_child0_child0_child0_child0_child0_child0.setHeight(120f);
-    root_child0_child0_child0_child0_child0.addChildAt(
-        root_child0_child0_child0_child0_child0_child0, 0);
+    root_child0_child0_child0_child0_child0.addChildAt(root_child0_child0_child0_child0_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0_child0_child1 = new YogaNode(config);
     root_child0_child0_child0_child0_child1.setAlignContent(YogaAlign.STRETCH);
@@ -67,14 +66,12 @@ public class YGAndroidNewsFeed {
     root_child0_child0_child0_child0_child1_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0_child0_child0_child1_child0.setAlignContent(YogaAlign.STRETCH);
     root_child0_child0_child0_child0_child1_child0.setFlexShrink(1f);
-    root_child0_child0_child0_child0_child1.addChildAt(
-        root_child0_child0_child0_child0_child1_child0, 0);
+    root_child0_child0_child0_child0_child1.addChildAt(root_child0_child0_child0_child0_child1_child0, 0);
 
     final YogaNode root_child0_child0_child0_child0_child1_child1 = new YogaNode(config);
     root_child0_child0_child0_child0_child1_child1.setAlignContent(YogaAlign.STRETCH);
     root_child0_child0_child0_child0_child1_child1.setFlexShrink(1f);
-    root_child0_child0_child0_child0_child1.addChildAt(
-        root_child0_child0_child0_child0_child1_child1, 1);
+    root_child0_child0_child0_child0_child1.addChildAt(root_child0_child0_child0_child0_child1_child1, 1);
 
     final YogaNode root_child0_child0_child1 = new YogaNode(config);
     root_child0_child0_child1.setAlignContent(YogaAlign.STRETCH);
@@ -97,8 +94,7 @@ public class YGAndroidNewsFeed {
     root_child0_child0_child1_child0_child0_child0.setAlignContent(YogaAlign.STRETCH);
     root_child0_child0_child1_child0_child0_child0.setWidth(72f);
     root_child0_child0_child1_child0_child0_child0.setHeight(72f);
-    root_child0_child0_child1_child0_child0.addChildAt(
-        root_child0_child0_child1_child0_child0_child0, 0);
+    root_child0_child0_child1_child0_child0.addChildAt(root_child0_child0_child1_child0_child0_child0, 0);
 
     final YogaNode root_child0_child0_child1_child0_child1 = new YogaNode(config);
     root_child0_child0_child1_child0_child1.setAlignContent(YogaAlign.STRETCH);
@@ -114,14 +110,12 @@ public class YGAndroidNewsFeed {
     root_child0_child0_child1_child0_child1_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0_child1_child0_child1_child0.setAlignContent(YogaAlign.STRETCH);
     root_child0_child0_child1_child0_child1_child0.setFlexShrink(1f);
-    root_child0_child0_child1_child0_child1.addChildAt(
-        root_child0_child0_child1_child0_child1_child0, 0);
+    root_child0_child0_child1_child0_child1.addChildAt(root_child0_child0_child1_child0_child1_child0, 0);
 
     final YogaNode root_child0_child0_child1_child0_child1_child1 = new YogaNode(config);
     root_child0_child0_child1_child0_child1_child1.setAlignContent(YogaAlign.STRETCH);
     root_child0_child0_child1_child0_child1_child1.setFlexShrink(1f);
-    root_child0_child0_child1_child0_child1.addChildAt(
-        root_child0_child0_child1_child0_child1_child1, 1);
+    root_child0_child0_child1_child0_child1.addChildAt(root_child0_child0_child1_child0_child1_child1, 1);
     root.setDirection(YogaDirection.LTR);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
@@ -298,4 +292,5 @@ public class YGAndroidNewsFeed {
     assertEquals(0f, root_child0_child0_child1_child0_child1_child1.getLayoutWidth(), 0.0f);
     assertEquals(0f, root_child0_child0_child1_child0_child1_child1.getLayoutHeight(), 0.0f);
   }
+
 }

--- a/java/tests/com/facebook/yoga/YGMarginTest.java
+++ b/java/tests/com/facebook/yoga/YGMarginTest.java
@@ -1212,7 +1212,7 @@ public class YGMarginTest {
   }
 
   @Test
-  public void test_margin_auto_left_and_right_strech() {
+  public void test_margin_auto_left_and_right_stretch() {
     YogaConfig config = new YogaConfig();
 
     final YogaNode root = new YogaNode(config);
@@ -1269,7 +1269,7 @@ public class YGMarginTest {
   }
 
   @Test
-  public void test_margin_auto_top_and_bottom_strech() {
+  public void test_margin_auto_top_and_bottom_stretch() {
     YogaConfig config = new YogaConfig();
 
     final YogaNode root = new YogaNode(config);

--- a/javascript/tests/Facebook.Yoga/YGAlignItemsTest.js
+++ b/javascript/tests/Facebook.Yoga/YGAlignItemsTest.js
@@ -1951,7 +1951,7 @@ it("align_center_should_size_based_on_content", function () {
     config.free();
   }
 });
-it("align_strech_should_size_based_on_parent", function () {
+it("align_stretch_should_size_based_on_parent", function () {
   var config = Yoga.Config.create();
 
   try {

--- a/javascript/tests/Facebook.Yoga/YGMarginTest.js
+++ b/javascript/tests/Facebook.Yoga/YGMarginTest.js
@@ -1298,7 +1298,7 @@ it("margin_auto_right", function () {
     config.free();
   }
 });
-it("margin_auto_left_and_right_strech", function () {
+it("margin_auto_left_and_right_stretch", function () {
   var config = Yoga.Config.create();
 
   try {
@@ -1359,7 +1359,7 @@ it("margin_auto_left_and_right_strech", function () {
     config.free();
   }
 });
-it("margin_auto_top_and_bottom_strech", function () {
+it("margin_auto_top_and_bottom_stretch", function () {
   var config = Yoga.Config.create();
 
   try {

--- a/tests/YGAlignItemsTest.cpp
+++ b/tests/YGAlignItemsTest.cpp
@@ -1880,7 +1880,7 @@ TEST(YogaTest, align_center_should_size_based_on_content) {
   YGConfigFree(config);
 }
 
-TEST(YogaTest, align_strech_should_size_based_on_parent) {
+TEST(YogaTest, align_stretch_should_size_based_on_parent) {
   const YGConfigRef config = YGConfigNew();
 
   const YGNodeRef root = YGNodeNewWithConfig(config);

--- a/tests/YGAndroidNewsFeed.cpp
+++ b/tests/YGAndroidNewsFeed.cpp
@@ -28,157 +28,89 @@ TEST(YogaTest, android_news_feed) {
   YGNodeStyleSetAlignContent(root_child0_child0_child0, YGAlignStretch);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
 
-  const YGNodeRef root_child0_child0_child0_child0 =
-      YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(
-      root_child0_child0_child0_child0, YGFlexDirectionRow);
+  const YGNodeRef root_child0_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0_child0_child0_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root_child0_child0_child0_child0, YGAlignStretch);
   YGNodeStyleSetAlignItems(root_child0_child0_child0_child0, YGAlignFlexStart);
   YGNodeStyleSetMargin(root_child0_child0_child0_child0, YGEdgeStart, 36);
   YGNodeStyleSetMargin(root_child0_child0_child0_child0, YGEdgeTop, 24);
-  YGNodeInsertChild(
-      root_child0_child0_child0, root_child0_child0_child0_child0, 0);
+  YGNodeInsertChild(root_child0_child0_child0, root_child0_child0_child0_child0, 0);
 
-  const YGNodeRef root_child0_child0_child0_child0_child0 =
-      YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(
-      root_child0_child0_child0_child0_child0, YGFlexDirectionRow);
-  YGNodeStyleSetAlignContent(
-      root_child0_child0_child0_child0_child0, YGAlignStretch);
-  YGNodeInsertChild(
-      root_child0_child0_child0_child0,
-      root_child0_child0_child0_child0_child0,
-      0);
+  const YGNodeRef root_child0_child0_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0_child0_child0_child0_child0, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root_child0_child0_child0_child0_child0, YGAlignStretch);
+  YGNodeInsertChild(root_child0_child0_child0_child0, root_child0_child0_child0_child0_child0, 0);
 
-  const YGNodeRef root_child0_child0_child0_child0_child0_child0 =
-      YGNodeNewWithConfig(config);
-  YGNodeStyleSetAlignContent(
-      root_child0_child0_child0_child0_child0_child0, YGAlignStretch);
+  const YGNodeRef root_child0_child0_child0_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignContent(root_child0_child0_child0_child0_child0_child0, YGAlignStretch);
   YGNodeStyleSetWidth(root_child0_child0_child0_child0_child0_child0, 120);
   YGNodeStyleSetHeight(root_child0_child0_child0_child0_child0_child0, 120);
-  YGNodeInsertChild(
-      root_child0_child0_child0_child0_child0,
-      root_child0_child0_child0_child0_child0_child0,
-      0);
+  YGNodeInsertChild(root_child0_child0_child0_child0_child0, root_child0_child0_child0_child0_child0_child0, 0);
 
-  const YGNodeRef root_child0_child0_child0_child0_child1 =
-      YGNodeNewWithConfig(config);
-  YGNodeStyleSetAlignContent(
-      root_child0_child0_child0_child0_child1, YGAlignStretch);
+  const YGNodeRef root_child0_child0_child0_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignContent(root_child0_child0_child0_child0_child1, YGAlignStretch);
   YGNodeStyleSetFlexShrink(root_child0_child0_child0_child0_child1, 1);
-  YGNodeStyleSetMargin(
-      root_child0_child0_child0_child0_child1, YGEdgeRight, 36);
-  YGNodeStyleSetPadding(
-      root_child0_child0_child0_child0_child1, YGEdgeLeft, 36);
+  YGNodeStyleSetMargin(root_child0_child0_child0_child0_child1, YGEdgeRight, 36);
+  YGNodeStyleSetPadding(root_child0_child0_child0_child0_child1, YGEdgeLeft, 36);
   YGNodeStyleSetPadding(root_child0_child0_child0_child0_child1, YGEdgeTop, 21);
-  YGNodeStyleSetPadding(
-      root_child0_child0_child0_child0_child1, YGEdgeRight, 36);
-  YGNodeStyleSetPadding(
-      root_child0_child0_child0_child0_child1, YGEdgeBottom, 18);
-  YGNodeInsertChild(
-      root_child0_child0_child0_child0,
-      root_child0_child0_child0_child0_child1,
-      1);
+  YGNodeStyleSetPadding(root_child0_child0_child0_child0_child1, YGEdgeRight, 36);
+  YGNodeStyleSetPadding(root_child0_child0_child0_child0_child1, YGEdgeBottom, 18);
+  YGNodeInsertChild(root_child0_child0_child0_child0, root_child0_child0_child0_child0_child1, 1);
 
-  const YGNodeRef root_child0_child0_child0_child0_child1_child0 =
-      YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(
-      root_child0_child0_child0_child0_child1_child0, YGFlexDirectionRow);
-  YGNodeStyleSetAlignContent(
-      root_child0_child0_child0_child0_child1_child0, YGAlignStretch);
+  const YGNodeRef root_child0_child0_child0_child0_child1_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0_child0_child0_child0_child1_child0, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root_child0_child0_child0_child0_child1_child0, YGAlignStretch);
   YGNodeStyleSetFlexShrink(root_child0_child0_child0_child0_child1_child0, 1);
-  YGNodeInsertChild(
-      root_child0_child0_child0_child0_child1,
-      root_child0_child0_child0_child0_child1_child0,
-      0);
+  YGNodeInsertChild(root_child0_child0_child0_child0_child1, root_child0_child0_child0_child0_child1_child0, 0);
 
-  const YGNodeRef root_child0_child0_child0_child0_child1_child1 =
-      YGNodeNewWithConfig(config);
-  YGNodeStyleSetAlignContent(
-      root_child0_child0_child0_child0_child1_child1, YGAlignStretch);
+  const YGNodeRef root_child0_child0_child0_child0_child1_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignContent(root_child0_child0_child0_child0_child1_child1, YGAlignStretch);
   YGNodeStyleSetFlexShrink(root_child0_child0_child0_child0_child1_child1, 1);
-  YGNodeInsertChild(
-      root_child0_child0_child0_child0_child1,
-      root_child0_child0_child0_child0_child1_child1,
-      1);
+  YGNodeInsertChild(root_child0_child0_child0_child0_child1, root_child0_child0_child0_child0_child1_child1, 1);
 
   const YGNodeRef root_child0_child0_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignContent(root_child0_child0_child1, YGAlignStretch);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child1, 1);
 
-  const YGNodeRef root_child0_child0_child1_child0 =
-      YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(
-      root_child0_child0_child1_child0, YGFlexDirectionRow);
+  const YGNodeRef root_child0_child0_child1_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0_child0_child1_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root_child0_child0_child1_child0, YGAlignStretch);
   YGNodeStyleSetAlignItems(root_child0_child0_child1_child0, YGAlignFlexStart);
   YGNodeStyleSetMargin(root_child0_child0_child1_child0, YGEdgeStart, 174);
   YGNodeStyleSetMargin(root_child0_child0_child1_child0, YGEdgeTop, 24);
-  YGNodeInsertChild(
-      root_child0_child0_child1, root_child0_child0_child1_child0, 0);
+  YGNodeInsertChild(root_child0_child0_child1, root_child0_child0_child1_child0, 0);
 
-  const YGNodeRef root_child0_child0_child1_child0_child0 =
-      YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(
-      root_child0_child0_child1_child0_child0, YGFlexDirectionRow);
-  YGNodeStyleSetAlignContent(
-      root_child0_child0_child1_child0_child0, YGAlignStretch);
-  YGNodeInsertChild(
-      root_child0_child0_child1_child0,
-      root_child0_child0_child1_child0_child0,
-      0);
+  const YGNodeRef root_child0_child0_child1_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0_child0_child1_child0_child0, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root_child0_child0_child1_child0_child0, YGAlignStretch);
+  YGNodeInsertChild(root_child0_child0_child1_child0, root_child0_child0_child1_child0_child0, 0);
 
-  const YGNodeRef root_child0_child0_child1_child0_child0_child0 =
-      YGNodeNewWithConfig(config);
-  YGNodeStyleSetAlignContent(
-      root_child0_child0_child1_child0_child0_child0, YGAlignStretch);
+  const YGNodeRef root_child0_child0_child1_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignContent(root_child0_child0_child1_child0_child0_child0, YGAlignStretch);
   YGNodeStyleSetWidth(root_child0_child0_child1_child0_child0_child0, 72);
   YGNodeStyleSetHeight(root_child0_child0_child1_child0_child0_child0, 72);
-  YGNodeInsertChild(
-      root_child0_child0_child1_child0_child0,
-      root_child0_child0_child1_child0_child0_child0,
-      0);
+  YGNodeInsertChild(root_child0_child0_child1_child0_child0, root_child0_child0_child1_child0_child0_child0, 0);
 
-  const YGNodeRef root_child0_child0_child1_child0_child1 =
-      YGNodeNewWithConfig(config);
-  YGNodeStyleSetAlignContent(
-      root_child0_child0_child1_child0_child1, YGAlignStretch);
+  const YGNodeRef root_child0_child0_child1_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignContent(root_child0_child0_child1_child0_child1, YGAlignStretch);
   YGNodeStyleSetFlexShrink(root_child0_child0_child1_child0_child1, 1);
-  YGNodeStyleSetMargin(
-      root_child0_child0_child1_child0_child1, YGEdgeRight, 36);
-  YGNodeStyleSetPadding(
-      root_child0_child0_child1_child0_child1, YGEdgeLeft, 36);
+  YGNodeStyleSetMargin(root_child0_child0_child1_child0_child1, YGEdgeRight, 36);
+  YGNodeStyleSetPadding(root_child0_child0_child1_child0_child1, YGEdgeLeft, 36);
   YGNodeStyleSetPadding(root_child0_child0_child1_child0_child1, YGEdgeTop, 21);
-  YGNodeStyleSetPadding(
-      root_child0_child0_child1_child0_child1, YGEdgeRight, 36);
-  YGNodeStyleSetPadding(
-      root_child0_child0_child1_child0_child1, YGEdgeBottom, 18);
-  YGNodeInsertChild(
-      root_child0_child0_child1_child0,
-      root_child0_child0_child1_child0_child1,
-      1);
+  YGNodeStyleSetPadding(root_child0_child0_child1_child0_child1, YGEdgeRight, 36);
+  YGNodeStyleSetPadding(root_child0_child0_child1_child0_child1, YGEdgeBottom, 18);
+  YGNodeInsertChild(root_child0_child0_child1_child0, root_child0_child0_child1_child0_child1, 1);
 
-  const YGNodeRef root_child0_child0_child1_child0_child1_child0 =
-      YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(
-      root_child0_child0_child1_child0_child1_child0, YGFlexDirectionRow);
-  YGNodeStyleSetAlignContent(
-      root_child0_child0_child1_child0_child1_child0, YGAlignStretch);
+  const YGNodeRef root_child0_child0_child1_child0_child1_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0_child0_child1_child0_child1_child0, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root_child0_child0_child1_child0_child1_child0, YGAlignStretch);
   YGNodeStyleSetFlexShrink(root_child0_child0_child1_child0_child1_child0, 1);
-  YGNodeInsertChild(
-      root_child0_child0_child1_child0_child1,
-      root_child0_child0_child1_child0_child1_child0,
-      0);
+  YGNodeInsertChild(root_child0_child0_child1_child0_child1, root_child0_child0_child1_child0_child1_child0, 0);
 
-  const YGNodeRef root_child0_child0_child1_child0_child1_child1 =
-      YGNodeNewWithConfig(config);
-  YGNodeStyleSetAlignContent(
-      root_child0_child0_child1_child0_child1_child1, YGAlignStretch);
+  const YGNodeRef root_child0_child0_child1_child0_child1_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignContent(root_child0_child0_child1_child0_child1_child1, YGAlignStretch);
   YGNodeStyleSetFlexShrink(root_child0_child0_child1_child0_child1_child1, 1);
-  YGNodeInsertChild(
-      root_child0_child0_child1_child0_child1,
-      root_child0_child0_child1_child0_child1_child1,
-      1);
+  YGNodeInsertChild(root_child0_child0_child1_child0_child1, root_child0_child0_child1_child0_child1_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
@@ -206,52 +138,30 @@ TEST(YogaTest, android_news_feed) {
   ASSERT_FLOAT_EQ(1044, YGNodeLayoutGetWidth(root_child0_child0_child0_child0));
   ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root_child0_child0_child0_child0));
 
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      120, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      120, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child0));
 
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      120,
-      YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      120,
-      YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child0_child0));
 
-  ASSERT_FLOAT_EQ(
-      120, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child1));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child1));
-  ASSERT_FLOAT_EQ(
-      72, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child1));
-  ASSERT_FLOAT_EQ(
-      39, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child1));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child1));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child1));
+  ASSERT_FLOAT_EQ(39, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child1));
 
-  ASSERT_FLOAT_EQ(
-      36, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child1_child0));
-  ASSERT_FLOAT_EQ(
-      21, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child1_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child1_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child1_child0));
+  ASSERT_FLOAT_EQ(36, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child1_child0));
+  ASSERT_FLOAT_EQ(21, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child1_child0));
 
-  ASSERT_FLOAT_EQ(
-      36, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child1_child1));
-  ASSERT_FLOAT_EQ(
-      21, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child1_child1));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child1_child1));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child1_child1));
+  ASSERT_FLOAT_EQ(36, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child1_child1));
+  ASSERT_FLOAT_EQ(21, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child1_child1));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child1));
   ASSERT_FLOAT_EQ(144, YGNodeLayoutGetTop(root_child0_child0_child1));
@@ -263,51 +173,30 @@ TEST(YogaTest, android_news_feed) {
   ASSERT_FLOAT_EQ(906, YGNodeLayoutGetWidth(root_child0_child0_child1_child0));
   ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0_child0_child1_child0));
 
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child0));
-  ASSERT_FLOAT_EQ(
-      72, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child0));
-  ASSERT_FLOAT_EQ(
-      72, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child0));
 
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      72, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      72,
-      YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child0_child0));
 
-  ASSERT_FLOAT_EQ(
-      72, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child1));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child1));
-  ASSERT_FLOAT_EQ(
-      72, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child1));
-  ASSERT_FLOAT_EQ(
-      39, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child1));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child1));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child1));
+  ASSERT_FLOAT_EQ(39, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child1));
 
-  ASSERT_FLOAT_EQ(
-      36, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child1_child0));
-  ASSERT_FLOAT_EQ(
-      21, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child1_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child1_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child1_child0));
+  ASSERT_FLOAT_EQ(36, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child1_child0));
+  ASSERT_FLOAT_EQ(21, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child1_child0));
 
-  ASSERT_FLOAT_EQ(
-      36, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child1_child1));
-  ASSERT_FLOAT_EQ(
-      21, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child1_child1));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child1_child1));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child1_child1));
+  ASSERT_FLOAT_EQ(36, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child1_child1));
+  ASSERT_FLOAT_EQ(21, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child1_child1));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
 
@@ -336,52 +225,30 @@ TEST(YogaTest, android_news_feed) {
   ASSERT_FLOAT_EQ(1044, YGNodeLayoutGetWidth(root_child0_child0_child0_child0));
   ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root_child0_child0_child0_child0));
 
-  ASSERT_FLOAT_EQ(
-      924, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      120, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      120, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(924, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child0));
 
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      120,
-      YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      120,
-      YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child0_child0));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child0_child0));
 
-  ASSERT_FLOAT_EQ(
-      816, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child1));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child1));
-  ASSERT_FLOAT_EQ(
-      72, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child1));
-  ASSERT_FLOAT_EQ(
-      39, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child1));
+  ASSERT_FLOAT_EQ(816, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child1));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child1));
+  ASSERT_FLOAT_EQ(39, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child1));
 
-  ASSERT_FLOAT_EQ(
-      36, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child1_child0));
-  ASSERT_FLOAT_EQ(
-      21, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child1_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child1_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child1_child0));
+  ASSERT_FLOAT_EQ(36, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child1_child0));
+  ASSERT_FLOAT_EQ(21, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child1_child0));
 
-  ASSERT_FLOAT_EQ(
-      36, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child1_child1));
-  ASSERT_FLOAT_EQ(
-      21, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child1_child1));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child1_child1));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child1_child1));
+  ASSERT_FLOAT_EQ(36, YGNodeLayoutGetLeft(root_child0_child0_child0_child0_child1_child1));
+  ASSERT_FLOAT_EQ(21, YGNodeLayoutGetTop(root_child0_child0_child0_child0_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0_child0_child0_child0_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0_child0_child0_child1_child1));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child1));
   ASSERT_FLOAT_EQ(144, YGNodeLayoutGetTop(root_child0_child0_child1));
@@ -393,51 +260,30 @@ TEST(YogaTest, android_news_feed) {
   ASSERT_FLOAT_EQ(906, YGNodeLayoutGetWidth(root_child0_child0_child1_child0));
   ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0_child0_child1_child0));
 
-  ASSERT_FLOAT_EQ(
-      834, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child0));
-  ASSERT_FLOAT_EQ(
-      72, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child0));
-  ASSERT_FLOAT_EQ(
-      72, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child0));
+  ASSERT_FLOAT_EQ(834, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child0));
 
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      72, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child0_child0));
-  ASSERT_FLOAT_EQ(
-      72,
-      YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child0_child0));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child0_child0));
 
-  ASSERT_FLOAT_EQ(
-      726, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child1));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child1));
-  ASSERT_FLOAT_EQ(
-      72, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child1));
-  ASSERT_FLOAT_EQ(
-      39, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child1));
+  ASSERT_FLOAT_EQ(726, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child1));
+  ASSERT_FLOAT_EQ(72, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child1));
+  ASSERT_FLOAT_EQ(39, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child1));
 
-  ASSERT_FLOAT_EQ(
-      36, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child1_child0));
-  ASSERT_FLOAT_EQ(
-      21, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child1_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child1_child0));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child1_child0));
+  ASSERT_FLOAT_EQ(36, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child1_child0));
+  ASSERT_FLOAT_EQ(21, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child1_child0));
 
-  ASSERT_FLOAT_EQ(
-      36, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child1_child1));
-  ASSERT_FLOAT_EQ(
-      21, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child1_child1));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child1_child1));
-  ASSERT_FLOAT_EQ(
-      0, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child1_child1));
+  ASSERT_FLOAT_EQ(36, YGNodeLayoutGetLeft(root_child0_child0_child1_child0_child1_child1));
+  ASSERT_FLOAT_EQ(21, YGNodeLayoutGetTop(root_child0_child0_child1_child0_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0_child0_child1_child0_child1_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0_child1_child0_child1_child1));
 
   YGNodeFreeRecursive(root);
 

--- a/tests/YGMarginTest.cpp
+++ b/tests/YGMarginTest.cpp
@@ -1230,7 +1230,7 @@ TEST(YogaTest, margin_auto_right) {
   YGConfigFree(config);
 }
 
-TEST(YogaTest, margin_auto_left_and_right_strech) {
+TEST(YogaTest, margin_auto_left_and_right_stretch) {
   const YGConfigRef config = YGConfigNew();
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
@@ -1288,7 +1288,7 @@ TEST(YogaTest, margin_auto_left_and_right_strech) {
   YGConfigFree(config);
 }
 
-TEST(YogaTest, margin_auto_top_and_bottom_strech) {
+TEST(YogaTest, margin_auto_top_and_bottom_stretch) {
   const YGConfigRef config = YGConfigNew();
 
   const YGNodeRef root = YGNodeNewWithConfig(config);


### PR DESCRIPTION
In test fixtures, some `align-items` are defined as `strech`. It should be `stretch`.

```
<div style="align-items: strech;">
```

but it doesn't affect test result in spite of the typo because`stretch` is the default value of `align-items`