### PR TITLE
Add cmake install configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,52 @@ add_compile_options(
 file(GLOB_RECURSE yogacore_SRC yoga/*.cpp)
 add_library(yogacore STATIC ${yogacore_SRC})
 
-target_include_directories(yogacore PUBLIC .)
-target_link_libraries(yogacore android log)
+target_include_directories(yogacore
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/yoga>)
+
+if (ANDROID)
+    target_link_libraries(yogacore android log)
+endif()
+
 set_target_properties(yogacore PROPERTIES CXX_STANDARD 11)
+
+# cmake install config
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+# declare target to install
+install(TARGETS yogacore EXPORT yoga-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# install header files
+install(DIRECTORY
+    "${CMAKE_CURRENT_LIST_DIR}/yoga"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
+
+# install target config
+install(EXPORT yoga-targets
+    FILE yogaTargets.cmake
+    NAMESPACE yoga::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/yoga
+)
+
+
+# generate config file
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/scripts/yoga-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/yogaConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/yoga
+)
+
+# install config file
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/yogaConfig.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/yoga
+)

--- a/scripts/yoga-config.cmake.in
+++ b/scripts/yoga-config.cmake.in
@@ -1,0 +1,10 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/yogaTargets.cmake")
+
+check_required_components(yoga)


### PR DESCRIPTION
Summary: Add some cmake configurations to support cmake install command.

So other cmake based project can depends on yoga by using cmake `find_package` function as follow:

```
find_package(yoga CONFIG REQUIRED)
target_link_libraries(main PRIVATE yoga::yogacore)
```

Resolves #1057 