### PR TITLE
Addresses thread safety, GitHub issue #769.

### DIFF
--- a/yoga/YGLayout.h
+++ b/yoga/YGLayout.h
@@ -22,12 +22,8 @@ struct YGLayout {
   bool doesLegacyStretchFlagAffectsLayout : 1;
   bool hadOverflow : 1;
 
-  uint32_t computedFlexBasisGeneration = 0;
   YGFloatOptional computedFlexBasis = {};
 
-  // Instead of recomputing the entire layout every single time, we cache some
-  // information to break early when nothing changed
-  uint32_t generationCount = 0;
   YGDirection lastOwnerDirection = (YGDirection) -1;
 
   uint32_t nextCachedMeasurementsIndex = 0;

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -189,11 +189,6 @@ void YGNode::setLayoutPosition(float position, int index) {
   layout_.position[index] = position;
 }
 
-void YGNode::setLayoutComputedFlexBasisGeneration(
-    uint32_t computedFlexBasisGeneration) {
-  layout_.computedFlexBasisGeneration = computedFlexBasisGeneration;
-}
-
 void YGNode::setLayoutMeasuredDimension(float measuredDimension, int index) {
   layout_.measuredDimensions[index] = measuredDimension;
 }

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -239,8 +239,6 @@ public:
   void setDirty(bool isDirty);
   void setLayoutLastOwnerDirection(YGDirection direction);
   void setLayoutComputedFlexBasis(const YGFloatOptional computedFlexBasis);
-  void setLayoutComputedFlexBasisGeneration(
-      uint32_t computedFlexBasisGeneration);
   void setLayoutMeasuredDimension(float measuredDimension, int index);
   void setLayoutHadOverflow(bool hadOverflow);
   void setLayoutDimension(float dimension, int index);


### PR DESCRIPTION
See also: discussions in PR #852 and #786.

In addition to improving thread safety, it removes 8 bytes of heap per node.