### PR TITLE
Use correct spelling ('then' -> 'than')

### DIFF
--- a/website/src/pages/docs/index.js
+++ b/website/src/pages/docs/index.js
@@ -34,7 +34,7 @@ export default ({data}) => (
             comes with an interactive playground for you to explore that
             feature. The examples section showcases some of the most common
             layouts and how to build them. This is a community projects and
-            contributions within documentation, code, and tests are more then
+            contributions within documentation, code, and tests are more than
             welcome. The contributing section below covers how to get started.
           </p>
         </Col>


### PR DESCRIPTION
Might be the smallest PR in the world, but it caught my eye reading the
docs so I figured I should fix it.