### PR TITLE
 Move YGValue operator overloads outside of extern C. 

### DIFF
--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -45,13 +45,6 @@ typedef struct YGValue {
 extern const YGValue YGValueUndefined;
 extern const YGValue YGValueAuto;
 
-#ifdef __cplusplus
-
-extern bool operator==(const YGValue& lhs, const YGValue& rhs);
-extern bool operator!=(const YGValue& lhs, const YGValue& rhs);
-
-#endif
-
 typedef struct YGConfig* YGConfigRef;
 
 typedef struct YGNode* YGNodeRef;
@@ -458,5 +451,8 @@ extern void YGTraversePreOrder(
 extern void YGNodeSetChildren(
     YGNodeRef const owner,
     const std::vector<YGNodeRef>& children);
+
+extern bool operator==(const YGValue& lhs, const YGValue& rhs);
+extern bool operator!=(const YGValue& lhs, const YGValue& rhs);
 
 #endif


### PR DESCRIPTION
Currently the == and != operators for YGValue are declared with C linkage, despite C not being able to take advantage of such operators.

This causes issues, at least with MSVC, when another library makes the same mistake (I haven't dug into it, but somehow Catch2 causes the Windows SDK's guiddef.h to do this) and the two operator functions symbols collide.