### PR TITLE
Fix compilation with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,5 +12,6 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 file(GLOB yogacore_SRC yoga/*.cpp)
 add_library(yogacore STATIC ${yogacore_SRC})
 
+target_include_directories(yogacore PUBLIC .)
 target_link_libraries(yogacore android log)
 set_target_properties(yogacore PROPERTIES CXX_STANDARD 11)


### PR DESCRIPTION
This adds the root of the source tree to the include path, which allow `#include <yoga/YGEnums.h>` to work.

Fixes #908