### PR TITLE
use docker for android related build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 os: linux
+services:
+  - docker
 addons:
   apt:
     sources:
@@ -27,22 +29,6 @@ before_install:
     if [[ -n "$encrypted_d27e803291ff_iv" ]]; then
       openssl aes-256-cbc -K $encrypted_d27e803291ff_key -iv $encrypted_d27e803291ff_iv -in scripts/setup-keys.enc -d >> gradle.properties;
     fi
-  # Android
-  - |
-    if [[ $TARGET = "android" ]]; then
-      pushd $HOME
-      git clone --depth 1 https://github.com/facebook/buck.git
-      cd buck
-      ant
-      popd
-      export PATH=$PATH:$HOME/buck/bin/
-      buck --version
-      export TERMINAL=dumb
-      source scripts/android-setup.sh && installAndroidSDK
-      export ANDROID_SDK=$ANDROID_HOME
-      export ANDROID_NDK_REPOSITORY=$HOME/android-ndk
-      export ANDROID_NDK_HOME=$ANDROID_NDK_REPOSITORY/android-ndk-r15c
-    fi
   # Website
   - |
     if [[ $TARGET = "website" ]]; then
@@ -53,7 +39,7 @@ before_install:
 script:
   - |
     if [[ $TARGET = "android" ]]; then
-      ./gradlew testDebugUnit && scripts/publish-snapshot.sh
+      docker run --rm -v $PWD:/pwd -w /pwd reactnativecommunity/react-native-android bash -c "./gradlew testDebugUnit && scripts/publish-snapshot.sh"
     fi
   - |
     if [[ $TARGET = "website" ]]; then


### PR DESCRIPTION
## what is being fixed
Currently ci in master failed due to ndk version
## how is it fixed
use the android docker same as react-native (which include buck, ndk,=)
## why is docker being added.
see above.