### PR TITLE
Fix broken absolute/relative link in Playground Editor

### DIFF
--- a/website/src/components/Playground/src/Editor.js
+++ b/website/src/components/Playground/src/Editor.js
@@ -308,7 +308,7 @@ export default class Editor extends Component<Props> {
             ))}
             <h2>
               Position Type
-              <InfoText doclink="/docs/absolute-position">
+              <InfoText doclink="/docs/absolute-relative-layout">
                 Relative position offsets the node from it's calculated
                 position. Absolute position removes the node from the flexbox
                 flow and positions it at the given position.


### PR DESCRIPTION
The correct link is https://yogalayout.com/docs/absolute-relative-layout
The current link leads to a broken page https://yogalayout.com/docs/absolute-position