### PR TITLE
yoga | Fix error about implicit conversion to bit-field

### DIFF
--- a/yoga/YGStyle.h
+++ b/yoga/YGStyle.h
@@ -102,6 +102,11 @@ public:
     }
   };
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wbitfield-constant-conversion"
+#endif
+
   YGStyle()
       : direction_(YGDirectionInherit),
         flexDirection_(YGFlexDirectionColumn),
@@ -113,6 +118,11 @@ public:
         flexWrap_(YGWrapNoWrap),
         overflow_(YGOverflowVisible),
         display_(YGDisplayFlex) {}
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
   ~YGStyle() = default;
 
   static constexpr int directionBit = 0;


### PR DESCRIPTION
Summary: `YGStyle` puts Yoga enums (which are signed integers by default) into bitfields and it triggers `-Wbitfield-constant-conversion` warning in clang.

Reviewed By: davidaurelio

Differential Revision: D16336729

