### PR TITLE
fix: remove gap if its last element in line

### DIFF
--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -2543,7 +2543,7 @@ static void YGJustifyMainAxis(
     const bool isLastChild = i == collectedFlexItemsValues.endOfLineIndex - 1;
     // remove the gap if it is the last element of the line
     if (isLastChild) {
-        betweenMainDim -= gap;
+      betweenMainDim -= gap;
     }
     if (childStyle.display() == YGDisplayNone) {
       continue;

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -2542,7 +2542,9 @@ static void YGJustifyMainAxis(
     const YGLayout childLayout = child->getLayout();
     const bool isLastChild = i == collectedFlexItemsValues.endOfLineIndex - 1;
     // remove the gap if it is the last element of the line
-    betweenMainDim -= isLastChild ? gap : 0;
+    if (isLastChild) {
+        betweenMainDim -= gap;
+    }
     if (childStyle.display() == YGDisplayNone) {
       continue;
     }

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -2540,6 +2540,9 @@ static void YGJustifyMainAxis(
     const YGNodeRef child = node->getChild(i);
     const YGStyle& childStyle = child->getStyle();
     const YGLayout childLayout = child->getLayout();
+    const bool isLastChild = i == collectedFlexItemsValues.endOfLineIndex - 1;
+    // remove the gap if it is the last element of the line
+    betweenMainDim -= isLastChild ? gap : 0;
     if (childStyle.display() == YGDisplayNone) {
       continue;
     }


### PR DESCRIPTION
Fixes - https://github.com/facebook/react-native/issues/35553

## Approach
We're using `betweenMainDim` to add [gap between](https://github.com/intergalacticspacehighway/yoga/blob/bbeede82d36cd89657faf385aaa704f45443c326/yoga/Yoga.cpp#L2495) items in main axis. This is resulting in increased [main axis](https://github.com/intergalacticspacehighway/yoga/blob/bbeede82d36cd89657faf385aaa704f45443c326/yoga/Yoga.cpp#L2598) dimension of the container as it gets added even for the last element. One solution is to keep using it and subtract the gap when last element is reached. 

## Aside
Mutating this value feels weird, but I think `betweenMainDim` gets initialized for every line so should be fine? I did some manual tests to verify. I tried running tests but I'll have to downgrade the java version. Let me know if anything fails. Thanks! 🙏 
