### PR TITLE
Add explicit defaulted copy ctor to `Values`

### DIFF
--- a/yoga/Yoga-internal.h
+++ b/yoga/Yoga-internal.h
@@ -110,6 +110,8 @@ private:
 
 public:
   Values() = default;
+  Values(const Values& other) = default;
+
   explicit Values(const YGValue& defaultValue) noexcept {
     values_.fill(defaultValue);
   }


### PR DESCRIPTION
Summary:
`Values` is a wrapper to story an array of YGValue's as CompactValues.

From https://github.com/facebook/yoga/issues/1174 we see a warning `Wdeprecated-copy` beacuse a user-defined copy constructor is not present, but a user-defined asignment operator is (the defaulted one). This adds an explicitly defaulted copy contructor which should silence the warning I think.

Changelog:
[Internal]

Differential Revision: D41447490

