### PR TITLE
Pin website workflows to ubuntu-20.04

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish:
     name: Publish to GitHub Pages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/validate-website.yml
+++ b/.github/workflows/validate-website.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The website build started failing with what looks like an incompatibility between nbind and a new libc++ version. GithHub is rolling out a new Ubuntu image, which is the likely culprit.

Pin to an older version of Ubuntu since nbind will never be updated, and we haven't replaced it yet.