### PR TITLE
Fix `yg_positionType` ordinals

### DIFF
--- a/.github/workflows/validate-android.yml
+++ b/.github/workflows/validate-android.yml
@@ -17,4 +17,4 @@ jobs:
         uses: ./.github/actions/setup-android
 
       - name: Build
-        run: ./gradlew assemble${{ matrix.mode }}
+        run: ./gradlew assemble${{ matrix.mode }} --stacktrace

--- a/android/src/main/res/values/attrs.xml
+++ b/android/src/main/res/values/attrs.xml
@@ -130,9 +130,14 @@
     <attr name="yg_positionAll" format="dimension|string"/>
 
     <attr name="yg_positionType" format="enum">
+      <!-- "static" is a reserved keyword
       <enum name="static" value="0"/>
+      -->
       <enum name="relative" value="1"/>
       <enum name="absolute" value="2"/>
+      <enum name="position_static" value="0"/>
+      <enum name="position_relative" value="1"/>
+      <enum name="position_absolute" value="2"/>
     </attr>
 
     <attr name="yg_width" format="dimension|string"/>

--- a/android/src/main/res/values/attrs.xml
+++ b/android/src/main/res/values/attrs.xml
@@ -2,7 +2,7 @@
 
 <!--
   Copyright (c) Facebook, Inc. and its affiliates.
-  
+
   This source code is licensed under the MIT license found in the
   LICENSE file in the root directory of this source tree.
 -->
@@ -130,8 +130,9 @@
     <attr name="yg_positionAll" format="dimension|string"/>
 
     <attr name="yg_positionType" format="enum">
-      <enum name="relative" value="0"/>
-      <enum name="absolute" value="1"/>
+      <enum name="static" value="0"/>
+      <enum name="relative" value="1"/>
+      <enum name="absolute" value="2"/>
     </attr>
 
     <attr name="yg_width" format="dimension|string"/>


### PR DESCRIPTION
Fixes #1179

https://github.com/facebook/yoga/commit/fc88b2f774f0ab9090d7ca15de6680f26d7285ad shifted ordinals for the position enum, but only updated a limited set of code for the new values. Binding generation has since been fixed, but #1179 seems to be another case where the ordinal offsetting means that `yg_positionType` of a `YogaLayout` view does not work correctly.

Update the ordinals in accordance with the ordering in YogaPositionType which the integer value is converted to.

Using "static" (the new position type) directly gives a compilation error due to it being a reserved keyword, so I added it as "position_static" along with aliases to other properties with the same naming scheme for consistency.