### PR TITLE
Fix Android snapshot version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 
 org.gradle.jvmargs=-Xmx1536M
 
-VERSION_NAME=1.10.0-SNAPSHOT
+VERSION_NAME=1.10.1-SNAPSHOT
 POM_URL=https://github.com/facebook/yoga
 POM_SCM_URL=https://github.com/facebook/yoga.git
 POM_SCM_CONNECTION=scm:git:https://github.com/facebook/yoga.git


### PR DESCRIPTION
Summary:
The current snapshot version is not in line with the standard versioning
scheme.

Test Plan:
Let CI do it's thing, observe Litho CI not failing anymore (hopefully).