### PR TITLE
Fix typo 'laid our' to 'laid out'

### DIFF
--- a/website/contents/properties/layout-direction.md
+++ b/website/contents/properties/layout-direction.md
@@ -14,10 +14,10 @@ refers to `right`. When localizing your apps for markets with RTL languages
 you should customize this by either by passing a direction
 to the `CalculateLayout` call or by setting the direction on the root node.
 
-**LTR (DEFAULT)** Text and children and laid our from left to right. Margin and
+**LTR (DEFAULT)** Text and children and laid out from left to right. Margin and
 padding applied the start of an element are applied on the left side.
 
-**RTL** Text and children and laid our from right to left. Margin and
+**RTL** Text and children and laid out from right to left. Margin and
 padding applied the start of an element are applied on the right side.
 
 <controls prop="layoutDirection"></controls>


### PR DESCRIPTION
I've fixed typo `laid our` to `laid out` in [`website/contents/properties/layout-direction.md`].