### PR TITLE
Add missing reference to CXX to yoga_defs.bzl

### DIFF
--- a/tools/build_defs/oss/yoga_defs.bzl
+++ b/tools/build_defs/oss/yoga_defs.bzl
@@ -44,6 +44,8 @@ ANDROID_SAMPLE_JAVA_TARGET = "//android/sample/java/com/facebook/samples/yoga:yo
 
 ANDROID_SAMPLE_RES_TARGET = "//android/sample:res"
 
+CXX = ""
+
 CXX_LIBRARY_WHITELIST = [
     "//:yoga",
     "//lib/fb:fbjni",


### PR DESCRIPTION
Fix for #1131 

This issue seems to have been introduced in https://github.com/facebook/yoga/commit/477fedd1b64ad4ac45ef12ef1ea82966fdb7ceeb

I don't know if this is a complete fix, as I'm still not having any luck getting the tests to run on Windows ("File not found: cl
"), but I thought I may as well get the conversation started.