### PR TITLE
Update From Node 8 to Node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 8.x
+          node-version: 10.x
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
         working-directory: website


### PR DESCRIPTION
After updating the lockfile, a package is requiring Node >= 10 for installation. This causes the website validation to fail, since GitHub Actions are currently pinned to Node 8. Try bumping to the next LTS, Node 10.

This is still quite old, but is the most recent LTS that yoga is currently installable on.