### PR TITLE
Remove bit specification from nodeType_ in YGNode.h

### DIFF
--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -27,7 +27,7 @@ private:
   bool hasNewLayout_ : 1;
   bool isReferenceBaseline_ : 1;
   bool isDirty_ : 1;
-  YGNodeType nodeType_ : 1;
+  YGNodeType nodeType_ = {};
   bool measureUsesContext_ : 1;
   bool baselineUsesContext_ : 1;
   bool printUsesContext_ : 1;


### PR DESCRIPTION
Fix failing textRounding flag by changing YGNodeType field in YGNode struct. Top 7 bits will now be in agreement with enum value allowing for comparisions without masking bit values.
By fixing the textRounding flag in Yoga.cpp's YGRoundToPixelGrid method (at line 4001), Text components will no longer attempt to round their width value to align with a whole pixel value. This flag being broken caused issues when the text was scaled leading to truncation of the text at certain scaled sizes of view with fractional width values.