### PR TITLE
update `flexShrink` description on the website

### DIFF
--- a/website/contents/properties/flex.md
+++ b/website/contents/properties/flex.md
@@ -21,7 +21,7 @@ flex shrink is very similar to flex grow and can be thought of in the same way i
 any overflowing size is considered to be negative remaining space.
 These two properties also work well together by allowing children to grow and shrink as needed.
 
-Flex shrink accepts any floating point value >= 0, with 1 being the default value.
+Flex shrink accepts any floating point value >= 0, with 1 being the default value on the most of platforms.
 A container will shrink its children weighted by the child’s flex shrink value.
 
 <controls prop="flexShrink"></controls>


### PR DESCRIPTION
This small PR updates the `flexShrink` description on the website to take the account for the React Native implementation (https://github.com/facebook/react-native/blob/master/ReactCommon/yoga/yoga/Yoga-internal.h), which uses `0` as a default value for the `flexShrink`.

Refs: https://github.com/facebook/react-native-website/pull/2451
