### PR TITLE
Fix issues with top, bottom, left, right keys in generated React Native code

### DIFF
--- a/website/src/components/Playground/CodeReactNative.js
+++ b/website/src/components/Playground/CodeReactNative.js
@@ -96,9 +96,11 @@ function getLayoutCode(node: LayoutRecordT, indent: string = ''): string {
         ) {
           lines.push(
             indent +
-              `  ${key}${pKey[0].toUpperCase()}${pKey.substr(1)}: ${getValue(
-                node[key][pKey],
-              )},`,
+              `  ${
+                key === "position"
+                  ? pKey
+                  : `${key}${pKey[0].toUpperCase()}${pKey.substr(1)}`
+              }: ${getValue(node[key][pKey])},`
           );
         }
       });

--- a/website/src/components/Playground/CodeReactNative.js
+++ b/website/src/components/Playground/CodeReactNative.js
@@ -71,18 +71,19 @@ function getLayoutCode(node: LayoutRecordT, indent: string = ''): string {
         top !== untouchedLayout[key].top &&
         top === left &&
         top === right &&
-        top === bottom
+        top === bottom &&
+        key !== 'position'
       ) {
         // all edges
         lines.push(indent + `  ${key}: ${node[key].top},`);
         return;
       }
       const alreadySet = [];
-      if (top && top !== untouchedLayout[key].top && top === bottom) {
+      if (top && top !== untouchedLayout[key].top && top === bottom && key !== 'position') {
         lines.push(indent + `  ${key}Vertical: ${getValue(node[key].top)},`);
         alreadySet.push('top', 'bottom');
       }
-      if (left && left !== untouchedLayout[key].left && left === right) {
+      if (left && left !== untouchedLayout[key].left && left === right && key !== 'position') {
         lines.push(indent + `  ${key}Horizontal: ${getValue(node[key].left)},`);
         alreadySet.push('left', 'right');
       }


### PR DESCRIPTION
This fixes two issues in the generation of React Native code.
* The `top: 10px` property is being generated as `positionTop: 10px` (as are bottom, left and right)
* `positionTop: 10px` and `positionBottom: 10px` is being combined into `positionVertical: 10px` (as is left and right into horizontal).