### PR TITLE
Fix C# unit tests

### DIFF
--- a/csharp/Windows/Facebook.Yoga.Universal.Tests/YogaNodeTest.cs
+++ b/csharp/Windows/Facebook.Yoga.Universal.Tests/YogaNodeTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 using Facebook.Yoga;
 
@@ -206,8 +206,8 @@ namespace Facebook.Yoga.Universal.Tests
                 return MeasureOutput.Make(123.4f, 81.7f);
             });
             node.CalculateLayout();
-            Assert.AreEqual(123, node.LayoutWidth);
-            Assert.AreEqual(81, node.LayoutHeight);
+            Assert.AreEqual(124, node.LayoutWidth);
+            Assert.AreEqual(82, node.LayoutHeight);
         }
 
         [TestMethod]
@@ -268,7 +268,12 @@ namespace Facebook.Yoga.Universal.Tests
             parent.Insert(0, child0);
             parent.Insert(0, child1);
             parent.CalculateLayout();
-            Assert.AreEqual(parent.Print(), "{layout: {width: 100, height: 120, top: 0, left: 0}, flexDirection: 'column', alignItems: 'stretch', flexGrow: 0, flexShrink: 0, overflow: 'visible', width: 100, height: 120, children: [\n  {layout: {width: 35, height: 45, top: 0, left: 0}, flexDirection: 'column', alignItems: 'stretch', flexGrow: 0, flexShrink: 0, overflow: 'visible', width: 35, height: 45, },\n  {layout: {width: 30, height: 40, top: 45, left: 0}, flexDirection: 'column', alignItems: 'stretch', flexGrow: 0, flexShrink: 0, overflow: 'visible', width: 30, height: 40, },\n]},\n");
+            Assert.AreEqual(parent.Print(),
+              "<div layout=\"width: 100; height: 120; top: 0; left: 0;\" style=\"width: 100px; height: 120px; \" >\n" +
+              "  <div layout=\"width: 35; height: 45; top: 0; left: 0;\" style=\"width: 35px; height: 45px; \" ></div>\n" +
+              "  <div layout=\"width: 30; height: 40; top: 45; left: 0;\" style=\"width: 30px; height: 40px; \" ></div>\n" +
+              "</div>"
+            );
         }
 
         [TestMethod]
@@ -285,7 +290,7 @@ namespace Facebook.Yoga.Universal.Tests
         }
 
 #if !UNITY_EDITOR
-        private void ForceGC()
+    private void ForceGC()
         {
             GC.Collect(GC.MaxGeneration);
             GC.WaitForPendingFinalizers();

--- a/csharp/Windows/Facebook.Yoga.Universal.Tests/YogaNodeTest.cs
+++ b/csharp/Windows/Facebook.Yoga.Universal.Tests/YogaNodeTest.cs
@@ -290,7 +290,7 @@ namespace Facebook.Yoga.Universal.Tests
         }
 
 #if !UNITY_EDITOR
-    private void ForceGC()
+        private void ForceGC()
         {
             GC.Collect(GC.MaxGeneration);
             GC.WaitForPendingFinalizers();

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -153,11 +153,11 @@ WIN_EXPORT void YGNodeCopyStyle(
     const YGNodeRef dstNode,
     const YGNodeRef srcNode);
 
-void* YGNodeGetContext(YGNodeRef node);
-void YGNodeSetContext(YGNodeRef node, void* context);
+WIN_EXPORT void* YGNodeGetContext(YGNodeRef node);
+WIN_EXPORT void YGNodeSetContext(YGNodeRef node, void* context);
 void YGConfigSetPrintTreeFlag(YGConfigRef config, bool enabled);
 YGMeasureFunc YGNodeGetMeasureFunc(YGNodeRef node);
-void YGNodeSetMeasureFunc(YGNodeRef node, YGMeasureFunc measureFunc);
+WIN_EXPORT void YGNodeSetMeasureFunc(YGNodeRef node, YGMeasureFunc measureFunc);
 YGBaselineFunc YGNodeGetBaselineFunc(YGNodeRef node);
 void YGNodeSetBaselineFunc(YGNodeRef node, YGBaselineFunc baselineFunc);
 YGDirtiedFunc YGNodeGetDirtiedFunc(YGNodeRef node);


### PR DESCRIPTION
This consists of several fixes:
  - Some of the C++ functions called by the tests were missing `WIN_EXPORT`
  - It looks like Yoga was changed to round up after `TestMeasureFuncWithFloat` was written. Here's the function call that results in the rounding: https://github.com/facebook/yoga/blob/357ca78f9f7bd86298ef00a1426cac5ca2041d3b/yoga/Yoga.cpp#L4019-L4026
  - The format of the result of the `Print` method was changed after `TestPrint` was written.