### PR TITLE
Allow Yoga Pod to be built on any platform

### DIFF
--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |spec|
     :git => 'https://github.com/facebook/yoga.git',
     :tag => spec.version.to_s,
   }
+  spec.platforms = { :ios => "4.3", :osx => "10.7", :tvos => "10.0", :watchos => "2.0" }
   spec.module_name = 'yoga'
   spec.requires_arc = false
   spec.pod_target_xcconfig = {

--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -19,7 +19,6 @@ Pod::Spec.new do |spec|
     :git => 'https://github.com/facebook/yoga.git',
     :tag => spec.version.to_s,
   }
-  spec.platforms = { :ios => "8.0", :tvos => "10.0" }
   spec.module_name = 'yoga'
   spec.requires_arc = false
   spec.pod_target_xcconfig = {

--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -34,6 +34,6 @@ Pod::Spec.new do |spec|
       '-fPIC'
   ]
   spec.source_files = 'yoga/**/*.{c,h,cpp}'
-  spec.public_header_files = 'yoga/{Yoga,YGEnums,YGMacros}.h'
+  spec.public_header_files = 'yoga/{Yoga,YGEnums,YGMacros,YGValue}.h'
 
 end


### PR DESCRIPTION
Currently the CocoaPod for Yoga explicitly states platform requirements.

Since the Yoga implementation doesn't depend on any platform features, it would be safe to build it on any platform.

That can be configured by omitting the `platform`/`platforms` key:

> The platform on which this Pod is supported. Leaving this blank means the Pod is supported on all platforms.
>
> http://guides.cocoapods.org/syntax/podspec.html#platform

Among others, that would allow to use the pod in macOS projects