### PR TITLE
Enhance build process

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -41,6 +41,20 @@ yoga_cxx_library(
 )
 
 yoga_cxx_library(
+    name = "yoga-static",
+    srcs = glob(["yoga/**/*.cpp"]),
+    compiler_flags = LIBRARY_COMPILER_FLAGS,
+    preferred_linkage = "static",
+    public_include_directories = ["."],
+    raw_headers = glob(["yoga/**/*.h"]),
+    tests = [":YogaTests"],
+    visibility = ["PUBLIC"],
+    deps = [
+        ":ndklog",
+    ],
+)
+
+yoga_cxx_library(
     name = "yogaForDebug",
     srcs = glob(["yoga/**/*.cpp"]),
     compiler_flags = TEST_COMPILER_FLAGS,

--- a/android/BUCK
+++ b/android/BUCK
@@ -7,6 +7,7 @@ load("//tools/build_defs/oss:yoga_defs.bzl", "ANDROID_JAVA_TARGET", "ANDROID_RES
 
 yoga_android_aar(
     name = "android",
+    enable_relinker = True,
     manifest_skeleton = "src/main/AndroidManifest.xml",
     visibility = [
         "PUBLIC",

--- a/java/BUCK
+++ b/java/BUCK
@@ -7,7 +7,7 @@ load("//tools/build_defs/oss:yoga_defs.bzl", "ANDROID", "CXX_LIBRARY_WHITELIST",
 
 CXX_LIBRARY_WHITELIST_FOR_TESTS = CXX_LIBRARY_WHITELIST + [
     yoga_cxx_lib("testutil:jni"),
-    yoga_cxx_lib("testutil:testutil"),
+    yoga_cxx_lib("testutil:testutil-jni"),
 ]
 
 YOGA_JAVA_IMPLEMENTATION_FILES = [
@@ -54,7 +54,7 @@ yoga_cxx_library(
     visibility = ["PUBLIC"],
     deps = [
         JNI_TARGET,
-        yoga_dep(":yoga"),
+        yoga_dep(":yoga-static"),
         ":ndklog",
     ],
 )

--- a/testutil/BUCK
+++ b/testutil/BUCK
@@ -11,6 +11,18 @@ yoga_cxx_library(
     deps = [yoga_dep(":yoga")],
 )
 
+yoga_cxx_library(
+    name = "testutil-jni",
+    srcs = ["src/main/cpp/testutil/testutil.cpp"],
+    header_namespace = "",
+    exported_headers = subdir_glob([("src/main/cpp/include", "yoga/testutil/testutil.h")]),
+    compiler_flags = LIBRARY_COMPILER_FLAGS,
+    platforms = ANDROID,
+    soname = "libyoga_testutil.$(ext)",
+    visibility = ["PUBLIC"],
+    deps = [yoga_dep("java:jni")],
+)
+
 yoga_java_library(
     name = "java",
     srcs = ["src/main/java/com/facebook/yoga/TestUtil.java"],
@@ -32,7 +44,7 @@ yoga_cxx_library(
     soname = "libyoga_testutil_jni.$(ext)",
     visibility = ["PUBLIC"],
     deps = [
-        ":testutil",
+        ":testutil-jni",
         FBJNI_TARGET,
     ],
 )


### PR DESCRIPTION
Summary:
After building yoga aar, we found several issues:
1. More dynamic so files. This is bad as lower-end Android devices cannot load that many sos.
2. Size increase.
3. (Minor) The libs are stored in asset folder rather than "libs/".

We apply the following optimizations:
1. Remove dependency on memalign16 (this is brought in by a pure header dependency jni-hack);
2. Enable native relinker to remove unused symbols in the so files.
3. Link yogacore statically to reduce size churn.

Differential Revision: D20808623

