### PR TITLE
[Docs] add space-evenly prop to justify-content.md

### DIFF
--- a/website/contents/properties/justify-content.md
+++ b/website/contents/properties/justify-content.md
@@ -25,4 +25,6 @@ remaining space around the children. Compared to `space between` using
 `space around` will result in space being distributed to the beginning of
 the first child and end of the last child.
 
+**SPACE EVENLY** Evenly distributed within the alignment container along the main axis. The spacing between each pair of adjacent items, the main-start edge and the first item, and the main-end edge and the last item, are all exactly the same.
+
 <controls prop="justifyContent"></controls>


### PR DESCRIPTION
This PR add the `space-evenly` prop, to the [justify-content.md](https://github.com/facebook/yoga/blob/master/website/contents/properties/justify-content.md) file.

The description was taken from [Mozilla](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)