### PR TITLE
When paddingStart is 0, is should override paddingHorizontal

### DIFF
--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -458,7 +458,7 @@ YGFloatOptional YGNode::getLeadingPadding(
       YGResolveValue(style_.padding[YGEdgeStart], widthSize);
   if (YGFlexDirectionIsRow(axis) &&
       style_.padding[YGEdgeStart].unit != YGUnitUndefined &&
-      !paddingEdgeStart.isUndefined() && paddingEdgeStart.getValue() > 0.0f) {
+      !paddingEdgeStart.isUndefined() && paddingEdgeStart.getValue() >= 0.0f) {
     return paddingEdgeStart;
   }
 


### PR DESCRIPTION
Fixes #815

### Problem

Imagine a node with this style: `{ paddingHorizontal: 10, paddingStart: 0 }`.

After running layout on this node, we expect its computed `paddingStart` to be `0`. However, it is actually `10`.

### Fix

Consider the expression `paddingEdgeStart.getValue() > 0.0f` in [`getLeadingPadding`](https://github.com/facebook/yoga/blob/328ec7dc4d104b42b836d5ccebff04033d045133/yoga/YGNode.cpp#L461). Why is `0` handled like a negative number rather than a positive number? I suspect this should be `>=` so `0` is handled like the positive numbers (this is how `getTrailingPadding` works).

### History

It looks like https://github.com/facebook/yoga/commit/3a82d2b1a8f5b65a2c3bd1407552d3ed2226238e?diff=unified&w=1#diff-07b4949bf42749fde386e769ff08a124 changed the operator from `>=` to `>` in `getLeadingPadding`. I suspect it was a mistake. `getTrailingPadding` still uses `>=`.

### Testing

I manually verified this using the code in #815.

I'm not sure how to write a test for this since it requires setting `paddingHorizontal` which isn't supported on the web. AFAIK, all of the Yoga tests are code-generated based on web browser behavior.

Adam Comella
Microsoft Corp.