### PR TITLE
Feature podspec modules

### DIFF
--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -16,6 +16,9 @@ Pod::Spec.new do |spec|
   spec.platforms = { :ios => "8.0", :tvos => "10.0" }
   spec.module_name = 'yoga'
   spec.requires_arc = false
+  spec.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES'
+  }
   spec.compiler_flags = [
       '-fno-omit-frame-pointer',
       '-fexceptions',

--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'Yoga'
-  spec.version = '1.8.1'
+  spec.version = '1.9'
   spec.license =  { :type => 'MIT', :file => "LICENSE" }
   spec.homepage = 'https://yogalayout.com/'
   spec.documentation_url = 'https://yogalayout.com/docs'


### PR DESCRIPTION
This PR adds support for using Yoga Swift dependents when Yoga is pulled as a static library.

### What is the problem?

Currently swift projects trying to pull static libraries are unable to import the module. The reason for that is because the `DEFINES_MODULES` build setting is set to`NO`.  If a Swift Framework is trying to `pod spec lint --use-libraries` with `Yoga` as a dependency, the validation will fail. With the `DEFINES_MODULE` enabled, the product will be treated as defining its own module. This enables automatic production of LLVM module map files when appropriate, and allows the product to be imported as a module.

A workaround to this issue would be passing the `:modular_headers` flag to the `Podfile`, but that would not fix the `pod spec lint` validation for framework/library dependencies, it would just allow consuming applications to build and run.

### Example of an existing issue

An example of this issue would be [SonarKit](https://github.com/facebook/Sonar/blob/master/iOS/SonarKit.podspec). `SonarKit` wasn't able to validate its podspec due to `YogaKit` (Swift Framework) depending on `Yoga` and SonarKit validating with the `--use-libraries` flag due to the c++ dependencies. We had to create a new version of [Yoga 1.9 podspec](https://github.com/facebook/Sonar/blob/master/Specs/Yoga/1.9/Yoga.podspec.json) and make sure to set the `DEFINES_MODULE` flag of the pod target. After that, we were able to `pod spec lint` `SonarKit.podspec` successfully.


After merging a new `tag` should be created and the new podspec should be pushed to cocoapods master repository.