### PR TITLE
Make all headers public and add #ifdef __cplusplus

### DIFF
--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -33,6 +33,6 @@ Pod::Spec.new do |spec|
       '-fPIC'
   ]
   spec.source_files = 'yoga/**/*.{c,h,cpp}'
-  spec.public_header_files = 'yoga/{Yoga,YGEnums,YGMacros,YGNode,YGStyle,YGValue}.h'
+  spec.public_header_files = 'yoga/*.h'
 
 end

--- a/yoga/BitUtils.h
+++ b/yoga/BitUtils.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <cstdio>
 #include <cstdint>
 #include "YGEnums.h"
@@ -65,3 +67,5 @@ inline void setBooleanData(uint8_t& flags, size_t index, bool value) {
 } // namespace detail
 } // namespace yoga
 } // namespace facebook
+
+#endif

--- a/yoga/CompactValue.h
+++ b/yoga/CompactValue.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include "YGValue.h"
 #include "YGMacros.h"
 #include <cmath>
@@ -182,3 +184,5 @@ constexpr bool operator!=(CompactValue a, CompactValue b) noexcept {
 } // namespace detail
 } // namespace yoga
 } // namespace facebook
+
+#endif

--- a/yoga/Utils.h
+++ b/yoga/Utils.h
@@ -6,6 +6,9 @@
  */
 
 #pragma once
+
+#ifdef __cplusplus
+
 #include "YGNode.h"
 #include "Yoga-internal.h"
 #include "CompactValue.h"
@@ -145,3 +148,5 @@ inline YGFloatOptional YGResolveValueMargin(
 }
 
 void throwLogicalErrorWithMessage(const char* message);
+
+#endif

--- a/yoga/YGConfig.h
+++ b/yoga/YGConfig.h
@@ -6,6 +6,9 @@
  */
 
 #pragma once
+
+#ifdef __cplusplus
+
 #include "Yoga-internal.h"
 #include "Yoga.h"
 
@@ -74,3 +77,5 @@ public:
     setCloneNodeCallback(YGCloneNodeFunc{nullptr});
   }
 };
+
+#endif

--- a/yoga/YGFloatOptional.h
+++ b/yoga/YGFloatOptional.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <cmath>
 #include <limits>
 #include "Yoga-internal.h"
@@ -68,3 +70,5 @@ inline bool operator>=(YGFloatOptional lhs, YGFloatOptional rhs) {
 inline bool operator<=(YGFloatOptional lhs, YGFloatOptional rhs) {
   return lhs < rhs || lhs == rhs;
 }
+
+#endif

--- a/yoga/YGLayout.h
+++ b/yoga/YGLayout.h
@@ -6,6 +6,9 @@
  */
 
 #pragma once
+
+#ifdef __cplusplus
+
 #include "BitUtils.h"
 #include "YGFloatOptional.h"
 #include "Yoga-internal.h"
@@ -85,3 +88,5 @@ public:
   bool operator==(YGLayout layout) const;
   bool operator!=(YGLayout layout) const { return !(*this == layout); }
 };
+
+#endif

--- a/yoga/YGNodePrint.h
+++ b/yoga/YGNodePrint.h
@@ -6,7 +6,11 @@
  */
 
 #ifdef DEBUG
+
 #pragma once
+
+#ifdef __cplusplus
+
 #include <string>
 
 #include "Yoga.h"
@@ -22,4 +26,7 @@ void YGNodeToString(
 
 } // namespace yoga
 } // namespace facebook
+
+#endif
+
 #endif

--- a/yoga/Yoga-internal.h
+++ b/yoga/Yoga-internal.h
@@ -6,6 +6,9 @@
  */
 
 #pragma once
+
+#ifdef __cplusplus
+
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -148,3 +151,5 @@ static const float kDefaultFlexShrink = 0.0f;
 static const float kWebDefaultFlexShrink = 1.0f;
 
 extern bool YGFloatsEqual(const float a, const float b);
+
+#endif

--- a/yoga/log.h
+++ b/yoga/log.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include "YGEnums.h"
 
 struct YGNode;
@@ -36,3 +38,5 @@ struct Log {
 } // namespace detail
 } // namespace yoga
 } // namespace facebook
+
+#endif


### PR DESCRIPTION
This change is mostly needed to support the new react-native architecture with Swift. Some private yoga headers end up being included in the swift build and result in compilation failure since swift cannot compile c++ modules. See https://github.com/facebook/react-native/pull/33381.

The most reliable fix is to include all headers as public headers, and add `#ifdef __cplusplus` to those that include c++. This is already what we do for other headers, this applies this to all headers.

Tested in the YogaKitSample, and also in a react-native app.