### PR TITLE
Fix build error caused by -Werror=class-memaccess

### DIFF
--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -1851,7 +1851,7 @@ static bool YGNodeFixedSizeSetMeasuredDimensions(
 }
 
 static void YGZeroOutLayoutRecursivly(const YGNodeRef node) {
-  memset(&(node->getLayout()), 0, sizeof(YGLayout));
+  memset(static_cast<void*>(&(node->getLayout())), 0, sizeof(YGLayout));
   node->setHasNewLayout(true);
   node->cloneChildrenIfNeeded();
   const uint32_t childCount = YGNodeGetChildCount(node);

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -1851,7 +1851,9 @@ static bool YGNodeFixedSizeSetMeasuredDimensions(
 }
 
 static void YGZeroOutLayoutRecursivly(const YGNodeRef node) {
-  memset(static_cast<void*>(&(node->getLayout())), 0, sizeof(YGLayout));
+  node->getLayout() = {};
+  node->setLayoutDimension(0, 0);
+  node->setLayoutDimension(0, 1);
   node->setHasNewLayout(true);
   node->cloneChildrenIfNeeded();
   const uint32_t childCount = YGNodeGetChildCount(node);


### PR DESCRIPTION
OS: Arch Linux
GCC Version: gcc (GCC) 8.2.1 20180831
Clang Version: 6.0.1 (tags/RELEASE_601/final)

Build Log Before Fix:

command: `buck build //:yoga`
```
Not using buckd because watchman isn't installed.
yoga/Yoga.cpp: In function ‘void YGZeroOutLayoutRecursivly(YGNodeRef)’:
yoga/Yoga.cpp:1854:51: error: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct YGLayout’; use assignment or value-initialization instead [-Werror=class-memaccess]
   memset(&(node->getLayout()), 0, sizeof(YGLayout));
                                                   ^
In file included from yoga/YGNode.h:11,
                 from yoga/Utils.h:9,
                 from yoga/Yoga.cpp:13:
yoga/YGLayout.h:12:8: note: ‘struct YGLayout’ declared here
 struct YGLayout {
        ^~~~~~~~
cc1plus: all warnings being treated as errors
Build failed: Command failed with exit code 1.
stderr: yoga/Yoga.cpp: In function ‘void YGZeroOutLayoutRecursivly(YGNodeRef)’:
yoga/Yoga.cpp:1854:51: error: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct YGLayout’; use assignment or value-initialization instead [-Werror=class-memaccess]
   memset(&(node->getLayout()), 0, sizeof(YGLayout));
                                                   ^
In file included from yoga/YGNode.h:11,
                 from yoga/Utils.h:9,
                 from yoga/Yoga.cpp:13:
yoga/YGLayout.h:12:8: note: ‘struct YGLayout’ declared here
 struct YGLayout {
        ^~~~~~~~
cc1plus: all warnings being treated as errors
    When running <c++ preprocess_and_compile>.
    When building rule //:yoga#compile-Yoga.cpp.o9b5477b5,default.
Parsing buck files: finished in 0.8 sec (100%)
Building: finished in 2.2 sec (100%) 10/10 jobs, 1 updated
  Total time: 3.3 sec
```

Build Log After Fix

command: `buck build //:yoga`
```
Not using buckd because watchman isn't installed.
Parsing buck files: finished in 0.8 sec (100%)
Building: finished in 0.6 sec (100%) 1/1 jobs, 0 updated
  Total time: 1.6 sec
```

All tests are passing
