### PR TITLE
Add back deprecated getParent methods for non-breaking API change

### DIFF
--- a/java/com/facebook/yoga/YogaNode.java
+++ b/java/com/facebook/yoga/YogaNode.java
@@ -234,15 +234,14 @@ public class YogaNode implements Cloneable {
    * {@link YogaNode} is shared between two or more YogaTrees.
    */
   @Nullable
-  public
-  YogaNode getOwner() {
+  public YogaNode getOwner() {
     return mOwner;
   }
 
   /** @deprecated Use #getOwner() instead. This will be removed in the next version. */
   @Deprecated
   @Nullable
-  YogaNode getParent() {
+  public YogaNode getParent() {
     return getOwner();
   }
 

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -53,6 +53,10 @@ YGNodeRef YGNode::getOwner() const {
   return owner_;
 }
 
+YGNodeRef YGNode::getParent() const {
+  return getOwner();
+}
+
 YGVector YGNode::getChildren() const {
   return children_;
 }

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -78,6 +78,8 @@ struct YGNode {
   // to one YogaTree or nullptr when the YGNode is shared between two or more
   // YogaTrees.
   YGNodeRef getOwner() const;
+  // Deprecated, use getOwner() instead.
+  YGNodeRef getParent() const;
   YGVector getChildren() const;
   uint32_t getChildrenCount() const;
   YGNodeRef getChild(uint32_t index) const;

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -535,6 +535,10 @@ YGNodeRef YGNodeGetOwner(const YGNodeRef node) {
   return node->getOwner();
 }
 
+YGNodeRef YGNodeGetParent(const YGNodeRef node) {
+  return node->getOwner();
+}
+
 void YGNodeMarkDirty(const YGNodeRef node) {
   YGAssertWithNode(
       node,

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -92,6 +92,7 @@ WIN_EXPORT void YGNodeRemoveChild(const YGNodeRef node, const YGNodeRef child);
 WIN_EXPORT void YGNodeRemoveAllChildren(const YGNodeRef node);
 WIN_EXPORT YGNodeRef YGNodeGetChild(const YGNodeRef node, const uint32_t index);
 WIN_EXPORT YGNodeRef YGNodeGetOwner(const YGNodeRef node);
+WIN_EXPORT YGNodeRef YGNodeGetParent(const YGNodeRef node);
 WIN_EXPORT uint32_t YGNodeGetChildCount(const YGNodeRef node);
 WIN_EXPORT void YGNodeSetChildren(
     YGNodeRef const owner,


### PR DESCRIPTION
I'm not totally sure what I'm doing so if this needs changes let me know.