### PR TITLE
Export YGInteropSetLogger method

### DIFF
--- a/csharp/Yoga/YGInterop.cpp
+++ b/csharp/Yoga/YGInterop.cpp
@@ -23,7 +23,7 @@ static int unmanagedLogger(const YGConfigRef config,
   return result;
 }
 
-void YGInteropSetLogger(YGInteropLogger managedLogger) {
+YOGA_EXPORT void YGInteropSetLogger(YGInteropLogger managedLogger) {
   gManagedLogger = managedLogger;
   YGConfigSetLogger(YGConfigGetDefault(), &unmanagedLogger);
 }

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -4363,6 +4363,11 @@ YOGA_EXPORT void YGConfigSetUseWebDefaults(
   config->useWebDefaults = enabled;
 }
 
+YOGA_EXPORT bool YGConfigGetUseLegacyStretchBehaviour(
+    const YGConfigRef config) {
+  return config->useLegacyStretchBehaviour;
+}
+
 YOGA_EXPORT void YGConfigSetUseLegacyStretchBehaviour(
     const YGConfigRef config,
     const bool useLegacyStretchBehaviour) {

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -313,6 +313,7 @@ void YGConfigSetShouldDiffLayoutWithoutLegacyStretchBehaviour(
 // resulted in implicit behaviour similar to align-self: stretch; Because this
 // was such a long-standing bug we must allow legacy users to switch back to
 // this behaviour.
+WIN_EXPORT bool YGConfigGetUseLegacyStretchBehaviour(YGConfigRef config);
 WIN_EXPORT void YGConfigSetUseLegacyStretchBehaviour(
     YGConfigRef config,
     bool useLegacyStretchBehaviour);


### PR DESCRIPTION
When building and using C # libraries,
EntryPointNotFoundException thrown from YGInteropSetLogger.

so, I added YOGA_EXPORT on YGInteropSetLogger.