### PR TITLE
`flexWrap` should be kebab-case inside inline-style

### DIFF
--- a/yoga/YGNodePrint.cpp
+++ b/yoga/YGNodePrint.cpp
@@ -165,7 +165,7 @@ void YGNodeToString(
 
     if (node->getStyle().flexWrap != YGNode().getStyle().flexWrap) {
       appendFormatedString(
-          str, "flexWrap: %s; ", YGWrapToString(node->getStyle().flexWrap));
+          str, "flex-wrap: %s; ", YGWrapToString(node->getStyle().flexWrap));
     }
 
     if (node->getStyle().overflow != YGNode().getStyle().overflow) {


### PR DESCRIPTION
Inside css inline style, it should be spelled as `flex-wrap`.