### PR TITLE
fix missing invalidation if owner has undefinied dims

### DIFF
--- a/tests/YGRelayoutTest.cpp
+++ b/tests/YGRelayoutTest.cpp
@@ -49,3 +49,33 @@ TEST(YogaTest, recalculate_resolvedDimonsion_onchange) {
 
   YGNodeFreeRecursive(root);
 }
+
+
+YGSize _measureRecalc(YGNodeRef node, float width, YGMeasureMode widthMode, float height, YGMeasureMode heightMode) {
+    return YGSize { 0, 0};
+}
+
+TEST(YogaTest, recalculate_on_layout_values_change) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureWebFlexBasis, true);
+  YGConfigSetPointScaleFactor(config, 3.f);
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignFlexStart);
+  YGNodeStyleSetAlignContent(root, YGAlignFlexStart);
+  const YGNodeRef child = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMinHeightPercent(child, 40.f);
+  YGNodeStyleSetMaxHeightPercent(child, 60.f);
+  YGNodeStyleSetHeight(child, 10.f);
+  YGNodeStyleSetWidth(child, 50.0f);
+  YGNodeSetMeasureFunc(child, _measureRecalc);
+  YGNodeInsertChild(root, child, 0);
+
+  YGNodeCalculateLayout(root, 50.0f, YGUndefined, YGDirectionLTR);
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(child));
+
+  YGNodeCalculateLayout(root, 50.0f, 30.0f, YGDirectionLTR);
+  ASSERT_FLOAT_EQ(12, YGNodeLayoutGetHeight(child));
+
+  YGNodeFreeRecursive(root);
+}

--- a/yoga/YGLayout.h
+++ b/yoga/YGLayout.h
@@ -38,6 +38,9 @@ public:
   uint32_t generationCount = 0;
   YGDirection lastOwnerDirection = YGDirectionInherit;
 
+  bool lastOwnerHadUndefinedHeight = false;
+  bool lastOwnerHadUndefinedWidth = false;
+
   uint32_t nextCachedMeasurementsIndex = 0;
   std::array<YGCachedMeasurement, YG_MAX_CACHED_RESULT_COUNT>
       cachedMeasurements = {};

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -3811,9 +3811,14 @@ bool YGLayoutNodeInternal(
 
   depth++;
 
+  bool ownerHasUndefinedHeight = YGFloatIsUndefined(ownerHeight);
+  bool ownerHasUndefinedWidth = YGFloatIsUndefined(ownerWidth);
+
   const bool needToVisitNode =
       (node->isDirty() && layout->generationCount != generationCount) ||
-      layout->lastOwnerDirection != ownerDirection;
+      layout->lastOwnerDirection != ownerDirection || 
+      layout->lastOwnerHadUndefinedHeight != ownerHasUndefinedHeight|| 
+      layout->lastOwnerHadUndefinedWidth != ownerHasUndefinedWidth;
 
   if (needToVisitNode) {
     // Invalidate the cached results.
@@ -3995,6 +4000,8 @@ bool YGLayoutNodeInternal(
     }
 
     layout->lastOwnerDirection = ownerDirection;
+    layout->lastOwnerHadUndefinedHeight = ownerHasUndefinedHeight;
+    layout->lastOwnerHadUndefinedWidth = ownerHasUndefinedWidth;
 
     if (cachedResults == nullptr) {
       if (layout->nextCachedMeasurementsIndex + 1 >


### PR DESCRIPTION
Fixes #1003 by adding additional values, which keep track if the owner size has been undefined before. Being undefined lead to different calculations for min/max constraints thus, in that specific case leading to the wrong behavior.