### PR TITLE
fix: path to react native docs

### DIFF
--- a/website/contents/getting-started/react-native.md
+++ b/website/contents/getting-started/react-native.md
@@ -1,5 +1,5 @@
 ---
-path: "http://facebook.github.io/react-native/docs/getting-started.html"
+path: "http://facebook.github.io/react-native/docs/getting-started"
 title: "React Native"
 redirect: true
 ---


### PR DESCRIPTION
Fix link to React Native getting started documentation page