### PR TITLE
[CI] Disable snapshot publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,4 @@ jobs:
           buck --version
       - name: Build
         # TODO: Run the tests here again. They're currently crashing the JVM in GitHub Actions for some reason.
-        run: ./gradlew :yoga-layout:assembleDebug && scripts/publish-snapshot.sh
+        run: ./gradlew :yoga-layout:assembleDebug


### PR DESCRIPTION
Currently broken. Will reenable this separately.