### PR TITLE
Refine workflow push trigger

### DIFF
--- a/.github/workflows/validate-android.yml
+++ b/.github/workflows/validate-android.yml
@@ -1,6 +1,11 @@
 name: Android
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/validate-apple.yml
+++ b/.github/workflows/validate-apple.yml
@@ -1,6 +1,11 @@
 name: Apple
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   lint-pods:

--- a/.github/workflows/validate-cpp.yml
+++ b/.github/workflows/validate-cpp.yml
@@ -1,6 +1,11 @@
 name: C++
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   clang-format:

--- a/.github/workflows/validate-website.yml
+++ b/.github/workflows/validate-website.yml
@@ -1,6 +1,11 @@
 name: Website
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
We run validation workflows on push, but we do this for every branch, so dependabot PRs run every validation twice. We only really want push validation for the main branch.