### PR TITLE
minus total outer flex basis for available width or height, when compute flex basis for children

### DIFF
--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -1937,6 +1937,20 @@ static void YGNodeComputeFlexBasisForChildren(
   }
 
   for (auto child : children) {
+
+    float availableWidthForChild = availableInnerWidth;
+    float availableHeightForChild = availableInnerHeight;
+
+    if (YGFlexDirectionIsRow(mainAxis)) {
+      if (!YGFloatIsUndefined(availableInnerWidth)) {
+        availableWidthForChild -= totalOuterFlexBasis;
+      }
+    } else {
+      if (!YGFloatIsUndefined(availableInnerHeight)) {
+        availableHeightForChild -= totalOuterFlexBasis;
+      }
+    }
+
     child->resolveDimension();
     if (child->getStyle().display == YGDisplayNone) {
       YGZeroOutLayoutRecursivly(child);
@@ -1948,11 +1962,11 @@ static void YGNodeComputeFlexBasisForChildren(
       // Set the initial position (relative to the owner).
       const YGDirection childDirection = child->resolveDirection(direction);
       const float mainDim = YGFlexDirectionIsRow(mainAxis)
-          ? availableInnerWidth
-          : availableInnerHeight;
+          ? availableWidthForChild
+          : availableHeightForChild;
       const float crossDim = YGFlexDirectionIsRow(mainAxis)
-          ? availableInnerHeight
-          : availableInnerWidth;
+          ? availableHeightForChild
+          : availableWidthForChild;
       child->setPosition(
           childDirection, mainDim, crossDim, availableInnerWidth);
     }
@@ -1967,9 +1981,9 @@ static void YGNodeComputeFlexBasisForChildren(
       YGNodeComputeFlexBasisForChild(
           node,
           child,
-          availableInnerWidth,
+          availableWidthForChild,
           widthMeasureMode,
-          availableInnerHeight,
+          availableHeightForChild,
           availableInnerWidth,
           availableInnerHeight,
           heightMeasureMode,


### PR DESCRIPTION
I put an ImageView and an UILabel in a horizontal flex layout, the label's size is not calculated correctly. The size passed to UILabel's sizeThatFits is not correct. I think it should minus the previous calculated totalOuterFlexBasis. 

Thanks.