### PR TITLE
Fix cmake build / update CMakeLists.txt to use C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,3 +13,4 @@ file(GLOB yogacore_SRC yoga/*.cpp)
 add_library(yogacore STATIC ${yogacore_SRC})
 
 target_link_libraries(yogacore android log)
+set_target_properties(yogacore PROPERTIES CXX_STANDARD 11)


### PR DESCRIPTION
On MacOS, the following steps result in build errors:

```
mkdir build
cd build
cmake ..
make
```

The problem is that yogacore uses C++11 features (`constexpr`) but C++11 isn't specified in CMakeLists.txt.

This PR solves the poblem by adding the following code to the bottom of CMakeLists.txt:

```
set_target_properties(yogacore PROPERTIES CXX_STANDARD 11)
```

This solution was derived from https://stackoverflow.com/questions/45688522/how-to-enable-c17-in-cmake