### PR TITLE
Fix condition that is always false due to a typo

### DIFF
--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -2952,10 +2952,10 @@ static void YGNodelayoutImpl(
         availableInnerMainDim = maxInnerMainDim;
       } else {
         if (!node->getConfig()->useLegacyStretchBehaviour &&
-            ((YGFloatIsUndefined(
+            ((!YGFloatIsUndefined(
                   collectedFlexItemsValues.totalFlexGrowFactors) &&
               collectedFlexItemsValues.totalFlexGrowFactors == 0) ||
-             (YGFloatIsUndefined(node->resolveFlexGrow()) &&
+             (!YGFloatIsUndefined(node->resolveFlexGrow()) &&
               node->resolveFlexGrow() == 0))) {
           // If we don't have any children to flex or we can't flex the node
           // itself, space we've used is all space we need. Root node also


### PR DESCRIPTION
If a float is undefined, its comparison with zero does not produce meaningful result.
The intended behavior is to check for zero only if the value is NOT undefined, because the comment states the scenario of "no children" which matches with the value being equal to zero, and that contradicts "&& IsUndefined" part of the condition.