### PR TITLE
Rewrite CompactValue to avoid undefined behavior from the use of a union for type-punning 

### DIFF
--- a/yoga/CompactValue.h
+++ b/yoga/CompactValue.h
@@ -11,6 +11,8 @@
 
 #ifdef __cpp_lib_bit_cast
 #include <bit>
+#else
+#include <cstring>
 #endif
 #include "YGValue.h"
 #include "YGMacros.h"
@@ -169,7 +171,7 @@ private:
 
   static float asFloat(uint32_t u) {
 #ifdef __cpp_lib_bit_cast
-    return std::bit_cast<float>(data);
+    return std::bit_cast<float>(u);
 #else
     float f;
     static_assert(sizeof(f) == sizeof(u), "uint32_t and float must have the same size");


### PR DESCRIPTION
C++ does not, pedantically, allow the use of unions for type-punning in the way that C does. Most compilers, in practice, do support it; however, recent versions of MSVC appear to have a bug that cause bad code to be generated due to this U.B. (see: https://developercommunity.visualstudio.com/t/Bad-code-generated-for-std::isnan-compil/10082631). This led to a series of issues in the react-native-windows project, see:
* https://github.com/microsoft/react-native-windows/issues/4122
* https://github.com/microsoft/react-native-windows/issues/8675

In C++20, the `<bit>` header and `bit_cast` function provide a pleasant API for type-punning. Since C++20 is not universally available, if the feature-test macro for `bit_cast` is not defined, memcpy is used instead.