### PR TITLE
Remove incorrect constexpr specifier in YGLayout

### DIFF
--- a/yoga/YGLayout.h
+++ b/yoga/YGLayout.h
@@ -8,12 +8,9 @@
 #include "YGFloatOptional.h"
 #include "Yoga-internal.h"
 
-constexpr std::array<float, 2> kYGDefaultDimensionValues = {
-    {YGUndefined, YGUndefined}};
-
 struct YGLayout {
   std::array<float, 4> position = {};
-  std::array<float, 2> dimensions = kYGDefaultDimensionValues;
+  std::array<float, 2> dimensions = {{YGUndefined, YGUndefined}};
   std::array<float, 4> margin = {};
   std::array<float, 4> border = {};
   std::array<float, 4> padding = {};
@@ -33,7 +30,7 @@ struct YGLayout {
   uint32_t nextCachedMeasurementsIndex = 0;
   std::array<YGCachedMeasurement, YG_MAX_CACHED_RESULT_COUNT>
       cachedMeasurements = {};
-  std::array<float, 2> measuredDimensions = kYGDefaultDimensionValues;
+  std::array<float, 2> measuredDimensions = {{YGUndefined, YGUndefined}};
 
   YGCachedMeasurement cachedLayout = YGCachedMeasurement();
 


### PR DESCRIPTION
Summary:
* According to C++ standard values which produce undefined behavior cannot be declared as `constexpr`.
* Expressions which evaluate to `nan, infinity, etc` are undefined behavior.

For more details you can checkout this Stackoverflow answer: https://stackoverflow.com/a/46373136

Differential Revision: D16055108

