### PR TITLE
Fix libfbjni compilation

### DIFF
--- a/lib/fb/src/main/cpp/CMakeLists.txt
+++ b/lib/fb/src/main/cpp/CMakeLists.txt
@@ -20,6 +20,7 @@ add_compile_options(
 file(GLOB fb_SRC
     *.cpp
     jni/*.cpp
+    jni/detail/*.cpp
     lyra/*.cpp)
 
 add_library(fb SHARED


### PR DESCRIPTION
Summary: When D16220924 brought a new fbjni copy (with new directories), we forgot to fix the cmake files which are used by gradle build system.

Differential Revision: D17367160

