### PR TITLE
C#: Change NaN with large number

### DIFF
--- a/csharp/Facebook.Yoga/YogaConstants.cs
+++ b/csharp/Facebook.Yoga/YogaConstants.cs
@@ -9,11 +9,28 @@ namespace Facebook.Yoga
 {
     public static class YogaConstants
     {
-        public const float Undefined = float.NaN;
+        /**
+         * Large positive number signifies that the property(float) is undefined. Earlier we used to have
+         * YGundefined as NAN, but the downside of this is that we can't use -ffast-math compiler flag as
+         * it assumes all floating-point calculation involve and result into finite numbers. For more
+         * information regarding -ffast-math compiler flag in clang, have a look at
+         * https://clang.llvm.org/docs/UsersManual.html#cmdoption-ffast-math
+         */
+        public const float Undefined = 10E20F;
 
         public static bool IsUndefined(float value)
         {
-            return float.IsNaN(value);
+            // Value of a float in the case of it being not defined is 10.1E20. Earlier it used to be NAN,
+            // the benefit of which
+            // was that if NAN is involved in any mathematical expression the result was NAN. But since we
+            // want to have `-ffast-math`
+            // flag being used by compiler which assumes that the floating point values are not NAN and Inf,
+            // we represent YGUndefined as 10.1E20.
+            // But now if YGUndefined is involved in any mathematical operations this value(10.1E20) would
+            // change.
+            // So the following check makes sure that if the value is outside a range (-10E8, 10E8) then it
+            // is undefined.
+            return value >= 10E8F || value <= -10E8;
         }
 
         public static bool IsUndefined(YogaValue value)


### PR DESCRIPTION
This PR is the C# version of https://github.com/facebook/yoga/commit/3a82d2b1a8f5b65a2c3bd1407552d3ed2226238e?w=1

The above change moved Yoga away from NaN to facilitate usage of the `-ffast-math` compiler flag. However, that commit forgot to update the C# implementation.