### PR TITLE
Move GitHub Actions from Node 8 to Node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 8.x
+          node-version: 12.x
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
         working-directory: website

--- a/website/package.json
+++ b/website/package.json
@@ -33,5 +33,8 @@
   },
   "devDependencies": {
     "prettier": "1.19.1"
+  },
+  "resolutions": {
+    "nbind": "https://github.com/charto/nbind.git#fe3abe0"
   }
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6944,10 +6944,9 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-nbind@^0.3.14:
+nbind@^0.3.14, "nbind@https://github.com/charto/nbind.git#fe3abe0":
   version "0.3.15"
-  resolved "https://registry.yarnpkg.com/nbind/-/nbind-0.3.15.tgz#20c74d77d54e28627ab8268c2767f7e40aef8c53"
-  integrity sha512-TrKLNRj5D8wZRJb7XmUNbA1W3iTigAEpm3qaGig5bEWY/iCT2IQBgBc2EUGO59FbRIGhx5hB/McVwqxlSGScVw==
+  resolved "https://github.com/charto/nbind.git#fe3abe05462d1b7559e0933e7f83802e8f05af27"
   dependencies:
     emscripten-library-decorator "~0.2.2"
     mkdirp "~0.5.1"


### PR DESCRIPTION
Summary:
Yoga CI is currently running using Node 8, released in 2017. It has long been out of support, and is not able to install many of the packages in the updated lockfile due to version resrtrictions in the new packages.

Node 12 is able to install the current lockfile. Although it is old enough that security support has ended for it 5 months ago, `yoga-layout` currently fails to install on Node 12+, because a dependency, `nbind`, was reliant on V8 internals that have changed between versions, and has not published a version supporting anything later than Node 10.

There are unpublished commits in the official repo which add Node 12 support. So, we use that version when developing against the website, to jump us to something more up to date, without rewriting or removing all of the JS bindings quite yet.

Differential Revision: D40036466

