### PR TITLE
【YogaKit】Fix two crashes. YogaKitSample upgrade to swift 5

### DIFF
--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -489,10 +489,8 @@ static void YGApplyLayoutToViewHierarchy(UIView* view, BOOL preserveOrigin) {
           },
       .size =
           {
-              .width = YGRoundPixelValue(bottomRight.x) -
-                  YGRoundPixelValue(topLeft.x),
-              .height = YGRoundPixelValue(bottomRight.y) -
-                  YGRoundPixelValue(topLeft.y),
+              .width = MAX(0, YGRoundPixelValue(bottomRight.x) - YGRoundPixelValue(topLeft.x)),
+              .height = MAX(0, YGRoundPixelValue(bottomRight.y) - YGRoundPixelValue(topLeft.y)),
           },
   };
 

--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -430,7 +430,13 @@ static void YGAttachNodesFromViewHierachy(UIView* const view) {
     if (!YGNodeHasExactSameChildren(node, subviewsToInclude)) {
       YGRemoveAllChildren(node);
       for (int i = 0; i < subviewsToInclude.count; i++) {
-        YGNodeInsertChild(node, subviewsToInclude[i].yoga.node, i);
+          // should remove from owner if node has one owner
+          const YGNodeRef child = subviewsToInclude[i].yoga.node;
+          YGNodeRef owner = YGNodeGetOwner(child);
+          if (owner) {
+              YGNodeRemoveChild(owner, child);
+          }
+        YGNodeInsertChild(node, child, i);
       }
     }
 

--- a/YogaKit/YogaKitSample/Podfile.lock
+++ b/YogaKit/YogaKitSample/Podfile.lock
@@ -4,23 +4,28 @@ PODS:
   - IGListKit/Default (2.1.0):
     - IGListKit/Diffing
   - IGListKit/Diffing (2.1.0)
-  - Yoga (1.7.0)
-  - YogaKit (1.7.0):
-    - Yoga (~> 1.7)
+  - Yoga (1.14.0)
+  - YogaKit (1.18.1):
+    - Yoga (~> 1.14)
 
 DEPENDENCIES:
   - IGListKit (~> 2.1.0)
   - YogaKit (from `../../YogaKit.podspec`)
 
+SPEC REPOS:
+  trunk:
+    - IGListKit
+    - Yoga
+
 EXTERNAL SOURCES:
   YogaKit:
-    :path: ../../YogaKit.podspec
+    :path: "../../YogaKit.podspec"
 
 SPEC CHECKSUMS:
   IGListKit: b826c68ef7a4ae1626c09d4d3e1ea7a169e6c36e
-  Yoga: 2ed1d7accfef3610a67f58c0cf101a0662137f2c
-  YogaKit: 31576530e8fcae3175469719ec3212397403330b
+  Yoga: cff67a400f6b74dc38eb0bad4f156673d9aa980c
+  YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 216f8e7127767709e0e43f3711208d238fa5c404
 
-COCOAPODS: 1.1.1
+COCOAPODS: 1.11.2

--- a/YogaKit/YogaKitSample/YogaKitSample.xcodeproj/project.pbxproj
+++ b/YogaKit/YogaKitSample/YogaKitSample.xcodeproj/project.pbxproj
@@ -178,7 +178,6 @@
 				13687D401DF8748300E7C260 /* Frameworks */,
 				13687D411DF8748300E7C260 /* Resources */,
 				FA2FB9DD6471BDD3FBCE503B /* [CP] Embed Pods Frameworks */,
-				6E01EB987F1564F3D71EBE5A /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -233,6 +232,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -272,28 +272,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-YogaKitSample-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		6E01EB987F1564F3D71EBE5A /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-YogaKitSample/Pods-YogaKitSample-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FA2FB9DD6471BDD3FBCE503B /* [CP] Embed Pods Frameworks */ = {
@@ -302,13 +290,20 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-YogaKitSample/Pods-YogaKitSample-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/IGListKit/IGListKit.framework",
+				"${BUILT_PRODUCTS_DIR}/Yoga/yoga.framework",
+				"${BUILT_PRODUCTS_DIR}/YogaKit/YogaKit.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IGListKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/yoga.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YogaKit.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-YogaKitSample/Pods-YogaKitSample-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-YogaKitSample/Pods-YogaKitSample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -446,7 +441,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -461,7 +456,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.YogaKitSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
1. if A view addSubviews(B), B view addSubviews(C),  sometimes we need A view addSubviews(C),   yoga  asset because of C had a owner,  when node insert a child node, i think we need to remove child node from owner first.
2. yoga maybe calculate a Nan value, but UIKit size can't accept a Nan Value, it will be cause unexpect crashes
3. YogaKitSample upgrade to swift 5 