### PR TITLE
Fix env setting and Android setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,8 @@ jobs:
           cd buck
           ant
           popd
-          echo "::set-env name=PATH::$PATH:$HOME/buck/bin/"
+          echo "$HOME/buck/bin" >> $GITHUB_PATH
           export PATH=$PATH:$HOME/buck/bin/
           buck --version
-          export TERMINAL=dumb
-          source scripts/android-setup.sh && installAndroidSDK
-          echo "::set-env name=ANDROID_SDK::$ANDROID_HOME"
-          echo "::set-env name=ANDROID_NDK_REPOSITORY::$HOME/android-ndk"
-          echo "::set-env name=ANDROID_NDK_HOME::$ANDROID_NDK_REPOSITORY/android-ndk-r15c"
       - name: Build
         run: ./gradlew testDebugUnit && scripts/publish-snapshot.sh


### PR DESCRIPTION
Summary:
The current way env variables are set is no longer supported. The manual Android setup is also quite tricky to maintain and can mostly be done through GitHub Actions itself.

Please note that the actual build is still failing but that's because we're so far behind with the setup here that the Gradle version no longer works on a modern JVM. I'll fix that in subsequent diffs.

Test Plan:
CI