### PR TITLE
[YogaKit] Fix layout view with yoga disabled

### DIFF
--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -445,7 +445,7 @@ static void YGApplyLayoutToViewHierarchy(UIView *view, BOOL preserveOrigin)
 
   const YGLayout *yoga = view.yoga;
 
-  if (!yoga.isIncludedInLayout) {
+  if (!yoga.isEnabled || !yoga.isIncludedInLayout) {
      return;
   }
 

--- a/YogaKit/Tests/YogaKitTests.m
+++ b/YogaKit/Tests/YogaKitTests.m
@@ -751,4 +751,29 @@
   XCTAssertEqual(view.yoga.borderEndWidth, 7);
 }
 
+- (void)testLayoutWithYogaNotEnabled
+{
+    UIView *container = [[UIView alloc] initWithFrame:CGRectMake(0,0,50,75)];
+    container.yoga.isEnabled = YES;
+
+    UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
+    view.yoga.isEnabled = YES;
+    view.yoga.flexBasis = YGPointValue(0);
+    view.yoga.flexGrow = 1;
+    [container addSubview:view];
+    
+    UIView *view2 = [[UIView alloc] initWithFrame:CGRectMake(10, 20, 30, 40)];
+    [container addSubview:view2];
+
+    [container.yoga applyLayoutPreservingOrigin:YES];
+    
+    XCTAssertEqual(50, view.frame.size.width);
+    XCTAssertEqual(75, view.frame.size.height);
+    
+    XCTAssertEqual(10, view2.frame.origin.x);
+    XCTAssertEqual(20, view2.frame.origin.y);
+    XCTAssertEqual(30, view2.frame.size.width);
+    XCTAssertEqual(40, view2.frame.size.height);
+}
+
 @end


### PR DESCRIPTION
# Problem

- YogaKit crash when applying layout to a view whose child subview do not have yoga enabled.
```CALayer position contains NaN: [nan nan].```

# Solution

- Check if yoga is enabled in the view when applying layout.

# Testing plan

Create a container view with yoga enabled
Add to the container a subview to the view with yoga enabled
Add to the container a subview to the view without yoga enabled
Call ```applyLayoutPreservingOrigin``` on the container view.

Code:
```objc
UIView *container = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 50, 75)];
container.yoga.isEnabled = YES;

UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
view.yoga.isEnabled = YES;
view.yoga.flexBasis = YGPointValue(0);
view.yoga.flexGrow = 1;
[container addSubview:view];

UIView *view2 = [[UIView alloc] initWithFrame:CGRectMake(10, 20, 30, 40)];
[container addSubview:view2];

[container.yoga applyLayoutPreservingOrigin:YES];
```

Error:
```
caught "CALayerInvalidGeometry", "CALayer position contains NaN: [nan nan]. Layer: <CALayer:0x7fdd6055c070; position = CGPoint (25 40); bounds = CGRect (0 0; 30 40); delegate = <UIView: 0x7fdd6055dc40; frame = (10 20; 30 40); layer = <CALayer: 0x7fdd6055c070>>; opaque = YES; allowsGroupOpacity = YES; >"
```