### PR TITLE
Make calling convention explicit.

### DIFF
--- a/yoga/BitUtils.h
+++ b/yoga/BitUtils.h
@@ -16,44 +16,44 @@ namespace yoga {
 
 namespace detail {
 
-constexpr size_t log2ceilFn(size_t n) {
+constexpr size_t __cdecl log2ceilFn(size_t n) {
   return n < 1 ? 0 : (1 + log2ceilFn(n / 2));
 }
 
-constexpr int mask(size_t bitWidth, size_t index) {
+constexpr int __cdecl mask(size_t bitWidth, size_t index) {
   return ((1 << bitWidth) - 1) << index;
 }
 
 // The number of bits necessary to represent enums defined with YG_ENUM_SEQ_DECL
 template <typename Enum>
-constexpr size_t bitWidthFn() {
+constexpr size_t __cdecl bitWidthFn() {
   static_assert(
       enums::count<Enum>() > 0, "Enums must have at least one entries");
   return log2ceilFn(enums::count<Enum>() - 1);
 }
 
 template <typename Enum>
-constexpr Enum getEnumData(int flags, size_t index) {
+constexpr Enum __cdecl getEnumData(int flags, size_t index) {
   return static_cast<Enum>((flags & mask(bitWidthFn<Enum>(), index)) >> index);
 }
 
 template <typename Enum>
-void setEnumData(uint32_t& flags, size_t index, int newValue) {
+void __cdecl setEnumData(uint32_t& flags, size_t index, int newValue) {
   flags = (flags & ~mask(bitWidthFn<Enum>(), index)) |
       ((newValue << index) & (mask(bitWidthFn<Enum>(), index)));
 }
 
 template <typename Enum>
-void setEnumData(uint8_t& flags, size_t index, int newValue) {
+void __cdecl setEnumData(uint8_t& flags, size_t index, int newValue) {
   flags = (flags & ~mask(bitWidthFn<Enum>(), index)) |
       ((newValue << index) & (mask(bitWidthFn<Enum>(), index)));
 }
 
-constexpr bool getBooleanData(int flags, size_t index) {
+constexpr bool __cdecl getBooleanData(int flags, size_t index) {
   return (flags >> index) & 1;
 }
 
-inline void setBooleanData(uint8_t& flags, size_t index, bool value) {
+inline void __cdecl setBooleanData(uint8_t& flags, size_t index, bool value) {
   if (value) {
     flags |= 1 << index;
   } else {

--- a/yoga/Utils.cpp
+++ b/yoga/Utils.cpp
@@ -9,7 +9,7 @@
 
 using namespace facebook;
 
-YGFlexDirection YGFlexDirectionCross(
+YGFlexDirection __cdecl YGFlexDirectionCross(
     const YGFlexDirection flexDirection,
     const YGDirection direction) {
   return YGFlexDirectionIsColumn(flexDirection)
@@ -17,14 +17,14 @@ YGFlexDirection YGFlexDirectionCross(
       : YGFlexDirectionColumn;
 }
 
-float YGFloatMax(const float a, const float b) {
+float __cdecl YGFloatMax(const float a, const float b) {
   if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
     return fmaxf(a, b);
   }
   return yoga::isUndefined(a) ? b : a;
 }
 
-float YGFloatMin(const float a, const float b) {
+float __cdecl YGFloatMin(const float a, const float b) {
   if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
     return fminf(a, b);
   }
@@ -32,7 +32,7 @@ float YGFloatMin(const float a, const float b) {
   return yoga::isUndefined(a) ? b : a;
 }
 
-bool YGValueEqual(const YGValue& a, const YGValue& b) {
+bool __cdecl YGValueEqual(const YGValue& a, const YGValue& b) {
   if (a.unit != b.unit) {
     return false;
   }
@@ -45,18 +45,18 @@ bool YGValueEqual(const YGValue& a, const YGValue& b) {
   return fabs(a.value - b.value) < 0.0001f;
 }
 
-bool YGFloatsEqual(const float a, const float b) {
+bool __cdecl YGFloatsEqual(const float a, const float b) {
   if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
     return fabs(a - b) < 0.0001f;
   }
   return yoga::isUndefined(a) && yoga::isUndefined(b);
 }
 
-float YGFloatSanitize(const float val) {
+float __cdecl YGFloatSanitize(const float val) {
   return yoga::isUndefined(val) ? 0 : val;
 }
 
-YGFloatOptional YGFloatOptionalMax(YGFloatOptional op1, YGFloatOptional op2) {
+YGFloatOptional __cdecl YGFloatOptionalMax(YGFloatOptional op1, YGFloatOptional op2) {
   if (op1 >= op2) {
     return op1;
   }

--- a/yoga/Utils.h
+++ b/yoga/Utils.h
@@ -53,8 +53,8 @@ struct YGCollectFlexItemsRowValues {
   float crossDim;
 };
 
-bool YGValueEqual(const YGValue& a, const YGValue& b);
-inline bool YGValueEqual(
+bool __cdecl YGValueEqual(const YGValue& a, const YGValue& b);
+inline bool __cdecl YGValueEqual(
     facebook::yoga::detail::CompactValue a,
     facebook::yoga::detail::CompactValue b) {
   return YGValueEqual((YGValue) a, (YGValue) b);
@@ -62,21 +62,21 @@ inline bool YGValueEqual(
 
 // This custom float equality function returns true if either absolute
 // difference between two floats is less than 0.0001f or both are undefined.
-bool YGFloatsEqual(const float a, const float b);
+bool __cdecl YGFloatsEqual(const float a, const float b);
 
-float YGFloatMax(const float a, const float b);
+float __cdecl YGFloatMax(const float a, const float b);
 
-YGFloatOptional YGFloatOptionalMax(
+YGFloatOptional __cdecl YGFloatOptionalMax(
     const YGFloatOptional op1,
     const YGFloatOptional op2);
 
-float YGFloatMin(const float a, const float b);
+float __cdecl YGFloatMin(const float a, const float b);
 
 // This custom float comparison function compares the array of float with
 // YGFloatsEqual, as the default float comparison operator will not work(Look
 // at the comments of YGFloatsEqual function).
 template <std::size_t size>
-bool YGFloatArrayEqual(
+bool __cdecl YGFloatArrayEqual(
     const std::array<float, size>& val1,
     const std::array<float, size>& val2) {
   bool areEqual = true;
@@ -87,18 +87,18 @@ bool YGFloatArrayEqual(
 }
 
 // This function returns 0 if YGFloatIsUndefined(val) is true and val otherwise
-float YGFloatSanitize(const float val);
+float __cdecl YGFloatSanitize(const float val);
 
-YGFlexDirection YGFlexDirectionCross(
+YGFlexDirection __cdecl YGFlexDirectionCross(
     const YGFlexDirection flexDirection,
     const YGDirection direction);
 
-inline bool YGFlexDirectionIsRow(const YGFlexDirection flexDirection) {
+inline bool __cdecl YGFlexDirectionIsRow(const YGFlexDirection flexDirection) {
   return flexDirection == YGFlexDirectionRow ||
       flexDirection == YGFlexDirectionRowReverse;
 }
 
-inline YGFloatOptional YGResolveValue(
+inline YGFloatOptional __cdecl YGResolveValue(
     const YGValue value,
     const float ownerSize) {
   switch (value.unit) {
@@ -111,18 +111,18 @@ inline YGFloatOptional YGResolveValue(
   }
 }
 
-inline YGFloatOptional YGResolveValue(
+inline YGFloatOptional __cdecl YGResolveValue(
     yoga::detail::CompactValue value,
     float ownerSize) {
   return YGResolveValue((YGValue) value, ownerSize);
 }
 
-inline bool YGFlexDirectionIsColumn(const YGFlexDirection flexDirection) {
+inline bool __cdecl YGFlexDirectionIsColumn(const YGFlexDirection flexDirection) {
   return flexDirection == YGFlexDirectionColumn ||
       flexDirection == YGFlexDirectionColumnReverse;
 }
 
-inline YGFlexDirection YGResolveFlexDirection(
+inline YGFlexDirection __cdecl YGResolveFlexDirection(
     const YGFlexDirection flexDirection,
     const YGDirection direction) {
   if (direction == YGDirectionRTL) {
@@ -136,7 +136,7 @@ inline YGFlexDirection YGResolveFlexDirection(
   return flexDirection;
 }
 
-inline YGFloatOptional YGResolveValueMargin(
+inline YGFloatOptional __cdecl YGResolveValueMargin(
     yoga::detail::CompactValue value,
     const float ownerSize) {
   return value.isAuto() ? YGFloatOptional{0} : YGResolveValue(value, ownerSize);

--- a/yoga/YGEnums.h
+++ b/yoga/YGEnums.h
@@ -19,7 +19,7 @@ constexpr int count(); // can't use `= delete` due to a defect in clang < 3.9
 
 namespace detail {
 template <int... xs>
-constexpr int n() {
+constexpr int __cdecl n() {
   return sizeof...(xs);
 }
 } // namespace detail
@@ -31,7 +31,7 @@ constexpr int n() {
 
 #define YG_ENUM_DECL(NAME, ...)                               \
   typedef YG_ENUM_BEGIN(NAME){__VA_ARGS__} YG_ENUM_END(NAME); \
-  WIN_EXPORT const char* NAME##ToString(NAME);
+  WIN_EXPORT const char* __cdecl NAME##ToString(NAME);
 
 #ifdef __cplusplus
 #define YG_ENUM_SEQ_DECL(NAME, ...)  \
@@ -41,7 +41,7 @@ constexpr int n() {
   namespace yoga {                   \
   namespace enums {                  \
   template <>                        \
-  constexpr int count<NAME>() {      \
+  constexpr int __cdecl count<NAME>() {      \
     return detail::n<__VA_ARGS__>(); \
   }                                  \
   }                                  \

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -16,13 +16,13 @@
 #include "YGMacros.h"
 #include "Yoga-internal.h"
 
-YGConfigRef YGConfigGetDefault();
+YGConfigRef __cdecl YGConfigGetDefault();
 
 struct YOGA_EXPORT YGNode {
   using MeasureWithContextFn =
-      YGSize (*)(YGNode*, float, YGMeasureMode, float, YGMeasureMode, void*);
-  using BaselineWithContextFn = float (*)(YGNode*, float, float, void*);
-  using PrintWithContextFn = void (*)(YGNode*, void*);
+      YGSize (__cdecl *)(YGNode*, float, YGMeasureMode, float, YGMeasureMode, void*);
+  using BaselineWithContextFn = float (__cdecl *)(YGNode*, float, float, void*);
+  using PrintWithContextFn = void (__cdecl *)(YGNode*, void*);
 
 private:
   static constexpr size_t hasNewLayout_ = 0;

--- a/yoga/YGNodePrint.cpp
+++ b/yoga/YGNodePrint.cpp
@@ -110,7 +110,7 @@ static void appendEdgeIfNotUndefined(
       YGComputedEdgeValue(edges, edge, detail::CompactValue::ofUndefined()));
 }
 
-void YGNodeToString(
+void __cdecl YGNodeToString(
     std::string& str,
     YGNodeRef node,
     YGPrintOptions options,

--- a/yoga/YGNodePrint.h
+++ b/yoga/YGNodePrint.h
@@ -14,7 +14,7 @@
 namespace facebook {
 namespace yoga {
 
-void YGNodeToString(
+void __cdecl YGNodeToString(
     std::string& str,
     YGNodeRef node,
     YGPrintOptions options,

--- a/yoga/Yoga-internal.h
+++ b/yoga/Yoga-internal.h
@@ -17,7 +17,7 @@ using YGVector = std::vector<YGNodeRef>;
 
 YG_EXTERN_C_BEGIN
 
-void YGNodeCalculateLayoutWithContext(
+void __cdecl YGNodeCalculateLayoutWithContext(
     YGNodeRef node,
     float availableWidth,
     float availableHeight,
@@ -29,7 +29,7 @@ YG_EXTERN_C_END
 namespace facebook {
 namespace yoga {
 
-inline bool isUndefined(float value) {
+inline bool __cdecl isUndefined(float value) {
   return std::isnan(value);
 }
 
@@ -143,8 +143,8 @@ static const float kDefaultFlexGrow = 0.0f;
 static const float kDefaultFlexShrink = 0.0f;
 static const float kWebDefaultFlexShrink = 1.0f;
 
-extern bool YGFloatsEqual(const float a, const float b);
-extern facebook::yoga::detail::CompactValue YGComputedEdgeValue(
+extern bool __cdecl YGFloatsEqual(const float a, const float b);
+extern facebook::yoga::detail::CompactValue __cdecl YGComputedEdgeValue(
     const facebook::yoga::detail::Values<
         facebook::yoga::enums::count<YGEdge>()>& edges,
     YGEdge edge,

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -106,11 +106,11 @@ static int YGDefaultLog(
 #undef YG_UNUSED
 #endif
 
-YOGA_EXPORT bool YGFloatIsUndefined(const float value) {
+YOGA_EXPORT bool __cdecl YGFloatIsUndefined(const float value) {
   return facebook::yoga::isUndefined(value);
 }
 
-detail::CompactValue YGComputedEdgeValue(
+detail::CompactValue __cdecl YGComputedEdgeValue(
     const YGStyle::Edges& edges,
     YGEdge edge,
     detail::CompactValue defaultValue) {
@@ -140,84 +140,84 @@ detail::CompactValue YGComputedEdgeValue(
   return defaultValue;
 }
 
-YOGA_EXPORT void* YGNodeGetContext(YGNodeRef node) {
+YOGA_EXPORT void* __cdecl YGNodeGetContext(YGNodeRef node) {
   return node->getContext();
 }
 
-YOGA_EXPORT void YGNodeSetContext(YGNodeRef node, void* context) {
+YOGA_EXPORT void __cdecl YGNodeSetContext(YGNodeRef node, void* context) {
   return node->setContext(context);
 }
 
-YOGA_EXPORT bool YGNodeHasMeasureFunc(YGNodeRef node) {
+YOGA_EXPORT bool __cdecl YGNodeHasMeasureFunc(YGNodeRef node) {
   return node->hasMeasureFunc();
 }
 
-YOGA_EXPORT void YGNodeSetMeasureFunc(
+YOGA_EXPORT void __cdecl YGNodeSetMeasureFunc(
     YGNodeRef node,
     YGMeasureFunc measureFunc) {
   node->setMeasureFunc(measureFunc);
 }
 
-YOGA_EXPORT bool YGNodeHasBaselineFunc(YGNodeRef node) {
+YOGA_EXPORT bool __cdecl YGNodeHasBaselineFunc(YGNodeRef node) {
   return node->hasBaselineFunc();
 }
 
-YOGA_EXPORT void YGNodeSetBaselineFunc(
+YOGA_EXPORT void __cdecl YGNodeSetBaselineFunc(
     YGNodeRef node,
     YGBaselineFunc baselineFunc) {
   node->setBaselineFunc(baselineFunc);
 }
 
-YOGA_EXPORT YGDirtiedFunc YGNodeGetDirtiedFunc(YGNodeRef node) {
+YOGA_EXPORT YGDirtiedFunc __cdecl YGNodeGetDirtiedFunc(YGNodeRef node) {
   return node->getDirtied();
 }
 
-YOGA_EXPORT void YGNodeSetDirtiedFunc(
+YOGA_EXPORT void __cdecl YGNodeSetDirtiedFunc(
     YGNodeRef node,
     YGDirtiedFunc dirtiedFunc) {
   node->setDirtiedFunc(dirtiedFunc);
 }
 
-YOGA_EXPORT void YGNodeSetPrintFunc(YGNodeRef node, YGPrintFunc printFunc) {
+YOGA_EXPORT void __cdecl YGNodeSetPrintFunc(YGNodeRef node, YGPrintFunc printFunc) {
   node->setPrintFunc(printFunc);
 }
 
-YOGA_EXPORT bool YGNodeGetHasNewLayout(YGNodeRef node) {
+YOGA_EXPORT bool __cdecl YGNodeGetHasNewLayout(YGNodeRef node) {
   return node->getHasNewLayout();
 }
 
-YOGA_EXPORT void YGConfigSetPrintTreeFlag(YGConfigRef config, bool enabled) {
+YOGA_EXPORT void __cdecl YGConfigSetPrintTreeFlag(YGConfigRef config, bool enabled) {
   config->printTree = enabled;
 }
 
-YOGA_EXPORT void YGNodeSetHasNewLayout(YGNodeRef node, bool hasNewLayout) {
+YOGA_EXPORT void __cdecl YGNodeSetHasNewLayout(YGNodeRef node, bool hasNewLayout) {
   node->setHasNewLayout(hasNewLayout);
 }
 
-YOGA_EXPORT YGNodeType YGNodeGetNodeType(YGNodeRef node) {
+YOGA_EXPORT YGNodeType __cdecl YGNodeGetNodeType(YGNodeRef node) {
   return node->getNodeType();
 }
 
-YOGA_EXPORT void YGNodeSetNodeType(YGNodeRef node, YGNodeType nodeType) {
+YOGA_EXPORT void __cdecl YGNodeSetNodeType(YGNodeRef node, YGNodeType nodeType) {
   return node->setNodeType(nodeType);
 }
 
-YOGA_EXPORT bool YGNodeIsDirty(YGNodeRef node) {
+YOGA_EXPORT bool __cdecl YGNodeIsDirty(YGNodeRef node) {
   return node->isDirty();
 }
 
-YOGA_EXPORT bool YGNodeLayoutGetDidUseLegacyFlag(const YGNodeRef node) {
+YOGA_EXPORT bool __cdecl YGNodeLayoutGetDidUseLegacyFlag(const YGNodeRef node) {
   return node->didUseLegacyFlag();
 }
 
-YOGA_EXPORT void YGNodeMarkDirtyAndPropogateToDescendants(
+YOGA_EXPORT void __cdecl YGNodeMarkDirtyAndPropogateToDescendants(
     const YGNodeRef node) {
   return node->markDirtyAndPropogateDownwards();
 }
 
 int32_t gConfigInstanceCount = 0;
 
-YOGA_EXPORT WIN_EXPORT YGNodeRef YGNodeNewWithConfig(const YGConfigRef config) {
+YOGA_EXPORT WIN_EXPORT YGNodeRef __cdecl YGNodeNewWithConfig(const YGConfigRef config) {
   const YGNodeRef node = new YGNode{config};
   YGAssertWithConfig(
       config, node != nullptr, "Could not allocate memory for node");
@@ -226,16 +226,16 @@ YOGA_EXPORT WIN_EXPORT YGNodeRef YGNodeNewWithConfig(const YGConfigRef config) {
   return node;
 }
 
-YOGA_EXPORT YGConfigRef YGConfigGetDefault() {
+YOGA_EXPORT YGConfigRef __cdecl YGConfigGetDefault() {
   static YGConfigRef defaultConfig = YGConfigNew();
   return defaultConfig;
 }
 
-YOGA_EXPORT YGNodeRef YGNodeNew(void) {
+YOGA_EXPORT YGNodeRef __cdecl YGNodeNew(void) {
   return YGNodeNewWithConfig(YGConfigGetDefault());
 }
 
-YOGA_EXPORT YGNodeRef YGNodeClone(YGNodeRef oldNode) {
+YOGA_EXPORT YGNodeRef __cdecl YGNodeClone(YGNodeRef oldNode) {
   YGNodeRef node = new YGNode(*oldNode);
   YGAssertWithConfig(
       oldNode->getConfig(),
@@ -323,19 +323,19 @@ YOGA_EXPORT void YGNodeFreeRecursiveWithCleanupFunc(
   YGNodeFree(root);
 }
 
-YOGA_EXPORT void YGNodeFreeRecursive(const YGNodeRef root) {
+YOGA_EXPORT void __cdecl YGNodeFreeRecursive(const YGNodeRef root) {
   return YGNodeFreeRecursiveWithCleanupFunc(root, nullptr);
 }
 
-YOGA_EXPORT void YGNodeReset(YGNodeRef node) {
+YOGA_EXPORT void __cdecl YGNodeReset(YGNodeRef node) {
   node->reset();
 }
 
-int32_t YGConfigGetInstanceCount(void) {
+int32_t __cdecl YGConfigGetInstanceCount(void) {
   return gConfigInstanceCount;
 }
 
-YOGA_EXPORT YGConfigRef YGConfigNew(void) {
+YOGA_EXPORT YGConfigRef __cdecl YGConfigNew(void) {
 #ifdef ANDROID
   const YGConfigRef config = new YGConfig(YGAndroidLog);
 #else
@@ -345,16 +345,16 @@ YOGA_EXPORT YGConfigRef YGConfigNew(void) {
   return config;
 }
 
-YOGA_EXPORT void YGConfigFree(const YGConfigRef config) {
+YOGA_EXPORT void __cdecl YGConfigFree(const YGConfigRef config) {
   delete config;
   gConfigInstanceCount--;
 }
 
-void YGConfigCopy(const YGConfigRef dest, const YGConfigRef src) {
+void __cdecl YGConfigCopy(const YGConfigRef dest, const YGConfigRef src) {
   memcpy(dest, src, sizeof(YGConfig));
 }
 
-YOGA_EXPORT void YGNodeSetIsReferenceBaseline(
+YOGA_EXPORT void __cdecl YGNodeSetIsReferenceBaseline(
     YGNodeRef node,
     bool isReferenceBaseline) {
   if (node->isReferenceBaseline() != isReferenceBaseline) {
@@ -363,11 +363,11 @@ YOGA_EXPORT void YGNodeSetIsReferenceBaseline(
   }
 }
 
-YOGA_EXPORT bool YGNodeIsReferenceBaseline(YGNodeRef node) {
+YOGA_EXPORT bool __cdecl YGNodeIsReferenceBaseline(YGNodeRef node) {
   return node->isReferenceBaseline();
 }
 
-YOGA_EXPORT void YGNodeInsertChild(
+YOGA_EXPORT void __cdecl YGNodeInsertChild(
     const YGNodeRef owner,
     const YGNodeRef child,
     const uint32_t index) {
@@ -386,7 +386,7 @@ YOGA_EXPORT void YGNodeInsertChild(
   owner->markDirtyAndPropogate();
 }
 
-YOGA_EXPORT void YGNodeSwapChild(
+YOGA_EXPORT void __cdecl YGNodeSwapChild(
     const YGNodeRef owner,
     const YGNodeRef child,
     const uint32_t index) {
@@ -394,7 +394,7 @@ YOGA_EXPORT void YGNodeSwapChild(
   child->setOwner(owner);
 }
 
-YOGA_EXPORT void YGNodeRemoveChild(
+YOGA_EXPORT void __cdecl YGNodeRemoveChild(
     const YGNodeRef owner,
     const YGNodeRef excludedChild) {
   if (YGNodeGetChildCount(owner) == 0) {
@@ -415,7 +415,7 @@ YOGA_EXPORT void YGNodeRemoveChild(
   }
 }
 
-YOGA_EXPORT void YGNodeRemoveAllChildren(const YGNodeRef owner) {
+YOGA_EXPORT void __cdecl YGNodeRemoveAllChildren(const YGNodeRef owner) {
   const uint32_t childCount = YGNodeGetChildCount(owner);
   if (childCount == 0) {
     // This is an empty set already. Nothing to do.
@@ -475,7 +475,7 @@ static void YGNodeSetChildrenInternal(
   }
 }
 
-YOGA_EXPORT void YGNodeSetChildren(
+YOGA_EXPORT void __cdecl YGNodeSetChildren(
     const YGNodeRef owner,
     const YGNodeRef c[],
     const uint32_t count) {
@@ -483,33 +483,33 @@ YOGA_EXPORT void YGNodeSetChildren(
   YGNodeSetChildrenInternal(owner, children);
 }
 
-YOGA_EXPORT void YGNodeSetChildren(
+YOGA_EXPORT void __cdecl YGNodeSetChildren(
     YGNodeRef const owner,
     const std::vector<YGNodeRef>& children) {
   YGNodeSetChildrenInternal(owner, children);
 }
 
 YOGA_EXPORT YGNodeRef
-YGNodeGetChild(const YGNodeRef node, const uint32_t index) {
+__cdecl YGNodeGetChild(const YGNodeRef node, const uint32_t index) {
   if (index < node->getChildren().size()) {
     return node->getChild(index);
   }
   return nullptr;
 }
 
-YOGA_EXPORT uint32_t YGNodeGetChildCount(const YGNodeRef node) {
+YOGA_EXPORT uint32_t __cdecl YGNodeGetChildCount(const YGNodeRef node) {
   return static_cast<uint32_t>(node->getChildren().size());
 }
 
-YOGA_EXPORT YGNodeRef YGNodeGetOwner(const YGNodeRef node) {
+YOGA_EXPORT YGNodeRef __cdecl YGNodeGetOwner(const YGNodeRef node) {
   return node->getOwner();
 }
 
-YOGA_EXPORT YGNodeRef YGNodeGetParent(const YGNodeRef node) {
+YOGA_EXPORT YGNodeRef __cdecl YGNodeGetParent(const YGNodeRef node) {
   return node->getOwner();
 }
 
-YOGA_EXPORT void YGNodeMarkDirty(const YGNodeRef node) {
+YOGA_EXPORT void __cdecl YGNodeMarkDirty(const YGNodeRef node) {
   YGAssertWithNode(
       node,
       node->hasMeasureFunc(),
@@ -519,7 +519,7 @@ YOGA_EXPORT void YGNodeMarkDirty(const YGNodeRef node) {
   node->markDirtyAndPropogate();
 }
 
-YOGA_EXPORT void YGNodeCopyStyle(
+YOGA_EXPORT void __cdecl YGNodeCopyStyle(
     const YGNodeRef dstNode,
     const YGNodeRef srcNode) {
   if (!(dstNode->getStyle() == srcNode->getStyle())) {
@@ -528,13 +528,13 @@ YOGA_EXPORT void YGNodeCopyStyle(
   }
 }
 
-YOGA_EXPORT float YGNodeStyleGetFlexGrow(const YGNodeConstRef node) {
+YOGA_EXPORT float __cdecl YGNodeStyleGetFlexGrow(const YGNodeConstRef node) {
   return node->getStyle().flexGrow().isUndefined()
       ? kDefaultFlexGrow
       : node->getStyle().flexGrow().unwrap();
 }
 
-YOGA_EXPORT float YGNodeStyleGetFlexShrink(const YGNodeConstRef node) {
+YOGA_EXPORT float __cdecl YGNodeStyleGetFlexShrink(const YGNodeConstRef node) {
   return node->getStyle().flexShrink().isUndefined()
       ? (node->getConfig()->useWebDefaults ? kWebDefaultFlexShrink
                                            : kDefaultFlexShrink)
@@ -587,116 +587,116 @@ void updateIndexedStyleProp(
 // decltype, MSVC will prefer the non-const version.
 #define MSVC_HINT(PROP) decltype(YGStyle{}.PROP())
 
-YOGA_EXPORT void YGNodeStyleSetDirection(
+YOGA_EXPORT void __cdecl YGNodeStyleSetDirection(
     const YGNodeRef node,
     const YGDirection value) {
   updateStyle<MSVC_HINT(direction)>(node, &YGStyle::direction, value);
 }
-YOGA_EXPORT YGDirection YGNodeStyleGetDirection(const YGNodeConstRef node) {
+YOGA_EXPORT YGDirection __cdecl YGNodeStyleGetDirection(const YGNodeConstRef node) {
   return node->getStyle().direction();
 }
 
-YOGA_EXPORT void YGNodeStyleSetFlexDirection(
+YOGA_EXPORT void __cdecl YGNodeStyleSetFlexDirection(
     const YGNodeRef node,
     const YGFlexDirection flexDirection) {
   updateStyle<MSVC_HINT(flexDirection)>(
       node, &YGStyle::flexDirection, flexDirection);
 }
 YOGA_EXPORT YGFlexDirection
-YGNodeStyleGetFlexDirection(const YGNodeConstRef node) {
+__cdecl YGNodeStyleGetFlexDirection(const YGNodeConstRef node) {
   return node->getStyle().flexDirection();
 }
 
-YOGA_EXPORT void YGNodeStyleSetJustifyContent(
+YOGA_EXPORT void __cdecl YGNodeStyleSetJustifyContent(
     const YGNodeRef node,
     const YGJustify justifyContent) {
   updateStyle<MSVC_HINT(justifyContent)>(
       node, &YGStyle::justifyContent, justifyContent);
 }
-YOGA_EXPORT YGJustify YGNodeStyleGetJustifyContent(const YGNodeConstRef node) {
+YOGA_EXPORT YGJustify __cdecl YGNodeStyleGetJustifyContent(const YGNodeConstRef node) {
   return node->getStyle().justifyContent();
 }
 
-YOGA_EXPORT void YGNodeStyleSetAlignContent(
+YOGA_EXPORT void __cdecl YGNodeStyleSetAlignContent(
     const YGNodeRef node,
     const YGAlign alignContent) {
   updateStyle<MSVC_HINT(alignContent)>(
       node, &YGStyle::alignContent, alignContent);
 }
-YOGA_EXPORT YGAlign YGNodeStyleGetAlignContent(const YGNodeConstRef node) {
+YOGA_EXPORT YGAlign __cdecl YGNodeStyleGetAlignContent(const YGNodeConstRef node) {
   return node->getStyle().alignContent();
 }
 
-YOGA_EXPORT void YGNodeStyleSetAlignItems(
+YOGA_EXPORT void __cdecl YGNodeStyleSetAlignItems(
     const YGNodeRef node,
     const YGAlign alignItems) {
   updateStyle<MSVC_HINT(alignItems)>(node, &YGStyle::alignItems, alignItems);
 }
-YOGA_EXPORT YGAlign YGNodeStyleGetAlignItems(const YGNodeConstRef node) {
+YOGA_EXPORT YGAlign __cdecl YGNodeStyleGetAlignItems(const YGNodeConstRef node) {
   return node->getStyle().alignItems();
 }
 
-YOGA_EXPORT void YGNodeStyleSetAlignSelf(
+YOGA_EXPORT void __cdecl YGNodeStyleSetAlignSelf(
     const YGNodeRef node,
     const YGAlign alignSelf) {
   updateStyle<MSVC_HINT(alignSelf)>(node, &YGStyle::alignSelf, alignSelf);
 }
-YOGA_EXPORT YGAlign YGNodeStyleGetAlignSelf(const YGNodeConstRef node) {
+YOGA_EXPORT YGAlign __cdecl YGNodeStyleGetAlignSelf(const YGNodeConstRef node) {
   return node->getStyle().alignSelf();
 }
 
-YOGA_EXPORT void YGNodeStyleSetPositionType(
+YOGA_EXPORT void __cdecl YGNodeStyleSetPositionType(
     const YGNodeRef node,
     const YGPositionType positionType) {
   updateStyle<MSVC_HINT(positionType)>(
       node, &YGStyle::positionType, positionType);
 }
 YOGA_EXPORT YGPositionType
-YGNodeStyleGetPositionType(const YGNodeConstRef node) {
+__cdecl YGNodeStyleGetPositionType(const YGNodeConstRef node) {
   return node->getStyle().positionType();
 }
 
-YOGA_EXPORT void YGNodeStyleSetFlexWrap(
+YOGA_EXPORT void __cdecl YGNodeStyleSetFlexWrap(
     const YGNodeRef node,
     const YGWrap flexWrap) {
   updateStyle<MSVC_HINT(flexWrap)>(node, &YGStyle::flexWrap, flexWrap);
 }
-YOGA_EXPORT YGWrap YGNodeStyleGetFlexWrap(const YGNodeConstRef node) {
+YOGA_EXPORT YGWrap __cdecl YGNodeStyleGetFlexWrap(const YGNodeConstRef node) {
   return node->getStyle().flexWrap();
 }
 
-YOGA_EXPORT void YGNodeStyleSetOverflow(
+YOGA_EXPORT void __cdecl YGNodeStyleSetOverflow(
     const YGNodeRef node,
     const YGOverflow overflow) {
   updateStyle<MSVC_HINT(overflow)>(node, &YGStyle::overflow, overflow);
 }
-YOGA_EXPORT YGOverflow YGNodeStyleGetOverflow(const YGNodeConstRef node) {
+YOGA_EXPORT YGOverflow __cdecl YGNodeStyleGetOverflow(const YGNodeConstRef node) {
   return node->getStyle().overflow();
 }
 
-YOGA_EXPORT void YGNodeStyleSetDisplay(
+YOGA_EXPORT void __cdecl YGNodeStyleSetDisplay(
     const YGNodeRef node,
     const YGDisplay display) {
   updateStyle<MSVC_HINT(display)>(node, &YGStyle::display, display);
 }
-YOGA_EXPORT YGDisplay YGNodeStyleGetDisplay(const YGNodeConstRef node) {
+YOGA_EXPORT YGDisplay __cdecl YGNodeStyleGetDisplay(const YGNodeConstRef node) {
   return node->getStyle().display();
 }
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
-YOGA_EXPORT void YGNodeStyleSetFlex(const YGNodeRef node, const float flex) {
+YOGA_EXPORT void __cdecl YGNodeStyleSetFlex(const YGNodeRef node, const float flex) {
   updateStyle<MSVC_HINT(flex)>(node, &YGStyle::flex, YGFloatOptional{flex});
 }
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
-YOGA_EXPORT float YGNodeStyleGetFlex(const YGNodeConstRef node) {
+YOGA_EXPORT float __cdecl YGNodeStyleGetFlex(const YGNodeConstRef node) {
   return node->getStyle().flex().isUndefined()
       ? YGUndefined
       : node->getStyle().flex().unwrap();
 }
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
-YOGA_EXPORT void YGNodeStyleSetFlexGrow(
+YOGA_EXPORT void __cdecl YGNodeStyleSetFlexGrow(
     const YGNodeRef node,
     const float flexGrow) {
   updateStyle<MSVC_HINT(flexGrow)>(
@@ -704,14 +704,14 @@ YOGA_EXPORT void YGNodeStyleSetFlexGrow(
 }
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
-YOGA_EXPORT void YGNodeStyleSetFlexShrink(
+YOGA_EXPORT void __cdecl YGNodeStyleSetFlexShrink(
     const YGNodeRef node,
     const float flexShrink) {
   updateStyle<MSVC_HINT(flexShrink)>(
       node, &YGStyle::flexShrink, YGFloatOptional{flexShrink});
 }
 
-YOGA_EXPORT YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
+YOGA_EXPORT YGValue __cdecl YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
   YGValue flexBasis = node->getStyle().flexBasis();
   if (flexBasis.unit == YGUnitUndefined || flexBasis.unit == YGUnitAuto) {
     // TODO(T26792433): Get rid off the use of YGUndefined at client side
@@ -720,26 +720,26 @@ YOGA_EXPORT YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
   return flexBasis;
 }
 
-YOGA_EXPORT void YGNodeStyleSetFlexBasis(
+YOGA_EXPORT void __cdecl YGNodeStyleSetFlexBasis(
     const YGNodeRef node,
     const float flexBasis) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(flexBasis);
   updateStyle<MSVC_HINT(flexBasis)>(node, &YGStyle::flexBasis, value);
 }
 
-YOGA_EXPORT void YGNodeStyleSetFlexBasisPercent(
+YOGA_EXPORT void __cdecl YGNodeStyleSetFlexBasisPercent(
     const YGNodeRef node,
     const float flexBasisPercent) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(flexBasisPercent);
   updateStyle<MSVC_HINT(flexBasis)>(node, &YGStyle::flexBasis, value);
 }
 
-YOGA_EXPORT void YGNodeStyleSetFlexBasisAuto(const YGNodeRef node) {
+YOGA_EXPORT void __cdecl YGNodeStyleSetFlexBasisAuto(const YGNodeRef node) {
   updateStyle<MSVC_HINT(flexBasis)>(
       node, &YGStyle::flexBasis, detail::CompactValue::ofAuto());
 }
 
-YOGA_EXPORT void YGNodeStyleSetPosition(
+YOGA_EXPORT void __cdecl YGNodeStyleSetPosition(
     YGNodeRef node,
     YGEdge edge,
     float points) {
@@ -747,7 +747,7 @@ YOGA_EXPORT void YGNodeStyleSetPosition(
   updateIndexedStyleProp<MSVC_HINT(position)>(
       node, &YGStyle::position, edge, value);
 }
-YOGA_EXPORT void YGNodeStyleSetPositionPercent(
+YOGA_EXPORT void __cdecl YGNodeStyleSetPositionPercent(
     YGNodeRef node,
     YGEdge edge,
     float percent) {
@@ -755,11 +755,11 @@ YOGA_EXPORT void YGNodeStyleSetPositionPercent(
   updateIndexedStyleProp<MSVC_HINT(position)>(
       node, &YGStyle::position, edge, value);
 }
-YOGA_EXPORT YGValue YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge) {
+YOGA_EXPORT YGValue __cdecl YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge) {
   return node->getStyle().position()[edge];
 }
 
-YOGA_EXPORT void YGNodeStyleSetMargin(
+YOGA_EXPORT void __cdecl YGNodeStyleSetMargin(
     YGNodeRef node,
     YGEdge edge,
     float points) {
@@ -767,7 +767,7 @@ YOGA_EXPORT void YGNodeStyleSetMargin(
   updateIndexedStyleProp<MSVC_HINT(margin)>(
       node, &YGStyle::margin, edge, value);
 }
-YOGA_EXPORT void YGNodeStyleSetMarginPercent(
+YOGA_EXPORT void __cdecl YGNodeStyleSetMarginPercent(
     YGNodeRef node,
     YGEdge edge,
     float percent) {
@@ -775,15 +775,15 @@ YOGA_EXPORT void YGNodeStyleSetMarginPercent(
   updateIndexedStyleProp<MSVC_HINT(margin)>(
       node, &YGStyle::margin, edge, value);
 }
-YOGA_EXPORT void YGNodeStyleSetMarginAuto(YGNodeRef node, YGEdge edge) {
+YOGA_EXPORT void __cdecl YGNodeStyleSetMarginAuto(YGNodeRef node, YGEdge edge) {
   updateIndexedStyleProp<MSVC_HINT(margin)>(
       node, &YGStyle::margin, edge, detail::CompactValue::ofAuto());
 }
-YOGA_EXPORT YGValue YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge) {
+YOGA_EXPORT YGValue __cdecl YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge) {
   return node->getStyle().margin()[edge];
 }
 
-YOGA_EXPORT void YGNodeStyleSetPadding(
+YOGA_EXPORT void __cdecl YGNodeStyleSetPadding(
     YGNodeRef node,
     YGEdge edge,
     float points) {
@@ -791,7 +791,7 @@ YOGA_EXPORT void YGNodeStyleSetPadding(
   updateIndexedStyleProp<MSVC_HINT(padding)>(
       node, &YGStyle::padding, edge, value);
 }
-YOGA_EXPORT void YGNodeStyleSetPaddingPercent(
+YOGA_EXPORT void __cdecl YGNodeStyleSetPaddingPercent(
     YGNodeRef node,
     YGEdge edge,
     float percent) {
@@ -799,12 +799,12 @@ YOGA_EXPORT void YGNodeStyleSetPaddingPercent(
   updateIndexedStyleProp<MSVC_HINT(padding)>(
       node, &YGStyle::padding, edge, value);
 }
-YOGA_EXPORT YGValue YGNodeStyleGetPadding(YGNodeConstRef node, YGEdge edge) {
+YOGA_EXPORT YGValue __cdecl YGNodeStyleGetPadding(YGNodeConstRef node, YGEdge edge) {
   return node->getStyle().padding()[edge];
 }
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
-YOGA_EXPORT void YGNodeStyleSetBorder(
+YOGA_EXPORT void __cdecl YGNodeStyleSetBorder(
     const YGNodeRef node,
     const YGEdge edge,
     const float border) {
@@ -813,7 +813,7 @@ YOGA_EXPORT void YGNodeStyleSetBorder(
       node, &YGStyle::border, edge, value);
 }
 
-YOGA_EXPORT float YGNodeStyleGetBorder(
+YOGA_EXPORT float __cdecl YGNodeStyleGetBorder(
     const YGNodeConstRef node,
     const YGEdge edge) {
   auto border = node->getStyle().border()[edge];
@@ -829,130 +829,130 @@ YOGA_EXPORT float YGNodeStyleGetBorder(
 // Yoga specific properties, not compatible with flexbox specification
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
-YOGA_EXPORT float YGNodeStyleGetAspectRatio(const YGNodeConstRef node) {
+YOGA_EXPORT float __cdecl YGNodeStyleGetAspectRatio(const YGNodeConstRef node) {
   const YGFloatOptional op = node->getStyle().aspectRatio();
   return op.isUndefined() ? YGUndefined : op.unwrap();
 }
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
-YOGA_EXPORT void YGNodeStyleSetAspectRatio(
+YOGA_EXPORT void __cdecl YGNodeStyleSetAspectRatio(
     const YGNodeRef node,
     const float aspectRatio) {
   updateStyle<MSVC_HINT(aspectRatio)>(
       node, &YGStyle::aspectRatio, YGFloatOptional{aspectRatio});
 }
 
-YOGA_EXPORT void YGNodeStyleSetWidth(YGNodeRef node, float points) {
+YOGA_EXPORT void __cdecl YGNodeStyleSetWidth(YGNodeRef node, float points) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
       node, &YGStyle::dimensions, YGDimensionWidth, value);
 }
-YOGA_EXPORT void YGNodeStyleSetWidthPercent(YGNodeRef node, float percent) {
+YOGA_EXPORT void __cdecl YGNodeStyleSetWidthPercent(YGNodeRef node, float percent) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
       node, &YGStyle::dimensions, YGDimensionWidth, value);
 }
-YOGA_EXPORT void YGNodeStyleSetWidthAuto(YGNodeRef node) {
+YOGA_EXPORT void __cdecl YGNodeStyleSetWidthAuto(YGNodeRef node) {
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
       node,
       &YGStyle::dimensions,
       YGDimensionWidth,
       detail::CompactValue::ofAuto());
 }
-YOGA_EXPORT YGValue YGNodeStyleGetWidth(YGNodeConstRef node) {
+YOGA_EXPORT YGValue __cdecl YGNodeStyleGetWidth(YGNodeConstRef node) {
   return node->getStyle().dimensions()[YGDimensionWidth];
 }
 
-YOGA_EXPORT void YGNodeStyleSetHeight(YGNodeRef node, float points) {
+YOGA_EXPORT void __cdecl YGNodeStyleSetHeight(YGNodeRef node, float points) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
       node, &YGStyle::dimensions, YGDimensionHeight, value);
 }
-YOGA_EXPORT void YGNodeStyleSetHeightPercent(YGNodeRef node, float percent) {
+YOGA_EXPORT void __cdecl YGNodeStyleSetHeightPercent(YGNodeRef node, float percent) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
       node, &YGStyle::dimensions, YGDimensionHeight, value);
 }
-YOGA_EXPORT void YGNodeStyleSetHeightAuto(YGNodeRef node) {
+YOGA_EXPORT void __cdecl YGNodeStyleSetHeightAuto(YGNodeRef node) {
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
       node,
       &YGStyle::dimensions,
       YGDimensionHeight,
       detail::CompactValue::ofAuto());
 }
-YOGA_EXPORT YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
+YOGA_EXPORT YGValue __cdecl YGNodeStyleGetHeight(YGNodeConstRef node) {
   return node->getStyle().dimensions()[YGDimensionHeight];
 }
 
-YOGA_EXPORT void YGNodeStyleSetMinWidth(
+YOGA_EXPORT void __cdecl YGNodeStyleSetMinWidth(
     const YGNodeRef node,
     const float minWidth) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(minWidth);
   updateIndexedStyleProp<MSVC_HINT(minDimensions)>(
       node, &YGStyle::minDimensions, YGDimensionWidth, value);
 }
-YOGA_EXPORT void YGNodeStyleSetMinWidthPercent(
+YOGA_EXPORT void __cdecl YGNodeStyleSetMinWidthPercent(
     const YGNodeRef node,
     const float minWidth) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(minWidth);
   updateIndexedStyleProp<MSVC_HINT(minDimensions)>(
       node, &YGStyle::minDimensions, YGDimensionWidth, value);
 }
-YOGA_EXPORT YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
+YOGA_EXPORT YGValue __cdecl YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
   return node->getStyle().minDimensions()[YGDimensionWidth];
 };
 
-YOGA_EXPORT void YGNodeStyleSetMinHeight(
+YOGA_EXPORT void __cdecl YGNodeStyleSetMinHeight(
     const YGNodeRef node,
     const float minHeight) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(minHeight);
   updateIndexedStyleProp<MSVC_HINT(minDimensions)>(
       node, &YGStyle::minDimensions, YGDimensionHeight, value);
 }
-YOGA_EXPORT void YGNodeStyleSetMinHeightPercent(
+YOGA_EXPORT void __cdecl YGNodeStyleSetMinHeightPercent(
     const YGNodeRef node,
     const float minHeight) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(minHeight);
   updateIndexedStyleProp<MSVC_HINT(minDimensions)>(
       node, &YGStyle::minDimensions, YGDimensionHeight, value);
 }
-YOGA_EXPORT YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
+YOGA_EXPORT YGValue __cdecl YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
   return node->getStyle().minDimensions()[YGDimensionHeight];
 };
 
-YOGA_EXPORT void YGNodeStyleSetMaxWidth(
+YOGA_EXPORT void __cdecl YGNodeStyleSetMaxWidth(
     const YGNodeRef node,
     const float maxWidth) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(maxWidth);
   updateIndexedStyleProp<MSVC_HINT(maxDimensions)>(
       node, &YGStyle::maxDimensions, YGDimensionWidth, value);
 }
-YOGA_EXPORT void YGNodeStyleSetMaxWidthPercent(
+YOGA_EXPORT void __cdecl YGNodeStyleSetMaxWidthPercent(
     const YGNodeRef node,
     const float maxWidth) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(maxWidth);
   updateIndexedStyleProp<MSVC_HINT(maxDimensions)>(
       node, &YGStyle::maxDimensions, YGDimensionWidth, value);
 }
-YOGA_EXPORT YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
+YOGA_EXPORT YGValue __cdecl YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
   return node->getStyle().maxDimensions()[YGDimensionWidth];
 };
 
-YOGA_EXPORT void YGNodeStyleSetMaxHeight(
+YOGA_EXPORT void __cdecl YGNodeStyleSetMaxHeight(
     const YGNodeRef node,
     const float maxHeight) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(maxHeight);
   updateIndexedStyleProp<MSVC_HINT(maxDimensions)>(
       node, &YGStyle::maxDimensions, YGDimensionHeight, value);
 }
-YOGA_EXPORT void YGNodeStyleSetMaxHeightPercent(
+YOGA_EXPORT void __cdecl YGNodeStyleSetMaxHeightPercent(
     const YGNodeRef node,
     const float maxHeight) {
   auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(maxHeight);
   updateIndexedStyleProp<MSVC_HINT(maxDimensions)>(
       node, &YGStyle::maxDimensions, YGDimensionHeight, value);
 }
-YOGA_EXPORT YGValue YGNodeStyleGetMaxHeight(const YGNodeConstRef node) {
+YOGA_EXPORT YGValue __cdecl YGNodeStyleGetMaxHeight(const YGNodeConstRef node) {
   return node->getStyle().maxDimensions()[YGDimensionHeight];
 };
 
@@ -1001,7 +1001,7 @@ YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(float, Margin, margin);
 YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(float, Border, border);
 YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(float, Padding, padding);
 
-YOGA_EXPORT bool YGNodeLayoutGetDidLegacyStretchFlagAffectLayout(
+YOGA_EXPORT bool __cdecl YGNodeLayoutGetDidLegacyStretchFlagAffectLayout(
     const YGNodeRef node) {
   return node->getLayout().doesLegacyStretchFlagAffectsLayout();
 }
@@ -1034,7 +1034,7 @@ static void YGNodePrintInternal(
   Log::log(node, YGLogLevelDebug, nullptr, str.c_str());
 }
 
-YOGA_EXPORT void YGNodePrint(
+YOGA_EXPORT void __cdecl YGNodePrint(
     const YGNodeRef node,
     const YGPrintOptions options) {
   YGNodePrintInternal(node, options);
@@ -3655,7 +3655,7 @@ static inline bool YGMeasureModeNewMeasureSizeIsStricterAndStillValid(
       (lastComputedSize <= size || YGFloatsEqual(size, lastComputedSize));
 }
 
-YOGA_EXPORT float YGRoundValueToPixelGrid(
+YOGA_EXPORT float __cdecl YGRoundValueToPixelGrid(
     const float value,
     const float pointScaleFactor,
     const bool forceCeil,
@@ -3706,7 +3706,7 @@ YOGA_EXPORT float YGRoundValueToPixelGrid(
       : scaledValue / pointScaleFactor;
 }
 
-YOGA_EXPORT bool YGNodeCanUseCachedMeasurement(
+YOGA_EXPORT bool __cdecl YGNodeCanUseCachedMeasurement(
     const YGMeasureMode widthMode,
     const float width,
     const YGMeasureMode heightMode,
@@ -4052,7 +4052,7 @@ bool YGLayoutNodeInternal(
   return (needToVisitNode || cachedResults == nullptr);
 }
 
-YOGA_EXPORT void YGConfigSetPointScaleFactor(
+YOGA_EXPORT void __cdecl YGConfigSetPointScaleFactor(
     const YGConfigRef config,
     const float pixelsInPoint) {
   YGAssertWithConfig(
@@ -4149,7 +4149,7 @@ static void unsetUseLegacyFlagRecursively(YGNodeRef node) {
   }
 }
 
-YOGA_EXPORT void YGNodeCalculateLayoutWithContext(
+YOGA_EXPORT void __cdecl YGNodeCalculateLayoutWithContext(
     const YGNodeRef node,
     const float ownerWidth,
     const float ownerHeight,
@@ -4301,7 +4301,7 @@ YOGA_EXPORT void YGNodeCalculateLayoutWithContext(
   }
 }
 
-YOGA_EXPORT void YGNodeCalculateLayout(
+YOGA_EXPORT void __cdecl YGNodeCalculateLayout(
     const YGNodeRef node,
     const float ownerWidth,
     const float ownerHeight,
@@ -4310,7 +4310,7 @@ YOGA_EXPORT void YGNodeCalculateLayout(
       node, ownerWidth, ownerHeight, ownerDirection, nullptr);
 }
 
-YOGA_EXPORT void YGConfigSetLogger(const YGConfigRef config, YGLogger logger) {
+YOGA_EXPORT void __cdecl YGConfigSetLogger(const YGConfigRef config, YGLogger logger) {
   if (logger != nullptr) {
     config->setLogger(logger);
   } else {
@@ -4322,19 +4322,19 @@ YOGA_EXPORT void YGConfigSetLogger(const YGConfigRef config, YGLogger logger) {
   }
 }
 
-YOGA_EXPORT void YGConfigSetShouldDiffLayoutWithoutLegacyStretchBehaviour(
+YOGA_EXPORT void __cdecl YGConfigSetShouldDiffLayoutWithoutLegacyStretchBehaviour(
     const YGConfigRef config,
     const bool shouldDiffLayout) {
   config->shouldDiffLayoutWithoutLegacyStretchBehaviour = shouldDiffLayout;
 }
 
-void YGAssert(const bool condition, const char* message) {
+void __cdecl YGAssert(const bool condition, const char* message) {
   if (!condition) {
     Log::log(YGNodeRef{nullptr}, YGLogLevelFatal, nullptr, "%s\n", message);
   }
 }
 
-void YGAssertWithNode(
+void __cdecl YGAssertWithNode(
     const YGNodeRef node,
     const bool condition,
     const char* message) {
@@ -4352,44 +4352,44 @@ void YGAssertWithConfig(
   }
 }
 
-YOGA_EXPORT void YGConfigSetExperimentalFeatureEnabled(
+YOGA_EXPORT void __cdecl YGConfigSetExperimentalFeatureEnabled(
     const YGConfigRef config,
     const YGExperimentalFeature feature,
     const bool enabled) {
   config->experimentalFeatures[feature] = enabled;
 }
 
-inline bool YGConfigIsExperimentalFeatureEnabled(
+inline bool __cdecl YGConfigIsExperimentalFeatureEnabled(
     const YGConfigRef config,
     const YGExperimentalFeature feature) {
   return config->experimentalFeatures[feature];
 }
 
-YOGA_EXPORT void YGConfigSetUseWebDefaults(
+YOGA_EXPORT void __cdecl YGConfigSetUseWebDefaults(
     const YGConfigRef config,
     const bool enabled) {
   config->useWebDefaults = enabled;
 }
 
-YOGA_EXPORT void YGConfigSetUseLegacyStretchBehaviour(
+YOGA_EXPORT void __cdecl YGConfigSetUseLegacyStretchBehaviour(
     const YGConfigRef config,
     const bool useLegacyStretchBehaviour) {
   config->useLegacyStretchBehaviour = useLegacyStretchBehaviour;
 }
 
-bool YGConfigGetUseWebDefaults(const YGConfigRef config) {
+bool __cdecl YGConfigGetUseWebDefaults(const YGConfigRef config) {
   return config->useWebDefaults;
 }
 
-YOGA_EXPORT void YGConfigSetContext(const YGConfigRef config, void* context) {
+YOGA_EXPORT void __cdecl YGConfigSetContext(const YGConfigRef config, void* context) {
   config->context = context;
 }
 
-YOGA_EXPORT void* YGConfigGetContext(const YGConfigRef config) {
+YOGA_EXPORT void* __cdecl YGConfigGetContext(const YGConfigRef config) {
   return config->context;
 }
 
-YOGA_EXPORT void YGConfigSetCloneNodeFunc(
+YOGA_EXPORT void __cdecl YGConfigSetCloneNodeFunc(
     const YGConfigRef config,
     const YGCloneNodeFunc callback) {
   config->setCloneNodeCallback(callback);
@@ -4404,7 +4404,7 @@ static void YGTraverseChildrenPreOrder(
   }
 }
 
-void YGTraversePreOrder(
+void __cdecl YGTraversePreOrder(
     YGNodeRef const node,
     std::function<void(YGNodeRef node)>&& f) {
   if (!node) {

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -34,17 +34,17 @@ typedef struct YGConfig* YGConfigRef;
 typedef struct YGNode* YGNodeRef;
 typedef const struct YGNode* YGNodeConstRef;
 
-typedef YGSize (*YGMeasureFunc)(
+typedef YGSize (__cdecl *YGMeasureFunc)(
     YGNodeRef node,
     float width,
     YGMeasureMode widthMode,
     float height,
     YGMeasureMode heightMode);
-typedef float (*YGBaselineFunc)(YGNodeRef node, float width, float height);
-typedef void (*YGDirtiedFunc)(YGNodeRef node);
-typedef void (*YGPrintFunc)(YGNodeRef node);
-typedef void (*YGNodeCleanupFunc)(YGNodeRef node);
-typedef int (*YGLogger)(
+typedef float (__cdecl *YGBaselineFunc)(YGNodeRef node, float width, float height);
+typedef void (__cdecl *YGDirtiedFunc)(YGNodeRef node);
+typedef void (__cdecl *YGPrintFunc)(YGNodeRef node);
+typedef void (__cdecl *YGNodeCleanupFunc)(YGNodeRef node);
+typedef int (__cdecl *YGLogger)(
     YGConfigRef config,
     YGNodeRef node,
     YGLogLevel level,
@@ -54,44 +54,44 @@ typedef YGNodeRef (
     *YGCloneNodeFunc)(YGNodeRef oldNode, YGNodeRef owner, int childIndex);
 
 // YGNode
-WIN_EXPORT YGNodeRef YGNodeNew(void);
-WIN_EXPORT YGNodeRef YGNodeNewWithConfig(YGConfigRef config);
-WIN_EXPORT YGNodeRef YGNodeClone(YGNodeRef node);
-WIN_EXPORT void YGNodeFree(YGNodeRef node);
-WIN_EXPORT void YGNodeFreeRecursiveWithCleanupFunc(
+WIN_EXPORT YGNodeRef __cdecl YGNodeNew(void);
+WIN_EXPORT YGNodeRef __cdecl YGNodeNewWithConfig(YGConfigRef config);
+WIN_EXPORT YGNodeRef __cdecl YGNodeClone(YGNodeRef node);
+WIN_EXPORT void __cdecl YGNodeFree(YGNodeRef node);
+WIN_EXPORT void __cdecl YGNodeFreeRecursiveWithCleanupFunc(
     YGNodeRef node,
     YGNodeCleanupFunc cleanup);
-WIN_EXPORT void YGNodeFreeRecursive(YGNodeRef node);
-WIN_EXPORT void YGNodeReset(YGNodeRef node);
+WIN_EXPORT void __cdecl YGNodeFreeRecursive(YGNodeRef node);
+WIN_EXPORT void __cdecl YGNodeReset(YGNodeRef node);
 
-WIN_EXPORT void YGNodeInsertChild(
+WIN_EXPORT void __cdecl YGNodeInsertChild(
     YGNodeRef node,
     YGNodeRef child,
     uint32_t index);
 
-WIN_EXPORT void YGNodeSwapChild(
+WIN_EXPORT void __cdecl YGNodeSwapChild(
     YGNodeRef node,
     YGNodeRef child,
     uint32_t index);
 
-WIN_EXPORT void YGNodeRemoveChild(YGNodeRef node, YGNodeRef child);
-WIN_EXPORT void YGNodeRemoveAllChildren(YGNodeRef node);
-WIN_EXPORT YGNodeRef YGNodeGetChild(YGNodeRef node, uint32_t index);
-WIN_EXPORT YGNodeRef YGNodeGetOwner(YGNodeRef node);
-WIN_EXPORT YGNodeRef YGNodeGetParent(YGNodeRef node);
-WIN_EXPORT uint32_t YGNodeGetChildCount(YGNodeRef node);
-WIN_EXPORT void YGNodeSetChildren(
+WIN_EXPORT void __cdecl YGNodeRemoveChild(YGNodeRef node, YGNodeRef child);
+WIN_EXPORT void __cdecl YGNodeRemoveAllChildren(YGNodeRef node);
+WIN_EXPORT YGNodeRef __cdecl YGNodeGetChild(YGNodeRef node, uint32_t index);
+WIN_EXPORT YGNodeRef __cdecl YGNodeGetOwner(YGNodeRef node);
+WIN_EXPORT YGNodeRef __cdecl YGNodeGetParent(YGNodeRef node);
+WIN_EXPORT uint32_t __cdecl YGNodeGetChildCount(YGNodeRef node);
+WIN_EXPORT void __cdecl YGNodeSetChildren(
     YGNodeRef owner,
     const YGNodeRef children[],
     uint32_t count);
 
-WIN_EXPORT void YGNodeSetIsReferenceBaseline(
+WIN_EXPORT void __cdecl YGNodeSetIsReferenceBaseline(
     YGNodeRef node,
     bool isReferenceBaseline);
 
-WIN_EXPORT bool YGNodeIsReferenceBaseline(YGNodeRef node);
+WIN_EXPORT bool __cdecl YGNodeIsReferenceBaseline(YGNodeRef node);
 
-WIN_EXPORT void YGNodeCalculateLayout(
+WIN_EXPORT void __cdecl YGNodeCalculateLayout(
     YGNodeRef node,
     float availableWidth,
     float availableHeight,
@@ -103,19 +103,19 @@ WIN_EXPORT void YGNodeCalculateLayout(
 // Yoga knows when to mark all other nodes as dirty but because nodes with
 // measure functions depend on information not known to Yoga they must perform
 // this dirty marking manually.
-WIN_EXPORT void YGNodeMarkDirty(YGNodeRef node);
+WIN_EXPORT void __cdecl YGNodeMarkDirty(YGNodeRef node);
 
 // Marks the current node and all its descendants as dirty.
 //
 // Intended to be used for Uoga benchmarks. Don't use in production, as calling
 // `YGCalculateLayout` will cause the recalculation of each and every node.
-WIN_EXPORT void YGNodeMarkDirtyAndPropogateToDescendants(YGNodeRef node);
+WIN_EXPORT void __cdecl YGNodeMarkDirtyAndPropogateToDescendants(YGNodeRef node);
 
-WIN_EXPORT void YGNodePrint(YGNodeRef node, YGPrintOptions options);
+WIN_EXPORT void __cdecl YGNodePrint(YGNodeRef node, YGPrintOptions options);
 
-WIN_EXPORT bool YGFloatIsUndefined(float value);
+WIN_EXPORT bool __cdecl YGFloatIsUndefined(float value);
 
-WIN_EXPORT bool YGNodeCanUseCachedMeasurement(
+WIN_EXPORT bool __cdecl YGNodeCanUseCachedMeasurement(
     YGMeasureMode widthMode,
     float width,
     YGMeasureMode heightMode,
@@ -130,133 +130,133 @@ WIN_EXPORT bool YGNodeCanUseCachedMeasurement(
     float marginColumn,
     YGConfigRef config);
 
-WIN_EXPORT void YGNodeCopyStyle(YGNodeRef dstNode, YGNodeRef srcNode);
+WIN_EXPORT void __cdecl YGNodeCopyStyle(YGNodeRef dstNode, YGNodeRef srcNode);
 
-WIN_EXPORT void* YGNodeGetContext(YGNodeRef node);
-WIN_EXPORT void YGNodeSetContext(YGNodeRef node, void* context);
-void YGConfigSetPrintTreeFlag(YGConfigRef config, bool enabled);
-bool YGNodeHasMeasureFunc(YGNodeRef node);
-WIN_EXPORT void YGNodeSetMeasureFunc(YGNodeRef node, YGMeasureFunc measureFunc);
-bool YGNodeHasBaselineFunc(YGNodeRef node);
-void YGNodeSetBaselineFunc(YGNodeRef node, YGBaselineFunc baselineFunc);
-YGDirtiedFunc YGNodeGetDirtiedFunc(YGNodeRef node);
-void YGNodeSetDirtiedFunc(YGNodeRef node, YGDirtiedFunc dirtiedFunc);
-void YGNodeSetPrintFunc(YGNodeRef node, YGPrintFunc printFunc);
-WIN_EXPORT bool YGNodeGetHasNewLayout(YGNodeRef node);
-WIN_EXPORT void YGNodeSetHasNewLayout(YGNodeRef node, bool hasNewLayout);
-YGNodeType YGNodeGetNodeType(YGNodeRef node);
-void YGNodeSetNodeType(YGNodeRef node, YGNodeType nodeType);
-WIN_EXPORT bool YGNodeIsDirty(YGNodeRef node);
-bool YGNodeLayoutGetDidUseLegacyFlag(YGNodeRef node);
+WIN_EXPORT void* __cdecl YGNodeGetContext(YGNodeRef node);
+WIN_EXPORT void __cdecl YGNodeSetContext(YGNodeRef node, void* context);
+void __cdecl YGConfigSetPrintTreeFlag(YGConfigRef config, bool enabled);
+bool __cdecl YGNodeHasMeasureFunc(YGNodeRef node);
+WIN_EXPORT void __cdecl YGNodeSetMeasureFunc(YGNodeRef node, YGMeasureFunc measureFunc);
+bool __cdecl YGNodeHasBaselineFunc(YGNodeRef node);
+void __cdecl YGNodeSetBaselineFunc(YGNodeRef node, YGBaselineFunc baselineFunc);
+YGDirtiedFunc __cdecl YGNodeGetDirtiedFunc(YGNodeRef node);
+void __cdecl YGNodeSetDirtiedFunc(YGNodeRef node, YGDirtiedFunc dirtiedFunc);
+void __cdecl YGNodeSetPrintFunc(YGNodeRef node, YGPrintFunc printFunc);
+WIN_EXPORT bool __cdecl YGNodeGetHasNewLayout(YGNodeRef node);
+WIN_EXPORT void __cdecl YGNodeSetHasNewLayout(YGNodeRef node, bool hasNewLayout);
+YGNodeType __cdecl YGNodeGetNodeType(YGNodeRef node);
+void __cdecl YGNodeSetNodeType(YGNodeRef node, YGNodeType nodeType);
+WIN_EXPORT bool __cdecl YGNodeIsDirty(YGNodeRef node);
+bool __cdecl YGNodeLayoutGetDidUseLegacyFlag(YGNodeRef node);
 
-WIN_EXPORT void YGNodeStyleSetDirection(YGNodeRef node, YGDirection direction);
-WIN_EXPORT YGDirection YGNodeStyleGetDirection(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetDirection(YGNodeRef node, YGDirection direction);
+WIN_EXPORT YGDirection __cdecl YGNodeStyleGetDirection(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetFlexDirection(
+WIN_EXPORT void __cdecl YGNodeStyleSetFlexDirection(
     YGNodeRef node,
     YGFlexDirection flexDirection);
-WIN_EXPORT YGFlexDirection YGNodeStyleGetFlexDirection(YGNodeConstRef node);
+WIN_EXPORT YGFlexDirection __cdecl YGNodeStyleGetFlexDirection(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetJustifyContent(
+WIN_EXPORT void __cdecl YGNodeStyleSetJustifyContent(
     YGNodeRef node,
     YGJustify justifyContent);
-WIN_EXPORT YGJustify YGNodeStyleGetJustifyContent(YGNodeConstRef node);
+WIN_EXPORT YGJustify __cdecl YGNodeStyleGetJustifyContent(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetAlignContent(
+WIN_EXPORT void __cdecl YGNodeStyleSetAlignContent(
     YGNodeRef node,
     YGAlign alignContent);
-WIN_EXPORT YGAlign YGNodeStyleGetAlignContent(YGNodeConstRef node);
+WIN_EXPORT YGAlign __cdecl YGNodeStyleGetAlignContent(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetAlignItems(YGNodeRef node, YGAlign alignItems);
-WIN_EXPORT YGAlign YGNodeStyleGetAlignItems(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetAlignItems(YGNodeRef node, YGAlign alignItems);
+WIN_EXPORT YGAlign __cdecl YGNodeStyleGetAlignItems(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetAlignSelf(YGNodeRef node, YGAlign alignSelf);
-WIN_EXPORT YGAlign YGNodeStyleGetAlignSelf(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetAlignSelf(YGNodeRef node, YGAlign alignSelf);
+WIN_EXPORT YGAlign __cdecl YGNodeStyleGetAlignSelf(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetPositionType(
+WIN_EXPORT void __cdecl YGNodeStyleSetPositionType(
     YGNodeRef node,
     YGPositionType positionType);
-WIN_EXPORT YGPositionType YGNodeStyleGetPositionType(YGNodeConstRef node);
+WIN_EXPORT YGPositionType __cdecl YGNodeStyleGetPositionType(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetFlexWrap(YGNodeRef node, YGWrap flexWrap);
-WIN_EXPORT YGWrap YGNodeStyleGetFlexWrap(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetFlexWrap(YGNodeRef node, YGWrap flexWrap);
+WIN_EXPORT YGWrap __cdecl YGNodeStyleGetFlexWrap(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetOverflow(YGNodeRef node, YGOverflow overflow);
-WIN_EXPORT YGOverflow YGNodeStyleGetOverflow(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetOverflow(YGNodeRef node, YGOverflow overflow);
+WIN_EXPORT YGOverflow __cdecl YGNodeStyleGetOverflow(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetDisplay(YGNodeRef node, YGDisplay display);
-WIN_EXPORT YGDisplay YGNodeStyleGetDisplay(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetDisplay(YGNodeRef node, YGDisplay display);
+WIN_EXPORT YGDisplay __cdecl YGNodeStyleGetDisplay(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetFlex(YGNodeRef node, float flex);
-WIN_EXPORT float YGNodeStyleGetFlex(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetFlex(YGNodeRef node, float flex);
+WIN_EXPORT float __cdecl YGNodeStyleGetFlex(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetFlexGrow(YGNodeRef node, float flexGrow);
-WIN_EXPORT float YGNodeStyleGetFlexGrow(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetFlexGrow(YGNodeRef node, float flexGrow);
+WIN_EXPORT float __cdecl YGNodeStyleGetFlexGrow(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetFlexShrink(YGNodeRef node, float flexShrink);
-WIN_EXPORT float YGNodeStyleGetFlexShrink(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetFlexShrink(YGNodeRef node, float flexShrink);
+WIN_EXPORT float __cdecl YGNodeStyleGetFlexShrink(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetFlexBasis(YGNodeRef node, float flexBasis);
-WIN_EXPORT void YGNodeStyleSetFlexBasisPercent(YGNodeRef node, float flexBasis);
-WIN_EXPORT void YGNodeStyleSetFlexBasisAuto(YGNodeRef node);
-WIN_EXPORT YGValue YGNodeStyleGetFlexBasis(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetFlexBasis(YGNodeRef node, float flexBasis);
+WIN_EXPORT void __cdecl YGNodeStyleSetFlexBasisPercent(YGNodeRef node, float flexBasis);
+WIN_EXPORT void __cdecl YGNodeStyleSetFlexBasisAuto(YGNodeRef node);
+WIN_EXPORT YGValue __cdecl YGNodeStyleGetFlexBasis(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetPosition(
+WIN_EXPORT void __cdecl YGNodeStyleSetPosition(
     YGNodeRef node,
     YGEdge edge,
     float position);
-WIN_EXPORT void YGNodeStyleSetPositionPercent(
+WIN_EXPORT void __cdecl YGNodeStyleSetPositionPercent(
     YGNodeRef node,
     YGEdge edge,
     float position);
-WIN_EXPORT YGValue YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge);
+WIN_EXPORT YGValue __cdecl YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge);
 
-WIN_EXPORT void YGNodeStyleSetMargin(YGNodeRef node, YGEdge edge, float margin);
-WIN_EXPORT void YGNodeStyleSetMarginPercent(
+WIN_EXPORT void __cdecl YGNodeStyleSetMargin(YGNodeRef node, YGEdge edge, float margin);
+WIN_EXPORT void __cdecl YGNodeStyleSetMarginPercent(
     YGNodeRef node,
     YGEdge edge,
     float margin);
-WIN_EXPORT void YGNodeStyleSetMarginAuto(YGNodeRef node, YGEdge edge);
-WIN_EXPORT YGValue YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge);
+WIN_EXPORT void __cdecl YGNodeStyleSetMarginAuto(YGNodeRef node, YGEdge edge);
+WIN_EXPORT YGValue __cdecl YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge);
 
-WIN_EXPORT void YGNodeStyleSetPadding(
+WIN_EXPORT void __cdecl YGNodeStyleSetPadding(
     YGNodeRef node,
     YGEdge edge,
     float padding);
-WIN_EXPORT void YGNodeStyleSetPaddingPercent(
+WIN_EXPORT void __cdecl YGNodeStyleSetPaddingPercent(
     YGNodeRef node,
     YGEdge edge,
     float padding);
-WIN_EXPORT YGValue YGNodeStyleGetPadding(YGNodeConstRef node, YGEdge edge);
+WIN_EXPORT YGValue __cdecl YGNodeStyleGetPadding(YGNodeConstRef node, YGEdge edge);
 
-WIN_EXPORT void YGNodeStyleSetBorder(YGNodeRef node, YGEdge edge, float border);
-WIN_EXPORT float YGNodeStyleGetBorder(YGNodeConstRef node, YGEdge edge);
+WIN_EXPORT void __cdecl YGNodeStyleSetBorder(YGNodeRef node, YGEdge edge, float border);
+WIN_EXPORT float __cdecl YGNodeStyleGetBorder(YGNodeConstRef node, YGEdge edge);
 
-WIN_EXPORT void YGNodeStyleSetWidth(YGNodeRef node, float width);
-WIN_EXPORT void YGNodeStyleSetWidthPercent(YGNodeRef node, float width);
-WIN_EXPORT void YGNodeStyleSetWidthAuto(YGNodeRef node);
-WIN_EXPORT YGValue YGNodeStyleGetWidth(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetWidth(YGNodeRef node, float width);
+WIN_EXPORT void __cdecl YGNodeStyleSetWidthPercent(YGNodeRef node, float width);
+WIN_EXPORT void __cdecl YGNodeStyleSetWidthAuto(YGNodeRef node);
+WIN_EXPORT YGValue __cdecl YGNodeStyleGetWidth(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetHeight(YGNodeRef node, float height);
-WIN_EXPORT void YGNodeStyleSetHeightPercent(YGNodeRef node, float height);
-WIN_EXPORT void YGNodeStyleSetHeightAuto(YGNodeRef node);
-WIN_EXPORT YGValue YGNodeStyleGetHeight(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetHeight(YGNodeRef node, float height);
+WIN_EXPORT void __cdecl YGNodeStyleSetHeightPercent(YGNodeRef node, float height);
+WIN_EXPORT void __cdecl YGNodeStyleSetHeightAuto(YGNodeRef node);
+WIN_EXPORT YGValue __cdecl YGNodeStyleGetHeight(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetMinWidth(YGNodeRef node, float minWidth);
-WIN_EXPORT void YGNodeStyleSetMinWidthPercent(YGNodeRef node, float minWidth);
-WIN_EXPORT YGValue YGNodeStyleGetMinWidth(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetMinWidth(YGNodeRef node, float minWidth);
+WIN_EXPORT void __cdecl YGNodeStyleSetMinWidthPercent(YGNodeRef node, float minWidth);
+WIN_EXPORT YGValue __cdecl YGNodeStyleGetMinWidth(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetMinHeight(YGNodeRef node, float minHeight);
-WIN_EXPORT void YGNodeStyleSetMinHeightPercent(YGNodeRef node, float minHeight);
-WIN_EXPORT YGValue YGNodeStyleGetMinHeight(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetMinHeight(YGNodeRef node, float minHeight);
+WIN_EXPORT void __cdecl YGNodeStyleSetMinHeightPercent(YGNodeRef node, float minHeight);
+WIN_EXPORT YGValue __cdecl YGNodeStyleGetMinHeight(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetMaxWidth(YGNodeRef node, float maxWidth);
-WIN_EXPORT void YGNodeStyleSetMaxWidthPercent(YGNodeRef node, float maxWidth);
-WIN_EXPORT YGValue YGNodeStyleGetMaxWidth(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetMaxWidth(YGNodeRef node, float maxWidth);
+WIN_EXPORT void __cdecl YGNodeStyleSetMaxWidthPercent(YGNodeRef node, float maxWidth);
+WIN_EXPORT YGValue __cdecl YGNodeStyleGetMaxWidth(YGNodeConstRef node);
 
-WIN_EXPORT void YGNodeStyleSetMaxHeight(YGNodeRef node, float maxHeight);
-WIN_EXPORT void YGNodeStyleSetMaxHeightPercent(YGNodeRef node, float maxHeight);
-WIN_EXPORT YGValue YGNodeStyleGetMaxHeight(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetMaxHeight(YGNodeRef node, float maxHeight);
+WIN_EXPORT void __cdecl YGNodeStyleSetMaxHeightPercent(YGNodeRef node, float maxHeight);
+WIN_EXPORT YGValue __cdecl YGNodeStyleGetMaxHeight(YGNodeConstRef node);
 
 // Yoga specific properties, not compatible with flexbox specification Aspect
 // ratio control the size of the undefined dimension of a node. Aspect ratio is
@@ -273,30 +273,30 @@ WIN_EXPORT YGValue YGNodeStyleGetMaxHeight(YGNodeConstRef node);
 // - On a node with flex grow/shrink aspect ratio controls the size of the node
 //   in the cross axis if unset
 // - Aspect ratio takes min/max dimensions into account
-WIN_EXPORT void YGNodeStyleSetAspectRatio(YGNodeRef node, float aspectRatio);
-WIN_EXPORT float YGNodeStyleGetAspectRatio(YGNodeConstRef node);
+WIN_EXPORT void __cdecl YGNodeStyleSetAspectRatio(YGNodeRef node, float aspectRatio);
+WIN_EXPORT float __cdecl YGNodeStyleGetAspectRatio(YGNodeConstRef node);
 
-WIN_EXPORT float YGNodeLayoutGetLeft(YGNodeRef node);
-WIN_EXPORT float YGNodeLayoutGetTop(YGNodeRef node);
-WIN_EXPORT float YGNodeLayoutGetRight(YGNodeRef node);
-WIN_EXPORT float YGNodeLayoutGetBottom(YGNodeRef node);
-WIN_EXPORT float YGNodeLayoutGetWidth(YGNodeRef node);
-WIN_EXPORT float YGNodeLayoutGetHeight(YGNodeRef node);
-WIN_EXPORT YGDirection YGNodeLayoutGetDirection(YGNodeRef node);
-WIN_EXPORT bool YGNodeLayoutGetHadOverflow(YGNodeRef node);
-bool YGNodeLayoutGetDidLegacyStretchFlagAffectLayout(YGNodeRef node);
+WIN_EXPORT float __cdecl YGNodeLayoutGetLeft(YGNodeRef node);
+WIN_EXPORT float __cdecl YGNodeLayoutGetTop(YGNodeRef node);
+WIN_EXPORT float __cdecl YGNodeLayoutGetRight(YGNodeRef node);
+WIN_EXPORT float __cdecl YGNodeLayoutGetBottom(YGNodeRef node);
+WIN_EXPORT float __cdecl YGNodeLayoutGetWidth(YGNodeRef node);
+WIN_EXPORT float __cdecl YGNodeLayoutGetHeight(YGNodeRef node);
+WIN_EXPORT YGDirection __cdecl YGNodeLayoutGetDirection(YGNodeRef node);
+WIN_EXPORT bool __cdecl YGNodeLayoutGetHadOverflow(YGNodeRef node);
+bool __cdecl YGNodeLayoutGetDidLegacyStretchFlagAffectLayout(YGNodeRef node);
 
 // Get the computed values for these nodes after performing layout. If they were
 // set using point values then the returned value will be the same as
 // YGNodeStyleGetXXX. However if they were set using a percentage value then the
 // returned value is the computed value used during layout.
-WIN_EXPORT float YGNodeLayoutGetMargin(YGNodeRef node, YGEdge edge);
-WIN_EXPORT float YGNodeLayoutGetBorder(YGNodeRef node, YGEdge edge);
-WIN_EXPORT float YGNodeLayoutGetPadding(YGNodeRef node, YGEdge edge);
+WIN_EXPORT float __cdecl YGNodeLayoutGetMargin(YGNodeRef node, YGEdge edge);
+WIN_EXPORT float __cdecl YGNodeLayoutGetBorder(YGNodeRef node, YGEdge edge);
+WIN_EXPORT float __cdecl YGNodeLayoutGetPadding(YGNodeRef node, YGEdge edge);
 
-WIN_EXPORT void YGConfigSetLogger(YGConfigRef config, YGLogger logger);
-WIN_EXPORT void YGAssert(bool condition, const char* message);
-WIN_EXPORT void YGAssertWithNode(
+WIN_EXPORT void __cdecl YGConfigSetLogger(YGConfigRef config, YGLogger logger);
+WIN_EXPORT void __cdecl YGAssert(bool condition, const char* message);
+WIN_EXPORT void __cdecl YGAssertWithNode(
     YGNodeRef node,
     bool condition,
     const char* message);
@@ -306,10 +306,10 @@ WIN_EXPORT void YGAssertWithConfig(
     const char* message);
 // Set this to number of pixels in 1 point to round calculation results If you
 // want to avoid rounding - set PointScaleFactor to 0
-WIN_EXPORT void YGConfigSetPointScaleFactor(
+WIN_EXPORT void __cdecl YGConfigSetPointScaleFactor(
     YGConfigRef config,
     float pixelsInPoint);
-void YGConfigSetShouldDiffLayoutWithoutLegacyStretchBehaviour(
+void __cdecl YGConfigSetShouldDiffLayoutWithoutLegacyStretchBehaviour(
     YGConfigRef config,
     bool shouldDiffLayout);
 
@@ -318,40 +318,40 @@ void YGConfigSetShouldDiffLayoutWithoutLegacyStretchBehaviour(
 // resulted in implicit behaviour similar to align-self: stretch; Because this
 // was such a long-standing bug we must allow legacy users to switch back to
 // this behaviour.
-WIN_EXPORT void YGConfigSetUseLegacyStretchBehaviour(
+WIN_EXPORT void __cdecl YGConfigSetUseLegacyStretchBehaviour(
     YGConfigRef config,
     bool useLegacyStretchBehaviour);
 
 // YGConfig
-WIN_EXPORT YGConfigRef YGConfigNew(void);
-WIN_EXPORT void YGConfigFree(YGConfigRef config);
-WIN_EXPORT void YGConfigCopy(YGConfigRef dest, YGConfigRef src);
-WIN_EXPORT int32_t YGConfigGetInstanceCount(void);
+WIN_EXPORT YGConfigRef __cdecl YGConfigNew(void);
+WIN_EXPORT void __cdecl YGConfigFree(YGConfigRef config);
+WIN_EXPORT void __cdecl YGConfigCopy(YGConfigRef dest, YGConfigRef src);
+WIN_EXPORT int32_t __cdecl YGConfigGetInstanceCount(void);
 
-WIN_EXPORT void YGConfigSetExperimentalFeatureEnabled(
+WIN_EXPORT void __cdecl YGConfigSetExperimentalFeatureEnabled(
     YGConfigRef config,
     YGExperimentalFeature feature,
     bool enabled);
-WIN_EXPORT bool YGConfigIsExperimentalFeatureEnabled(
+WIN_EXPORT bool __cdecl YGConfigIsExperimentalFeatureEnabled(
     YGConfigRef config,
     YGExperimentalFeature feature);
 
 // Using the web defaults is the preferred configuration for new projects. Usage
 // of non web defaults should be considered as legacy.
-WIN_EXPORT void YGConfigSetUseWebDefaults(YGConfigRef config, bool enabled);
-WIN_EXPORT bool YGConfigGetUseWebDefaults(YGConfigRef config);
+WIN_EXPORT void __cdecl YGConfigSetUseWebDefaults(YGConfigRef config, bool enabled);
+WIN_EXPORT bool __cdecl YGConfigGetUseWebDefaults(YGConfigRef config);
 
-WIN_EXPORT void YGConfigSetCloneNodeFunc(
+WIN_EXPORT void __cdecl YGConfigSetCloneNodeFunc(
     YGConfigRef config,
     YGCloneNodeFunc callback);
 
 // Export only for C#
-WIN_EXPORT YGConfigRef YGConfigGetDefault(void);
+WIN_EXPORT YGConfigRef __cdecl YGConfigGetDefault(void);
 
-WIN_EXPORT void YGConfigSetContext(YGConfigRef config, void* context);
-WIN_EXPORT void* YGConfigGetContext(YGConfigRef config);
+WIN_EXPORT void __cdecl YGConfigSetContext(YGConfigRef config, void* context);
+WIN_EXPORT void* __cdecl YGConfigGetContext(YGConfigRef config);
 
-WIN_EXPORT float YGRoundValueToPixelGrid(
+WIN_EXPORT float __cdecl YGRoundValueToPixelGrid(
     float value,
     float pointScaleFactor,
     bool forceCeil,
@@ -365,10 +365,10 @@ YG_EXTERN_C_END
 #include <vector>
 
 // Calls f on each node in the tree including the given node argument.
-void YGTraversePreOrder(
+void __cdecl YGTraversePreOrder(
     YGNodeRef node,
     std::function<void(YGNodeRef node)>&& f);
 
-void YGNodeSetChildren(YGNodeRef owner, const std::vector<YGNodeRef>& children);
+void __cdecl YGNodeSetChildren(YGNodeRef owner, const std::vector<YGNodeRef>& children);
 
 #endif

--- a/yoga/event/event.cpp
+++ b/yoga/event/event.cpp
@@ -13,7 +13,7 @@
 namespace facebook {
 namespace yoga {
 
-const char* LayoutPassReasonToString(const LayoutPassReason value) {
+const char* __cdecl LayoutPassReasonToString(const LayoutPassReason value) {
   switch (value) {
     case LayoutPassReason::kInitial:
       return "initial";

--- a/yoga/event/event.h
+++ b/yoga/event/event.h
@@ -48,7 +48,7 @@ struct LayoutData {
       measureCallbackReasonsCount;
 };
 
-const char* LayoutPassReasonToString(const LayoutPassReason value);
+const char* __cdecl LayoutPassReasonToString(const LayoutPassReason value);
 
 struct YOGA_EXPORT Event {
   enum Type {
@@ -63,7 +63,7 @@ struct YOGA_EXPORT Event {
     NodeBaselineEnd,
   };
   class Data;
-  using Subscriber = void(const YGNode&, Type, Data);
+  using Subscriber = void __cdecl (const YGNode&, Type, Data);
   using Subscribers = std::vector<std::function<Subscriber>>;
 
   template <Type E>

--- a/yoga/internal/experiments-inl.h
+++ b/yoga/internal/experiments-inl.h
@@ -19,11 +19,11 @@ namespace detail {
 extern std::bitset<sizeof(int)> enabledExperiments;
 } // namespace detail
 
-inline bool isEnabled(Experiment experiment) {
+inline bool __cdecl isEnabled(Experiment experiment) {
   return detail::enabledExperiments.test(static_cast<size_t>(experiment));
 }
 
-inline void disableAllExperiments() {
+inline void __cdecl disableAllExperiments() {
   detail::enabledExperiments = 0;
 }
 

--- a/yoga/internal/experiments.cpp
+++ b/yoga/internal/experiments.cpp
@@ -18,15 +18,15 @@ std::bitset<sizeof(int)> enabledExperiments = 0;
 
 } // namespace detail
 
-void enable(Experiment experiment) {
+void __cdecl enable(Experiment experiment) {
   detail::enabledExperiments.set(static_cast<size_t>(experiment));
 }
 
-void disable(Experiment experiment) {
+void __cdecl disable(Experiment experiment) {
   detail::enabledExperiments.reset(static_cast<size_t>(experiment));
 }
 
-bool toggle(Experiment experiment) {
+bool __cdecl toggle(Experiment experiment) {
   auto bit = static_cast<size_t>(experiment);
   auto previousState = detail::enabledExperiments.test(bit);
   detail::enabledExperiments.flip(bit);

--- a/yoga/internal/experiments.h
+++ b/yoga/internal/experiments.h
@@ -17,9 +17,9 @@ enum struct Experiment : size_t {
   kDoubleMeasureCallbacks,
 };
 
-void enable(Experiment);
-void disable(Experiment);
-bool toggle(Experiment);
+void __cdecl enable(Experiment);
+void __cdecl disable(Experiment);
+bool __cdecl toggle(Experiment);
 
 } // namespace internal
 } // namespace yoga


### PR DESCRIPTION
This allows for projects that depend on folly built with different calling conventions to share Yoga headers and  be binary-compatible.

By default, compilers use `__cdecl` as the calling convention on `x86` platforms.
This change ensures changing that compiler flag won't make binaries incompatible with other consuming software code bases or build configurations.