### PR TITLE
Add memory allocation API with templated C++ delegates & minor fixups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_compile_options(
     -fvisibility=hidden
     -ffunction-sections
     -fdata-sections
+    -fPIC
     -Wall
     -std=c++11)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 cmake_minimum_required(VERSION 3.4.1)
 
+project(yoga)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
@@ -16,9 +17,9 @@ add_compile_options(
     -Wall
     -std=c++11)
 
-file(GLOB_RECURSE yogacore_SRC yoga/*.cpp)
-add_library(yogacore STATIC ${yogacore_SRC})
+file(GLOB_RECURSE YOGA_SRC yoga/*.cpp)
+add_library(${CMAKE_PROJECT_NAME} STATIC ${YOGA_SRC})
 
-target_include_directories(yogacore PUBLIC .)
-target_link_libraries(yogacore android log)
-set_target_properties(yogacore PROPERTIES CXX_STANDARD 11)
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC .)
+target_link_libraries(${CMAKE_PROJECT_NAME} android log)
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES CXX_STANDARD 11)

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -11,7 +11,6 @@
 #include <string.h>
 #include <algorithm>
 #include <atomic>
-#include <malloc.h>
 #include "Utils.h"
 #include "YGNode.h"
 #include "YGNodePrint.h"

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -373,7 +373,6 @@ YG_EXTERN_C_END
 
 #include <functional>
 #include <vector>
-#include <type_traits>
 
 // Templated delegates for YGMemoryAllocate & YGMemoryFree, so we don't have to
 // cast nor pass in the size of the allocated chunk of memory explicitly.

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -29,7 +29,7 @@ typedef struct YGSize {
   float height;
 } YGSize;
 
-typedef void* (*YGAllocatorAllocateFunc)(size_t size);
+typedef void* (*YGAllocatorAllocateFunc)(size_t alignment, size_t size);
 typedef void (*YGAllocatorFreeFunc)(void* memory);
 
 typedef struct YGConfig* YGConfigRef;
@@ -60,7 +60,7 @@ typedef YGNodeRef (
 WIN_EXPORT void YGSetAllocationCallbacks(YGAllocatorAllocateFunc allocFunc, YGAllocatorFreeFunc freeFunc);
 WIN_EXPORT void YGGetAllocationCallbacks(YGAllocatorAllocateFunc* allocFunc, YGAllocatorFreeFunc* freeFunc);
 
-WIN_EXPORT void* YGMemoryAllocate(size_t size);
+WIN_EXPORT void* YGMemoryAllocate(size_t alignment, size_t size);
 WIN_EXPORT void YGMemoryFree(void* memory);
 
 // YGNode
@@ -378,7 +378,7 @@ YG_EXTERN_C_END
 // cast nor pass in the size of the allocated chunk of memory explicitly.
 template<typename T, typename... A>
 T* YGAllocate(A&&... arguments) {
-  auto* memory = reinterpret_cast<T*>(YGMemoryAllocate(sizeof(T)));
+  auto* memory = reinterpret_cast<T*>(YGMemoryAllocate(sizeof(T), alignof(T)));
   new(memory) T(std::forward<A>(arguments)...);
   return memory;
 }


### PR DESCRIPTION
This simple pull request adds a memory allocation API to the Yoga C API,
as well as the respective templated C++ delegate functions to allow for the use
of custom memory allocator alongside Yoga.