### PR TITLE
Add newer fixtures

### DIFF
--- a/csharp/tests/Facebook.Yoga/YGAbsolutePositionTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGAbsolutePositionTest.cs
@@ -26,7 +26,6 @@ namespace Facebook.Yoga
 
             YogaNode root_child0 = new YogaNode(config);
             root_child0.PositionType = YogaPositionType.Absolute;
-            root_child0.Start = 10;
             root_child0.Top = 10;
             root_child0.Width = 10;
             root_child0.Height = 10;
@@ -39,7 +38,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(10f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(10f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(10f, root_child0.LayoutHeight);
@@ -52,7 +51,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(80f, root_child0.LayoutX);
+            Assert.AreEqual(90f, root_child0.LayoutX);
             Assert.AreEqual(10f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(10f, root_child0.LayoutHeight);
@@ -69,7 +68,6 @@ namespace Facebook.Yoga
 
             YogaNode root_child0 = new YogaNode(config);
             root_child0.PositionType = YogaPositionType.Absolute;
-            root_child0.End = 10;
             root_child0.Bottom = 10;
             root_child0.Width = 10;
             root_child0.Height = 10;
@@ -82,7 +80,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(80f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(80f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(10f, root_child0.LayoutHeight);
@@ -95,7 +93,50 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(10f, root_child0.LayoutX);
+            Assert.AreEqual(90f, root_child0.LayoutX);
+            Assert.AreEqual(80f, root_child0.LayoutY);
+            Assert.AreEqual(10f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_absolute_layout_row_width_height_end_bottom()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.Width = 100;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.Bottom = 10;
+            root_child0.Width = 10;
+            root_child0.Height = 10;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(80f, root_child0.LayoutY);
+            Assert.AreEqual(10f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(90f, root_child0.LayoutX);
             Assert.AreEqual(80f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(10f, root_child0.LayoutHeight);
@@ -112,9 +153,7 @@ namespace Facebook.Yoga
 
             YogaNode root_child0 = new YogaNode(config);
             root_child0.PositionType = YogaPositionType.Absolute;
-            root_child0.Start = 10;
             root_child0.Top = 10;
-            root_child0.End = 10;
             root_child0.Bottom = 10;
             root.Insert(0, root_child0);
             root.StyleDirection = YogaDirection.LTR;
@@ -125,9 +164,9 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(10f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(10f, root_child0.LayoutY);
-            Assert.AreEqual(80f, root_child0.LayoutWidth);
+            Assert.AreEqual(0f, root_child0.LayoutWidth);
             Assert.AreEqual(80f, root_child0.LayoutHeight);
 
             root.StyleDirection = YogaDirection.RTL;
@@ -138,9 +177,9 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(10f, root_child0.LayoutX);
+            Assert.AreEqual(100f, root_child0.LayoutX);
             Assert.AreEqual(10f, root_child0.LayoutY);
-            Assert.AreEqual(80f, root_child0.LayoutWidth);
+            Assert.AreEqual(0f, root_child0.LayoutWidth);
             Assert.AreEqual(80f, root_child0.LayoutHeight);
         }
 
@@ -155,9 +194,7 @@ namespace Facebook.Yoga
 
             YogaNode root_child0 = new YogaNode(config);
             root_child0.PositionType = YogaPositionType.Absolute;
-            root_child0.Start = 10;
             root_child0.Top = 10;
-            root_child0.End = 10;
             root_child0.Bottom = 10;
             root_child0.Width = 10;
             root_child0.Height = 10;
@@ -170,7 +207,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(10f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(10f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(10f, root_child0.LayoutHeight);
@@ -183,7 +220,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(80f, root_child0.LayoutX);
+            Assert.AreEqual(90f, root_child0.LayoutX);
             Assert.AreEqual(10f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(10f, root_child0.LayoutHeight);
@@ -202,7 +239,6 @@ namespace Facebook.Yoga
 
             YogaNode root_child0 = new YogaNode(config);
             root_child0.PositionType = YogaPositionType.Absolute;
-            root_child0.Start = 0;
             root_child0.Top = 0;
             root.Insert(0, root_child0);
 
@@ -1033,6 +1069,229 @@ namespace Facebook.Yoga
             Assert.AreEqual(0f, root_child0.LayoutY);
             Assert.AreEqual(20f, root_child0.LayoutWidth);
             Assert.AreEqual(20f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_absolute_layout_percentage_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.Width = 200;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.Top = 10;
+            root_child0.Width = 10;
+            root_child0.Height = 50.Percent();
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(200f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(10f, root_child0.LayoutY);
+            Assert.AreEqual(10f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(200f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(190f, root_child0.LayoutX);
+            Assert.AreEqual(10f, root_child0.LayoutY);
+            Assert.AreEqual(10f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_absolute_child_with_cross_margin()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.JustifyContent = YogaJustify.SpaceBetween;
+            root.MinWidth = 311;
+            root.MaxWidth = 311;
+            root.MaxHeight = 3.68935e+19;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.FlexDirection = YogaFlexDirection.Row;
+            root_child0.AlignContent = YogaAlign.Stretch;
+            root_child0.Width = 28;
+            root_child0.Height = 27;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.FlexDirection = YogaFlexDirection.Row;
+            root_child1.AlignContent = YogaAlign.Stretch;
+            root_child1.PositionType = YogaPositionType.Absolute;
+            root_child1.FlexShrink = 1;
+            root_child1.MarginTop = 4;
+            root_child1.Width = 100.Percent();
+            root_child1.Height = 15;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode(config);
+            root_child2.FlexDirection = YogaFlexDirection.Row;
+            root_child2.AlignContent = YogaAlign.Stretch;
+            root_child2.Width = 25;
+            root_child2.Height = 27;
+            root.Insert(2, root_child2);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(311f, root.LayoutWidth);
+            Assert.AreEqual(27f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(28f, root_child0.LayoutWidth);
+            Assert.AreEqual(27f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(4f, root_child1.LayoutY);
+            Assert.AreEqual(311f, root_child1.LayoutWidth);
+            Assert.AreEqual(15f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(286f, root_child2.LayoutX);
+            Assert.AreEqual(0f, root_child2.LayoutY);
+            Assert.AreEqual(25f, root_child2.LayoutWidth);
+            Assert.AreEqual(27f, root_child2.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(311f, root.LayoutWidth);
+            Assert.AreEqual(27f, root.LayoutHeight);
+
+            Assert.AreEqual(283f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(28f, root_child0.LayoutWidth);
+            Assert.AreEqual(27f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(4f, root_child1.LayoutY);
+            Assert.AreEqual(311f, root_child1.LayoutWidth);
+            Assert.AreEqual(15f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child2.LayoutX);
+            Assert.AreEqual(0f, root_child2.LayoutY);
+            Assert.AreEqual(25f, root_child2.LayoutWidth);
+            Assert.AreEqual(27f, root_child2.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_absolute_child_with_main_margin()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.Width = 20;
+            root.Height = 37;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.MarginLeft = 7;
+            root_child0.Width = 9;
+            root_child0.Height = 9;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(20f, root.LayoutWidth);
+            Assert.AreEqual(37f, root.LayoutHeight);
+
+            Assert.AreEqual(7f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(9f, root_child0.LayoutWidth);
+            Assert.AreEqual(9f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(20f, root.LayoutWidth);
+            Assert.AreEqual(37f, root.LayoutHeight);
+
+            Assert.AreEqual(11f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(9f, root_child0.LayoutWidth);
+            Assert.AreEqual(9f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_absolute_child_with_max_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.Width = 100;
+            root.Height = 200;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.Bottom = 20;
+            root_child0.MaxHeight = 100;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child0_child0 = new YogaNode(config);
+            root_child0_child0.Width = 100;
+            root_child0_child0.Height = 30;
+            root_child0.Insert(0, root_child0_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(200f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(150f, root_child0.LayoutY);
+            Assert.AreEqual(100f, root_child0.LayoutWidth);
+            Assert.AreEqual(30f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(100f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(30f, root_child0_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(200f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(150f, root_child0.LayoutY);
+            Assert.AreEqual(100f, root_child0.LayoutWidth);
+            Assert.AreEqual(30f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(100f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(30f, root_child0_child0.LayoutHeight);
         }
 
     }

--- a/csharp/tests/Facebook.Yoga/YGAlignContentTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGAlignContentTest.cs
@@ -1882,5 +1882,88 @@ namespace Facebook.Yoga
             Assert.AreEqual(10f, root_child0_child0.LayoutHeight);
         }
 
+        [Test]
+        public void Test_align_content_not_stretch_with_align_items_stretch()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.Wrap = YogaWrap.Wrap;
+            root.Width = 328;
+            root.Height = 52;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root.Insert(0, root_child0);
+
+            YogaNode root_child0_child0 = new YogaNode(config);
+            root_child0_child0.Width = 272;
+            root_child0_child0.Height = 44;
+            root_child0.Insert(0, root_child0_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root.Insert(1, root_child1);
+
+            YogaNode root_child1_child0 = new YogaNode(config);
+            root_child1_child0.Width = 56;
+            root_child1_child0.Height = 44;
+            root_child1.Insert(0, root_child1_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(328f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(272f, root_child0.LayoutWidth);
+            Assert.AreEqual(44f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(272f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(44f, root_child0_child0.LayoutHeight);
+
+            Assert.AreEqual(272f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(56f, root_child1.LayoutWidth);
+            Assert.AreEqual(44f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(56f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(44f, root_child1_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(328f, root.LayoutWidth);
+            Assert.AreEqual(52f, root.LayoutHeight);
+
+            Assert.AreEqual(56f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(272f, root_child0.LayoutWidth);
+            Assert.AreEqual(44f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(272f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(44f, root_child0_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(56f, root_child1.LayoutWidth);
+            Assert.AreEqual(44f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(56f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(44f, root_child1_child0.LayoutHeight);
+        }
+
     }
 }

--- a/csharp/tests/Facebook.Yoga/YGAlignItemsTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGAlignItemsTest.cs
@@ -55,6 +55,45 @@ namespace Facebook.Yoga
         }
 
         [Test]
+        public void Test_align_items_stretch_min_cross()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.MinWidth = 400;
+            root.MinHeight = 50;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Height = 36;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(400f, root.LayoutWidth);
+            Assert.AreEqual(50f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(400f, root_child0.LayoutWidth);
+            Assert.AreEqual(36f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(400f, root.LayoutWidth);
+            Assert.AreEqual(50f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(400f, root_child0.LayoutWidth);
+            Assert.AreEqual(36f, root_child0.LayoutHeight);
+        }
+
+        [Test]
         public void Test_align_items_center()
         {
             YogaConfig config = new YogaConfig();
@@ -1234,240 +1273,6 @@ namespace Facebook.Yoga
         }
 
         [Test]
-        public void Test_align_baseline_multiline_column()
-        {
-            YogaConfig config = new YogaConfig();
-
-            YogaNode root = new YogaNode(config);
-            root.AlignItems = YogaAlign.Baseline;
-            root.Wrap = YogaWrap.Wrap;
-            root.Width = 100;
-            root.Height = 100;
-
-            YogaNode root_child0 = new YogaNode(config);
-            root_child0.Width = 50;
-            root_child0.Height = 50;
-            root.Insert(0, root_child0);
-
-            YogaNode root_child1 = new YogaNode(config);
-            root_child1.Width = 30;
-            root_child1.Height = 50;
-            root.Insert(1, root_child1);
-
-            YogaNode root_child1_child0 = new YogaNode(config);
-            root_child1_child0.Width = 20;
-            root_child1_child0.Height = 20;
-            root_child1.Insert(0, root_child1_child0);
-
-            YogaNode root_child2 = new YogaNode(config);
-            root_child2.Width = 40;
-            root_child2.Height = 70;
-            root.Insert(2, root_child2);
-
-            YogaNode root_child2_child0 = new YogaNode(config);
-            root_child2_child0.Width = 10;
-            root_child2_child0.Height = 10;
-            root_child2.Insert(0, root_child2_child0);
-
-            YogaNode root_child3 = new YogaNode(config);
-            root_child3.Width = 50;
-            root_child3.Height = 20;
-            root.Insert(3, root_child3);
-            root.StyleDirection = YogaDirection.LTR;
-            root.CalculateLayout();
-
-            Assert.AreEqual(0f, root.LayoutX);
-            Assert.AreEqual(0f, root.LayoutY);
-            Assert.AreEqual(100f, root.LayoutWidth);
-            Assert.AreEqual(100f, root.LayoutHeight);
-
-            Assert.AreEqual(0f, root_child0.LayoutX);
-            Assert.AreEqual(0f, root_child0.LayoutY);
-            Assert.AreEqual(50f, root_child0.LayoutWidth);
-            Assert.AreEqual(50f, root_child0.LayoutHeight);
-
-            Assert.AreEqual(0f, root_child1.LayoutX);
-            Assert.AreEqual(50f, root_child1.LayoutY);
-            Assert.AreEqual(30f, root_child1.LayoutWidth);
-            Assert.AreEqual(50f, root_child1.LayoutHeight);
-
-            Assert.AreEqual(0f, root_child1_child0.LayoutX);
-            Assert.AreEqual(0f, root_child1_child0.LayoutY);
-            Assert.AreEqual(20f, root_child1_child0.LayoutWidth);
-            Assert.AreEqual(20f, root_child1_child0.LayoutHeight);
-
-            Assert.AreEqual(50f, root_child2.LayoutX);
-            Assert.AreEqual(0f, root_child2.LayoutY);
-            Assert.AreEqual(40f, root_child2.LayoutWidth);
-            Assert.AreEqual(70f, root_child2.LayoutHeight);
-
-            Assert.AreEqual(0f, root_child2_child0.LayoutX);
-            Assert.AreEqual(0f, root_child2_child0.LayoutY);
-            Assert.AreEqual(10f, root_child2_child0.LayoutWidth);
-            Assert.AreEqual(10f, root_child2_child0.LayoutHeight);
-
-            Assert.AreEqual(50f, root_child3.LayoutX);
-            Assert.AreEqual(70f, root_child3.LayoutY);
-            Assert.AreEqual(50f, root_child3.LayoutWidth);
-            Assert.AreEqual(20f, root_child3.LayoutHeight);
-
-            root.StyleDirection = YogaDirection.RTL;
-            root.CalculateLayout();
-
-            Assert.AreEqual(0f, root.LayoutX);
-            Assert.AreEqual(0f, root.LayoutY);
-            Assert.AreEqual(100f, root.LayoutWidth);
-            Assert.AreEqual(100f, root.LayoutHeight);
-
-            Assert.AreEqual(50f, root_child0.LayoutX);
-            Assert.AreEqual(0f, root_child0.LayoutY);
-            Assert.AreEqual(50f, root_child0.LayoutWidth);
-            Assert.AreEqual(50f, root_child0.LayoutHeight);
-
-            Assert.AreEqual(70f, root_child1.LayoutX);
-            Assert.AreEqual(50f, root_child1.LayoutY);
-            Assert.AreEqual(30f, root_child1.LayoutWidth);
-            Assert.AreEqual(50f, root_child1.LayoutHeight);
-
-            Assert.AreEqual(10f, root_child1_child0.LayoutX);
-            Assert.AreEqual(0f, root_child1_child0.LayoutY);
-            Assert.AreEqual(20f, root_child1_child0.LayoutWidth);
-            Assert.AreEqual(20f, root_child1_child0.LayoutHeight);
-
-            Assert.AreEqual(10f, root_child2.LayoutX);
-            Assert.AreEqual(0f, root_child2.LayoutY);
-            Assert.AreEqual(40f, root_child2.LayoutWidth);
-            Assert.AreEqual(70f, root_child2.LayoutHeight);
-
-            Assert.AreEqual(30f, root_child2_child0.LayoutX);
-            Assert.AreEqual(0f, root_child2_child0.LayoutY);
-            Assert.AreEqual(10f, root_child2_child0.LayoutWidth);
-            Assert.AreEqual(10f, root_child2_child0.LayoutHeight);
-
-            Assert.AreEqual(0f, root_child3.LayoutX);
-            Assert.AreEqual(70f, root_child3.LayoutY);
-            Assert.AreEqual(50f, root_child3.LayoutWidth);
-            Assert.AreEqual(20f, root_child3.LayoutHeight);
-        }
-
-        [Test]
-        public void Test_align_baseline_multiline_column2()
-        {
-            YogaConfig config = new YogaConfig();
-
-            YogaNode root = new YogaNode(config);
-            root.AlignItems = YogaAlign.Baseline;
-            root.Wrap = YogaWrap.Wrap;
-            root.Width = 100;
-            root.Height = 100;
-
-            YogaNode root_child0 = new YogaNode(config);
-            root_child0.Width = 50;
-            root_child0.Height = 50;
-            root.Insert(0, root_child0);
-
-            YogaNode root_child1 = new YogaNode(config);
-            root_child1.Width = 30;
-            root_child1.Height = 50;
-            root.Insert(1, root_child1);
-
-            YogaNode root_child1_child0 = new YogaNode(config);
-            root_child1_child0.Width = 20;
-            root_child1_child0.Height = 20;
-            root_child1.Insert(0, root_child1_child0);
-
-            YogaNode root_child2 = new YogaNode(config);
-            root_child2.Width = 40;
-            root_child2.Height = 70;
-            root.Insert(2, root_child2);
-
-            YogaNode root_child2_child0 = new YogaNode(config);
-            root_child2_child0.Width = 10;
-            root_child2_child0.Height = 10;
-            root_child2.Insert(0, root_child2_child0);
-
-            YogaNode root_child3 = new YogaNode(config);
-            root_child3.Width = 50;
-            root_child3.Height = 20;
-            root.Insert(3, root_child3);
-            root.StyleDirection = YogaDirection.LTR;
-            root.CalculateLayout();
-
-            Assert.AreEqual(0f, root.LayoutX);
-            Assert.AreEqual(0f, root.LayoutY);
-            Assert.AreEqual(100f, root.LayoutWidth);
-            Assert.AreEqual(100f, root.LayoutHeight);
-
-            Assert.AreEqual(0f, root_child0.LayoutX);
-            Assert.AreEqual(0f, root_child0.LayoutY);
-            Assert.AreEqual(50f, root_child0.LayoutWidth);
-            Assert.AreEqual(50f, root_child0.LayoutHeight);
-
-            Assert.AreEqual(0f, root_child1.LayoutX);
-            Assert.AreEqual(50f, root_child1.LayoutY);
-            Assert.AreEqual(30f, root_child1.LayoutWidth);
-            Assert.AreEqual(50f, root_child1.LayoutHeight);
-
-            Assert.AreEqual(0f, root_child1_child0.LayoutX);
-            Assert.AreEqual(0f, root_child1_child0.LayoutY);
-            Assert.AreEqual(20f, root_child1_child0.LayoutWidth);
-            Assert.AreEqual(20f, root_child1_child0.LayoutHeight);
-
-            Assert.AreEqual(50f, root_child2.LayoutX);
-            Assert.AreEqual(0f, root_child2.LayoutY);
-            Assert.AreEqual(40f, root_child2.LayoutWidth);
-            Assert.AreEqual(70f, root_child2.LayoutHeight);
-
-            Assert.AreEqual(0f, root_child2_child0.LayoutX);
-            Assert.AreEqual(0f, root_child2_child0.LayoutY);
-            Assert.AreEqual(10f, root_child2_child0.LayoutWidth);
-            Assert.AreEqual(10f, root_child2_child0.LayoutHeight);
-
-            Assert.AreEqual(50f, root_child3.LayoutX);
-            Assert.AreEqual(70f, root_child3.LayoutY);
-            Assert.AreEqual(50f, root_child3.LayoutWidth);
-            Assert.AreEqual(20f, root_child3.LayoutHeight);
-
-            root.StyleDirection = YogaDirection.RTL;
-            root.CalculateLayout();
-
-            Assert.AreEqual(0f, root.LayoutX);
-            Assert.AreEqual(0f, root.LayoutY);
-            Assert.AreEqual(100f, root.LayoutWidth);
-            Assert.AreEqual(100f, root.LayoutHeight);
-
-            Assert.AreEqual(50f, root_child0.LayoutX);
-            Assert.AreEqual(0f, root_child0.LayoutY);
-            Assert.AreEqual(50f, root_child0.LayoutWidth);
-            Assert.AreEqual(50f, root_child0.LayoutHeight);
-
-            Assert.AreEqual(70f, root_child1.LayoutX);
-            Assert.AreEqual(50f, root_child1.LayoutY);
-            Assert.AreEqual(30f, root_child1.LayoutWidth);
-            Assert.AreEqual(50f, root_child1.LayoutHeight);
-
-            Assert.AreEqual(10f, root_child1_child0.LayoutX);
-            Assert.AreEqual(0f, root_child1_child0.LayoutY);
-            Assert.AreEqual(20f, root_child1_child0.LayoutWidth);
-            Assert.AreEqual(20f, root_child1_child0.LayoutHeight);
-
-            Assert.AreEqual(10f, root_child2.LayoutX);
-            Assert.AreEqual(0f, root_child2.LayoutY);
-            Assert.AreEqual(40f, root_child2.LayoutWidth);
-            Assert.AreEqual(70f, root_child2.LayoutHeight);
-
-            Assert.AreEqual(30f, root_child2_child0.LayoutX);
-            Assert.AreEqual(0f, root_child2_child0.LayoutY);
-            Assert.AreEqual(10f, root_child2_child0.LayoutWidth);
-            Assert.AreEqual(10f, root_child2_child0.LayoutHeight);
-
-            Assert.AreEqual(0f, root_child3.LayoutX);
-            Assert.AreEqual(70f, root_child3.LayoutY);
-            Assert.AreEqual(50f, root_child3.LayoutWidth);
-            Assert.AreEqual(20f, root_child3.LayoutHeight);
-        }
-
-        [Test]
         public void Test_align_baseline_multiline_row_and_column()
         {
             YogaConfig config = new YogaConfig();
@@ -2160,6 +1965,260 @@ namespace Facebook.Yoga
             Assert.AreEqual(0f, root_child0_child0_child0.LayoutY);
             Assert.AreEqual(0f, root_child0_child0_child0.LayoutWidth);
             Assert.AreEqual(0f, root_child0_child0_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_items_center_justify_content_center()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.Width = 500;
+            root.Height = 500;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.JustifyContent = YogaJustify.Center;
+            root_child0.AlignItems = YogaAlign.Center;
+            root_child0.Height = 50;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child0_child0 = new YogaNode(config);
+            root_child0_child0.JustifyContent = YogaJustify.Center;
+            root_child0_child0.AlignItems = YogaAlign.Center;
+            root_child0_child0.MarginLeft = 10;
+            root_child0_child0.MarginRight = 10;
+            root_child0_child0.Height = 100.Percent();
+            root_child0.Insert(0, root_child0_child0);
+
+            YogaNode root_child0_child0_child0 = new YogaNode(config);
+            root_child0_child0_child0.Width = 10;
+            root_child0_child0_child0.Height = 10;
+            root_child0_child0.Insert(0, root_child0_child0_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(500f, root.LayoutWidth);
+            Assert.AreEqual(500f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(500f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(245f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(10f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0_child0.LayoutX);
+            Assert.AreEqual(20f, root_child0_child0_child0.LayoutY);
+            Assert.AreEqual(10f, root_child0_child0_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0_child0_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(500f, root.LayoutWidth);
+            Assert.AreEqual(500f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(500f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(245f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(10f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0_child0.LayoutX);
+            Assert.AreEqual(20f, root_child0_child0_child0.LayoutY);
+            Assert.AreEqual(10f, root_child0_child0_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0_child0_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_baseline_child_margin_percent()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignItems = YogaAlign.Baseline;
+            root.Width = 100;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.MarginLeft = 5.Percent();
+            root_child0.MarginTop = 5.Percent();
+            root_child0.MarginRight = 5.Percent();
+            root_child0.MarginBottom = 5.Percent();
+            root_child0.Width = 50;
+            root_child0.Height = 50;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.Width = 50;
+            root_child1.Height = 20;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child1_child0 = new YogaNode(config);
+            root_child1_child0.MarginLeft = 1.Percent();
+            root_child1_child0.MarginTop = 1.Percent();
+            root_child1_child0.MarginRight = 1.Percent();
+            root_child1_child0.MarginBottom = 1.Percent();
+            root_child1_child0.Width = 50;
+            root_child1_child0.Height = 10;
+            root_child1.Insert(0, root_child1_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(5f, root_child0.LayoutX);
+            Assert.AreEqual(5f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(60f, root_child1.LayoutX);
+            Assert.AreEqual(45f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(1f, root_child1_child0.LayoutX);
+            Assert.AreEqual(1f, root_child1_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(45f, root_child0.LayoutX);
+            Assert.AreEqual(5f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(-10f, root_child1.LayoutX);
+            Assert.AreEqual(45f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(20f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0.LayoutX);
+            Assert.AreEqual(1f, root_child1_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child1_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_baseline_nested_column()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignItems = YogaAlign.Baseline;
+            root.Width = 100;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 50;
+            root_child0.Height = 60;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root.Insert(1, root_child1);
+
+            YogaNode root_child1_child0 = new YogaNode(config);
+            root_child1_child0.Width = 50;
+            root_child1_child0.Height = 80;
+            root_child1.Insert(0, root_child1_child0);
+
+            YogaNode root_child1_child0_child0 = new YogaNode(config);
+            root_child1_child0_child0.Width = 50;
+            root_child1_child0_child0.Height = 30;
+            root_child1_child0.Insert(0, root_child1_child0_child0);
+
+            YogaNode root_child1_child0_child1 = new YogaNode(config);
+            root_child1_child0_child1.Width = 50;
+            root_child1_child0_child1.Height = 40;
+            root_child1_child0.Insert(1, root_child1_child0_child1);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(60f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child1.LayoutX);
+            Assert.AreEqual(30f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(80f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(80f, root_child1_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0_child0.LayoutWidth);
+            Assert.AreEqual(30f, root_child1_child0_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0_child1.LayoutX);
+            Assert.AreEqual(30f, root_child1_child0_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0_child1.LayoutWidth);
+            Assert.AreEqual(40f, root_child1_child0_child1.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(60f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(30f, root_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
+            Assert.AreEqual(80f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0.LayoutWidth);
+            Assert.AreEqual(80f, root_child1_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child1_child0_child0.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0_child0.LayoutWidth);
+            Assert.AreEqual(30f, root_child1_child0_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1_child0_child1.LayoutX);
+            Assert.AreEqual(30f, root_child1_child0_child1.LayoutY);
+            Assert.AreEqual(50f, root_child1_child0_child1.LayoutWidth);
+            Assert.AreEqual(40f, root_child1_child0_child1.LayoutHeight);
         }
 
     }

--- a/csharp/tests/Facebook.Yoga/YGAlignSelfTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGAlignSelfTest.cs
@@ -57,6 +57,63 @@ namespace Facebook.Yoga
         }
 
         [Test]
+        public void Test_align_self_center_undefined_max_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.Width = 280;
+            root.MinHeight = 52;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 240;
+            root_child0.Height = 44;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.AlignSelf = YogaAlign.Center;
+            root_child1.Width = 40;
+            root_child1.Height = 56;
+            root.Insert(1, root_child1);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(280f, root.LayoutWidth);
+            Assert.AreEqual(56f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(240f, root_child0.LayoutWidth);
+            Assert.AreEqual(44f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(240f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(40f, root_child1.LayoutWidth);
+            Assert.AreEqual(56f, root_child1.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(280f, root.LayoutWidth);
+            Assert.AreEqual(56f, root.LayoutHeight);
+
+            Assert.AreEqual(40f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(240f, root_child0.LayoutWidth);
+            Assert.AreEqual(44f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(40f, root_child1.LayoutWidth);
+            Assert.AreEqual(56f, root_child1.LayoutHeight);
+        }
+
+        [Test]
         public void Test_align_self_flex_end()
         {
             YogaConfig config = new YogaConfig();

--- a/csharp/tests/Facebook.Yoga/YGBorderTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGBorderTest.cs
@@ -179,8 +179,6 @@ namespace Facebook.Yoga
             YogaNode root = new YogaNode(config);
             root.JustifyContent = YogaJustify.Center;
             root.AlignItems = YogaAlign.Center;
-            root.BorderStartWidth = 10;
-            root.BorderEndWidth = 20;
             root.BorderBottomWidth = 20;
             root.Width = 100;
             root.Height = 100;
@@ -197,7 +195,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(40f, root_child0.LayoutX);
+            Assert.AreEqual(45f, root_child0.LayoutX);
             Assert.AreEqual(35f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(10f, root_child0.LayoutHeight);
@@ -210,7 +208,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(50f, root_child0.LayoutX);
+            Assert.AreEqual(45f, root_child0.LayoutX);
             Assert.AreEqual(35f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(10f, root_child0.LayoutHeight);

--- a/csharp/tests/Facebook.Yoga/YGDisplayTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGDisplayTest.cs
@@ -376,5 +376,64 @@ namespace Facebook.Yoga
             Assert.AreEqual(0f, root_child0.LayoutHeight);
         }
 
+        [Test]
+        public void Test_display_none_absolute_child()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.Width = 100;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.FlexGrow = 1;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.PositionType = YogaPositionType.Absolute;
+            root_child1.Left = 10;
+            root_child1.Top = 10;
+            root_child1.Width = 20;
+            root_child1.Height = 20;
+            root_child1.Display = YogaDisplay.None;
+            root.Insert(1, root_child1);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(100f, root_child0.LayoutWidth);
+            Assert.AreEqual(100f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(0f, root_child1.LayoutWidth);
+            Assert.AreEqual(0f, root_child1.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(100f, root_child0.LayoutWidth);
+            Assert.AreEqual(100f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(0f, root_child1.LayoutWidth);
+            Assert.AreEqual(0f, root_child1.LayoutHeight);
+        }
+
     }
 }

--- a/csharp/tests/Facebook.Yoga/YGFlexDirectionTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGFlexDirectionTest.cs
@@ -419,5 +419,72 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root_child2.LayoutHeight);
         }
 
+        [Test]
+        public void Test_flex_direction_column_reverse_no_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.ColumnReverse;
+            root.Width = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Height = 10;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.Height = 10;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode(config);
+            root_child2.Height = 10;
+            root.Insert(2, root_child2);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(30f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(20f, root_child0.LayoutY);
+            Assert.AreEqual(100f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(10f, root_child1.LayoutY);
+            Assert.AreEqual(100f, root_child1.LayoutWidth);
+            Assert.AreEqual(10f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child2.LayoutX);
+            Assert.AreEqual(0f, root_child2.LayoutY);
+            Assert.AreEqual(100f, root_child2.LayoutWidth);
+            Assert.AreEqual(10f, root_child2.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(30f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(20f, root_child0.LayoutY);
+            Assert.AreEqual(100f, root_child0.LayoutWidth);
+            Assert.AreEqual(10f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(10f, root_child1.LayoutY);
+            Assert.AreEqual(100f, root_child1.LayoutWidth);
+            Assert.AreEqual(10f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child2.LayoutX);
+            Assert.AreEqual(0f, root_child2.LayoutY);
+            Assert.AreEqual(100f, root_child2.LayoutWidth);
+            Assert.AreEqual(10f, root_child2.LayoutHeight);
+        }
+
     }
 }

--- a/csharp/tests/Facebook.Yoga/YGFlexTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGFlexTest.cs
@@ -612,5 +612,197 @@ namespace Facebook.Yoga
             Assert.AreEqual(184f, root_child2.LayoutHeight);
         }
 
+        [Test]
+        public void Test_single_flex_child_after_absolute_child()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.Width = 428;
+            root.Height = 845;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.PositionType = YogaPositionType.Absolute;
+            root_child0.Width = 100.Percent();
+            root_child0.Height = 100.Percent();
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.FlexGrow = 1;
+            root_child1.FlexShrink = 1;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode(config);
+            root_child2.FlexBasis = 174;
+            root.Insert(2, root_child2);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(428f, root.LayoutWidth);
+            Assert.AreEqual(845f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(428f, root_child0.LayoutWidth);
+            Assert.AreEqual(845f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(428f, root_child1.LayoutWidth);
+            Assert.AreEqual(671f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child2.LayoutX);
+            Assert.AreEqual(671f, root_child2.LayoutY);
+            Assert.AreEqual(428f, root_child2.LayoutWidth);
+            Assert.AreEqual(174f, root_child2.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(428f, root.LayoutWidth);
+            Assert.AreEqual(845f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(428f, root_child0.LayoutWidth);
+            Assert.AreEqual(845f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(428f, root_child1.LayoutWidth);
+            Assert.AreEqual(671f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child2.LayoutX);
+            Assert.AreEqual(671f, root_child2.LayoutY);
+            Assert.AreEqual(428f, root_child2.LayoutWidth);
+            Assert.AreEqual(174f, root_child2.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_flex_basis_zero_undefined_main_size()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.FlexBasis = 0;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child0_child0 = new YogaNode(config);
+            root_child0_child0.Width = 100;
+            root_child0_child0.Height = 50;
+            root_child0.Insert(0, root_child0_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(50f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(100f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(100f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(50f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(100f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(100f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_only_shrinkable_item_with_flex_basis_zero()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.Width = 480;
+            root.MaxHeight = 764;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.FlexShrink = 1;
+            root_child0.FlexBasis = 0;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.FlexBasis = 93;
+            root_child1.MarginBottom = 6;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode(config);
+            root_child2.FlexBasis = 764;
+            root.Insert(2, root_child2);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(480f, root.LayoutWidth);
+            Assert.AreEqual(764f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(480f, root_child0.LayoutWidth);
+            Assert.AreEqual(0f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(480f, root_child1.LayoutWidth);
+            Assert.AreEqual(93f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child2.LayoutX);
+            Assert.AreEqual(99f, root_child2.LayoutY);
+            Assert.AreEqual(480f, root_child2.LayoutWidth);
+            Assert.AreEqual(764f, root_child2.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(480f, root.LayoutWidth);
+            Assert.AreEqual(764f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(480f, root_child0.LayoutWidth);
+            Assert.AreEqual(0f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(480f, root_child1.LayoutWidth);
+            Assert.AreEqual(93f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child2.LayoutX);
+            Assert.AreEqual(99f, root_child2.LayoutY);
+            Assert.AreEqual(480f, root_child2.LayoutWidth);
+            Assert.AreEqual(764f, root_child2.LayoutHeight);
+        }
+
     }
 }

--- a/csharp/tests/Facebook.Yoga/YGMarginTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGMarginTest.cs
@@ -26,7 +26,6 @@ namespace Facebook.Yoga
             root.Height = 100;
 
             YogaNode root_child0 = new YogaNode(config);
-            root_child0.MarginStart = 10;
             root_child0.Width = 10;
             root.Insert(0, root_child0);
             root.StyleDirection = YogaDirection.LTR;
@@ -37,7 +36,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(10f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(100f, root_child0.LayoutHeight);
@@ -50,7 +49,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(80f, root_child0.LayoutX);
+            Assert.AreEqual(90f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(100f, root_child0.LayoutHeight);
@@ -108,7 +107,6 @@ namespace Facebook.Yoga
             root.Height = 100;
 
             YogaNode root_child0 = new YogaNode(config);
-            root_child0.MarginEnd = 10;
             root_child0.Width = 10;
             root.Insert(0, root_child0);
             root.StyleDirection = YogaDirection.LTR;
@@ -119,7 +117,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(80f, root_child0.LayoutX);
+            Assert.AreEqual(90f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(100f, root_child0.LayoutHeight);
@@ -132,7 +130,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(10f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(100f, root_child0.LayoutHeight);
@@ -191,8 +189,6 @@ namespace Facebook.Yoga
 
             YogaNode root_child0 = new YogaNode(config);
             root_child0.FlexGrow = 1;
-            root_child0.MarginStart = 10;
-            root_child0.MarginEnd = 10;
             root.Insert(0, root_child0);
             root.StyleDirection = YogaDirection.LTR;
             root.CalculateLayout();
@@ -202,9 +198,9 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(10f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
-            Assert.AreEqual(80f, root_child0.LayoutWidth);
+            Assert.AreEqual(100f, root_child0.LayoutWidth);
             Assert.AreEqual(100f, root_child0.LayoutHeight);
 
             root.StyleDirection = YogaDirection.RTL;
@@ -215,9 +211,9 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(10f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
-            Assert.AreEqual(80f, root_child0.LayoutWidth);
+            Assert.AreEqual(100f, root_child0.LayoutWidth);
             Assert.AreEqual(100f, root_child0.LayoutHeight);
         }
 
@@ -315,8 +311,6 @@ namespace Facebook.Yoga
 
             YogaNode root_child0 = new YogaNode(config);
             root_child0.FlexGrow = 1;
-            root_child0.MarginStart = 10;
-            root_child0.MarginEnd = 10;
             root.Insert(0, root_child0);
             root.StyleDirection = YogaDirection.LTR;
             root.CalculateLayout();
@@ -326,9 +320,9 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(10f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
-            Assert.AreEqual(80f, root_child0.LayoutWidth);
+            Assert.AreEqual(100f, root_child0.LayoutWidth);
             Assert.AreEqual(100f, root_child0.LayoutHeight);
 
             root.StyleDirection = YogaDirection.RTL;
@@ -339,9 +333,9 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(10f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
-            Assert.AreEqual(80f, root_child0.LayoutWidth);
+            Assert.AreEqual(100f, root_child0.LayoutWidth);
             Assert.AreEqual(100f, root_child0.LayoutHeight);
         }
 
@@ -357,7 +351,6 @@ namespace Facebook.Yoga
 
             YogaNode root_child0 = new YogaNode(config);
             root_child0.FlexGrow = 1;
-            root_child0.MarginEnd = 10;
             root.Insert(0, root_child0);
 
             YogaNode root_child1 = new YogaNode(config);
@@ -373,12 +366,12 @@ namespace Facebook.Yoga
 
             Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
-            Assert.AreEqual(45f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
             Assert.AreEqual(100f, root_child0.LayoutHeight);
 
-            Assert.AreEqual(55f, root_child1.LayoutX);
+            Assert.AreEqual(50f, root_child1.LayoutX);
             Assert.AreEqual(0f, root_child1.LayoutY);
-            Assert.AreEqual(45f, root_child1.LayoutWidth);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
             Assert.AreEqual(100f, root_child1.LayoutHeight);
 
             root.StyleDirection = YogaDirection.RTL;
@@ -389,14 +382,14 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(55f, root_child0.LayoutX);
+            Assert.AreEqual(50f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
-            Assert.AreEqual(45f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
             Assert.AreEqual(100f, root_child0.LayoutHeight);
 
             Assert.AreEqual(0f, root_child1.LayoutX);
             Assert.AreEqual(0f, root_child1.LayoutY);
-            Assert.AreEqual(45f, root_child1.LayoutWidth);
+            Assert.AreEqual(50f, root_child1.LayoutWidth);
             Assert.AreEqual(100f, root_child1.LayoutHeight);
         }
 
@@ -959,8 +952,6 @@ namespace Facebook.Yoga
             root.Height = 200;
 
             YogaNode root_child0 = new YogaNode(config);
-            root_child0.MarginStart = YogaValue.Auto();
-            root_child0.MarginEnd = YogaValue.Auto();
             root_child0.Width = 50;
             root_child0.Height = 50;
             root.Insert(0, root_child0);
@@ -977,12 +968,12 @@ namespace Facebook.Yoga
             Assert.AreEqual(200f, root.LayoutWidth);
             Assert.AreEqual(200f, root.LayoutHeight);
 
-            Assert.AreEqual(50f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(75f, root_child0.LayoutY);
             Assert.AreEqual(50f, root_child0.LayoutWidth);
             Assert.AreEqual(50f, root_child0.LayoutHeight);
 
-            Assert.AreEqual(150f, root_child1.LayoutX);
+            Assert.AreEqual(50f, root_child1.LayoutX);
             Assert.AreEqual(75f, root_child1.LayoutY);
             Assert.AreEqual(50f, root_child1.LayoutWidth);
             Assert.AreEqual(50f, root_child1.LayoutHeight);
@@ -995,12 +986,12 @@ namespace Facebook.Yoga
             Assert.AreEqual(200f, root.LayoutWidth);
             Assert.AreEqual(200f, root.LayoutHeight);
 
-            Assert.AreEqual(100f, root_child0.LayoutX);
+            Assert.AreEqual(150f, root_child0.LayoutX);
             Assert.AreEqual(75f, root_child0.LayoutY);
             Assert.AreEqual(50f, root_child0.LayoutWidth);
             Assert.AreEqual(50f, root_child0.LayoutHeight);
 
-            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(100f, root_child1.LayoutX);
             Assert.AreEqual(75f, root_child1.LayoutY);
             Assert.AreEqual(50f, root_child1.LayoutWidth);
             Assert.AreEqual(50f, root_child1.LayoutHeight);
@@ -1016,8 +1007,6 @@ namespace Facebook.Yoga
             root.Height = 200;
 
             YogaNode root_child0 = new YogaNode(config);
-            root_child0.MarginStart = YogaValue.Auto();
-            root_child0.MarginEnd = YogaValue.Auto();
             root_child0.Width = 50;
             root_child0.Height = 50;
             root.Insert(0, root_child0);
@@ -1034,7 +1023,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(200f, root.LayoutWidth);
             Assert.AreEqual(200f, root.LayoutHeight);
 
-            Assert.AreEqual(75f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
             Assert.AreEqual(50f, root_child0.LayoutWidth);
             Assert.AreEqual(50f, root_child0.LayoutHeight);
@@ -1052,7 +1041,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(200f, root.LayoutWidth);
             Assert.AreEqual(200f, root.LayoutHeight);
 
-            Assert.AreEqual(75f, root_child0.LayoutX);
+            Assert.AreEqual(150f, root_child0.LayoutX);
             Assert.AreEqual(0f, root_child0.LayoutY);
             Assert.AreEqual(50f, root_child0.LayoutWidth);
             Assert.AreEqual(50f, root_child0.LayoutHeight);

--- a/csharp/tests/Facebook.Yoga/YGMinMaxDimensionTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGMinMaxDimensionTest.cs
@@ -56,6 +56,87 @@ namespace Facebook.Yoga
         }
 
         [Test]
+        public void Test_min_width_larger_than_width()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.Width = 100;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 25;
+            root_child0.MinWidth = 50;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(0f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(50f, root_child0.LayoutWidth);
+            Assert.AreEqual(0f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_min_height_larger_than_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.Width = 100;
+            root.Height = 100;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Height = 25;
+            root_child0.MinHeight = 50;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(0f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(100f, root.LayoutHeight);
+
+            Assert.AreEqual(100f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(0f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+        }
+
+        [Test]
         public void Test_max_height()
         {
             YogaConfig config = new YogaConfig();
@@ -94,6 +175,66 @@ namespace Facebook.Yoga
             Assert.AreEqual(0f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(50f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_min_height_with_nested_fixed_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.PaddingLeft = 16;
+            root.PaddingRight = 16;
+            root.Width = 320;
+            root.MinHeight = 44;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.AlignSelf = YogaAlign.FlexStart;
+            root_child0.MarginTop = 8;
+            root_child0.MarginBottom = 9;
+            root_child0.MinHeight = 28;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child0_child0 = new YogaNode(config);
+            root_child0_child0.Width = 40;
+            root_child0_child0.Height = 40;
+            root_child0.Insert(0, root_child0_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(320f, root.LayoutWidth);
+            Assert.AreEqual(57f, root.LayoutHeight);
+
+            Assert.AreEqual(16f, root_child0.LayoutX);
+            Assert.AreEqual(8f, root_child0.LayoutY);
+            Assert.AreEqual(40f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(40f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(320f, root.LayoutWidth);
+            Assert.AreEqual(57f, root.LayoutHeight);
+
+            Assert.AreEqual(264f, root_child0.LayoutX);
+            Assert.AreEqual(8f, root_child0.LayoutY);
+            Assert.AreEqual(40f, root_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(40f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(40f, root_child0_child0.LayoutHeight);
         }
 
         [Test]
@@ -178,6 +319,52 @@ namespace Facebook.Yoga
             Assert.AreEqual(0f, root_child0.LayoutY);
             Assert.AreEqual(60f, root_child0.LayoutWidth);
             Assert.AreEqual(60f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_align_items_center_min_max_with_padding()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignItems = YogaAlign.Center;
+            root.PaddingTop = 8;
+            root.PaddingBottom = 8;
+            root.MinWidth = 320;
+            root.MaxWidth = 320;
+            root.MinHeight = 72;
+            root.MaxHeight = 504;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 62;
+            root_child0.Height = 62;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(320f, root.LayoutWidth);
+            Assert.AreEqual(78f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(8f, root_child0.LayoutY);
+            Assert.AreEqual(62f, root_child0.LayoutWidth);
+            Assert.AreEqual(62f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(320f, root.LayoutWidth);
+            Assert.AreEqual(78f, root.LayoutHeight);
+
+            Assert.AreEqual(258f, root_child0.LayoutX);
+            Assert.AreEqual(8f, root_child0.LayoutY);
+            Assert.AreEqual(62f, root_child0.LayoutWidth);
+            Assert.AreEqual(62f, root_child0.LayoutHeight);
         }
 
         [Test]
@@ -1190,6 +1377,180 @@ namespace Facebook.Yoga
             Assert.AreEqual(0f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(10f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_min_max_percent_different_width_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.AlignItems = YogaAlign.FlexStart;
+            root.Width = 100;
+            root.Height = 200;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.MinWidth = 10.Percent();
+            root_child0.MaxWidth = 10.Percent();
+            root_child0.MinHeight = 10.Percent();
+            root_child0.MaxHeight = 10.Percent();
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(200f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(10f, root_child0.LayoutWidth);
+            Assert.AreEqual(20f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(200f, root.LayoutHeight);
+
+            Assert.AreEqual(90f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(10f, root_child0.LayoutWidth);
+            Assert.AreEqual(20f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_undefined_height_with_min_max()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.Width = 320;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.MaxHeight = 100;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(320f, root.LayoutWidth);
+            Assert.AreEqual(0f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(320f, root_child0.LayoutWidth);
+            Assert.AreEqual(0f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(320f, root.LayoutWidth);
+            Assert.AreEqual(0f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(320f, root_child0.LayoutWidth);
+            Assert.AreEqual(0f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_undefined_width_with_min_max()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.Height = 50;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.MaxWidth = 100;
+            root.Insert(0, root_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(0f, root.LayoutWidth);
+            Assert.AreEqual(50f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(0f, root_child0.LayoutWidth);
+            Assert.AreEqual(0f, root_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(0f, root.LayoutWidth);
+            Assert.AreEqual(50f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(0f, root_child0.LayoutWidth);
+            Assert.AreEqual(0f, root_child0.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_undefined_width_with_min_max_row()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.Height = 50;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.MinWidth = 60;
+            root_child0.MaxWidth = 300;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child0_child0 = new YogaNode(config);
+            root_child0_child0.Width = 30;
+            root_child0_child0.Height = 20;
+            root_child0.Insert(0, root_child0_child0);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(60f, root.LayoutWidth);
+            Assert.AreEqual(50f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(20f, root_child0_child0.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(60f, root.LayoutWidth);
+            Assert.AreEqual(50f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(60f, root_child0.LayoutWidth);
+            Assert.AreEqual(50f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(30f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(20f, root_child0_child0.LayoutHeight);
         }
 
     }

--- a/csharp/tests/Facebook.Yoga/YGPaddingTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGPaddingTest.cs
@@ -179,8 +179,6 @@ namespace Facebook.Yoga
             YogaNode root = new YogaNode(config);
             root.JustifyContent = YogaJustify.Center;
             root.AlignItems = YogaAlign.Center;
-            root.PaddingStart = 10;
-            root.PaddingEnd = 20;
             root.PaddingBottom = 20;
             root.Width = 100;
             root.Height = 100;
@@ -197,7 +195,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(40f, root_child0.LayoutX);
+            Assert.AreEqual(45f, root_child0.LayoutX);
             Assert.AreEqual(35f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(10f, root_child0.LayoutHeight);
@@ -210,7 +208,7 @@ namespace Facebook.Yoga
             Assert.AreEqual(100f, root.LayoutWidth);
             Assert.AreEqual(100f, root.LayoutHeight);
 
-            Assert.AreEqual(50f, root_child0.LayoutX);
+            Assert.AreEqual(45f, root_child0.LayoutX);
             Assert.AreEqual(35f, root_child0.LayoutY);
             Assert.AreEqual(10f, root_child0.LayoutWidth);
             Assert.AreEqual(10f, root_child0.LayoutHeight);

--- a/csharp/tests/Facebook.Yoga/YGPercentageTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGPercentageTest.cs
@@ -599,6 +599,74 @@ namespace Facebook.Yoga
         }
 
         [Test]
+        public void Test_percentage_main_max_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.Width = 71;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.AlignItems = YogaAlign.FlexStart;
+            root_child0.Height = 151;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child0_child0 = new YogaNode(config);
+            root_child0_child0.FlexBasis = 15;
+            root_child0.Insert(0, root_child0_child0);
+
+            YogaNode root_child0_child1 = new YogaNode(config);
+            root_child0_child1.FlexBasis = 48;
+            root_child0_child1.MaxHeight = 33.Percent();
+            root_child0.Insert(1, root_child0_child1);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(71f, root.LayoutWidth);
+            Assert.AreEqual(151f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(71f, root_child0.LayoutWidth);
+            Assert.AreEqual(151f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(0f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(15f, root_child0_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0_child1.LayoutX);
+            Assert.AreEqual(15f, root_child0_child1.LayoutY);
+            Assert.AreEqual(0f, root_child0_child1.LayoutWidth);
+            Assert.AreEqual(48f, root_child0_child1.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(71f, root.LayoutWidth);
+            Assert.AreEqual(151f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(71f, root_child0.LayoutWidth);
+            Assert.AreEqual(151f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(71f, root_child0_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0_child0.LayoutY);
+            Assert.AreEqual(0f, root_child0_child0.LayoutWidth);
+            Assert.AreEqual(15f, root_child0_child0.LayoutHeight);
+
+            Assert.AreEqual(71f, root_child0_child1.LayoutX);
+            Assert.AreEqual(15f, root_child0_child1.LayoutY);
+            Assert.AreEqual(0f, root_child0_child1.LayoutWidth);
+            Assert.AreEqual(48f, root_child0_child1.LayoutHeight);
+        }
+
+        [Test]
         public void Test_percentage_multiple_nested_with_padding_margin_and_percentage_values()
         {
             YogaConfig config = new YogaConfig();
@@ -1003,6 +1071,7 @@ namespace Facebook.Yoga
             YogaNode root_child0_child0 = new YogaNode(config);
             root_child0_child0.FlexDirection = YogaFlexDirection.Row;
             root_child0_child0.JustifyContent = YogaJustify.Center;
+            root_child0_child0.AlignItems = YogaAlign.Center;
             root_child0_child0.Width = 100.Percent();
             root_child0.Insert(0, root_child0_child0);
 
@@ -1141,6 +1210,114 @@ namespace Facebook.Yoga
             Assert.AreEqual(0f, root_child0_child1.LayoutY);
             Assert.AreEqual(60f, root_child0_child1.LayoutWidth);
             Assert.AreEqual(50f, root_child0_child1.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_percentage_different_width_height()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.Width = 200;
+            root.Height = 300;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.FlexGrow = 1;
+            root_child0.Height = 30.Percent();
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.Height = 30.Percent();
+            root.Insert(1, root_child1);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(200f, root.LayoutWidth);
+            Assert.AreEqual(300f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(200f, root_child0.LayoutWidth);
+            Assert.AreEqual(90f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(200f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(0f, root_child1.LayoutWidth);
+            Assert.AreEqual(90f, root_child1.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(200f, root.LayoutWidth);
+            Assert.AreEqual(300f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(200f, root_child0.LayoutWidth);
+            Assert.AreEqual(90f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(0f, root_child1.LayoutWidth);
+            Assert.AreEqual(90f, root_child1.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_percentage_different_width_height_column()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.Width = 200;
+            root.Height = 300;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.FlexGrow = 1;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.Height = 30.Percent();
+            root.Insert(1, root_child1);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(200f, root.LayoutWidth);
+            Assert.AreEqual(300f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(200f, root_child0.LayoutWidth);
+            Assert.AreEqual(210f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(210f, root_child1.LayoutY);
+            Assert.AreEqual(200f, root_child1.LayoutWidth);
+            Assert.AreEqual(90f, root_child1.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(200f, root.LayoutWidth);
+            Assert.AreEqual(300f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(200f, root_child0.LayoutWidth);
+            Assert.AreEqual(210f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child1.LayoutX);
+            Assert.AreEqual(210f, root_child1.LayoutY);
+            Assert.AreEqual(200f, root_child1.LayoutWidth);
+            Assert.AreEqual(90f, root_child1.LayoutHeight);
         }
 
     }

--- a/gentest/fixtures/YGAbsolutePositionTest.html
+++ b/gentest/fixtures/YGAbsolutePositionTest.html
@@ -1,21 +1,25 @@
 <div id="absolute_layout_width_height_start_top" style="width: 100px; height: 100px;">
-  <div style="width:10px; height: 10px; position: absolute; start: 10px; top: 10px;"></div>
+  <div style="width:10px; height: 10px; position: absolute; inset-inline-start: 10px; top: 10px;"></div>
 </div>
 
 <div id="absolute_layout_width_height_end_bottom" style="width: 100px; height: 100px;">
-  <div style="width:10px; height: 10px; position: absolute; end: 10px; bottom: 10px;"></div>
+  <div style="width:10px; height: 10px; position: absolute; inset-inline-end: 10px; bottom: 10px;"></div>
+</div>
+
+<div id="absolute_layout_row_width_height_end_bottom" style="width: 100px; height: 100px; flex-direction: row;">
+  <div style="width:10px; height: 10px; position: absolute; inset-inline-end: 10px; bottom: 10px;"></div>
 </div>
 
 <div id="absolute_layout_start_top_end_bottom" style="width: 100px; height: 100px;">
-  <div style="position: absolute; start: 10px; top: 10px; end: 10px; bottom: 10px;"></div>
+  <div style="position: absolute; inset-inline-start: 10px; top: 10px; inset-inline-end: 10px; bottom: 10px;"></div>
 </div>
 
 <div id="absolute_layout_width_height_start_top_end_bottom" style="width: 100px; height: 100px;">
-  <div style="width:10px; height: 10px; position: absolute; start: 10px; top: 10px; end: 10px; bottom: 10px;"></div>
+  <div style="width:10px; height: 10px; position: absolute; inset-inline-start: 10px; top: 10px; inset-inline-end: 10px; bottom: 10px;"></div>
 </div>
 
 <div id="do_not_clamp_height_of_absolute_node_to_height_of_its_overflow_hidden_parent" style="height: 50px; width: 50px; overflow: hidden; flex-direction: row;">
-  <div style="position: absolute; start: 0px; top: 0px;">
+  <div style="position: absolute; inset-inline-start: 0px; top: 0px;">
     <div style="width: 100px; height: 100px;"></div>
   </div>
 </div>
@@ -67,9 +71,9 @@
 </div>
 
 <div id="absolute_layout_percentage_bottom_based_on_parent_height" style="width: 100px; height: 200px;">
-    <div style="position: absolute; top: 50%; width: 10px; height: 10px;"></div>
-    <div style="position: absolute; bottom: 50%; width: 10px; height: 10px;"></div>
-    <div style="position: absolute; top: 10%; width: 10px; bottom: 10%;"></div>
+  <div style="position: absolute; top: 50%; width: 10px; height: 10px;"></div>
+  <div style="position: absolute; bottom: 50%; width: 10px; height: 10px;"></div>
+  <div style="position: absolute; top: 10%; width: 10px; bottom: 10%;"></div>
 </div>
 
 <div id="absolute_layout_in_wrap_reverse_column_container" style="flex-direction:column; width:100px; height:100px; flex-wrap: wrap-reverse;">
@@ -88,3 +92,32 @@
   <div style="width:20px; height:20px; position: absolute; align-self: flex-end;"></div>
 </div>
 
+<div id="absolute_layout_percentage_height" style="width: 200px; height: 100px;">
+  <div style="width:10px; height: 50%; position: absolute; inset-inline-start: 10px; top: 10px;"></div>
+</div>
+
+<div id="absolute_child_with_cross_margin"
+  style="flex-direction: row; justify-content: space-between; max-width: 311px; max-height: 3.68935e+19px; min-width: 311px; min-height: 0px; ">
+  <div style="flex-direction: row; align-content: stretch; width:28px; height:27px"></div>
+  <div
+    style="flex-direction: row; align-content: stretch; flex-grow: 0; flex-shrink: 1; margin-top: 4px; width: 100%; height: 15px; position: absolute;">
+  </div>
+  <div style="flex-direction: row; align-content: stretch; width:25px; height:27px"></div>
+</div>
+
+<div id="absolute_child_with_main_margin" style="flex-direction: row; width: 20px; height: 37px">
+  <div style="width: 9px; height: 9px; position: absolute; margin-left: 7px"></div>
+</div>
+
+<div id="absolute_child_with_max_height" style="width: 100px; height: 200px">
+  <div style="position: absolute; bottom: 20px; max-height: 100px;">
+    <div style="width: 100px; height: 30px"></div>
+  </div>
+</div>
+
+<!-- Yoga has incorrect behavior -->
+<!-- <div id="absolute_child_with_max_height_larger_shrinkable_grandchild" style="width: 100px; height: 200px">
+  <div style="position: absolute; bottom: 20px; max-height: 100px;">
+    <div style="width: 100px; flex-basis: 150px; flex-shrink: 1;"></div>
+  </div>
+</div> -->

--- a/gentest/fixtures/YGAlignContentTest.html
+++ b/gentest/fixtures/YGAlignContentTest.html
@@ -148,3 +148,13 @@
     <div style="height: 10px; width: 10px; align-content:stretch;"></div>
   </div>
 </div>
+
+<div id="align_content_not_stretch_with_align_items_stretch"
+  style="width: 328px; height: 52px; flex-direction: row; align-content: flex-start; flex-wrap: wrap;">
+  <div>
+    <div style="width: 272px; height: 44px;"></div>
+  </div>
+  <div>
+    <div style="width: 56px; height: 44px;"></div>
+  </div>
+</div>

--- a/gentest/fixtures/YGAlignItemsTest.html
+++ b/gentest/fixtures/YGAlignItemsTest.html
@@ -2,6 +2,10 @@
   <div style="height: 10px;"></div>
 </div>
 
+<div id="align_items_stretch_min_cross" style="flex-direction: column; min-width: 400px; min-height: 50px;">
+  <div style="flex-shrink: 0; height: 36px;"></div>
+</div>
+
 <div id="align_items_center" style="width: 100px; height: 100px; align-items: center;">
   <div style="height: 10px; width: 10px;"></div>
 </div>
@@ -111,7 +115,8 @@
   <div style="width: 50px; height: 50px;"></div>
 </div>
 
-<div id="align_baseline_multiline_column" style="width: 100px; height: 100px; flex-direction:column; align-items: baseline;flex-wrap:wrap;">
+<!-- Broken after Chrome behavior change -->
+<!-- <div id="align_baseline_multiline_column" style="width: 100px; height: 100px; flex-direction:column; align-items: baseline;flex-wrap:wrap;">
   <div style="width: 50px; height: 50px;"></div>
   <div style="width: 30px; height: 50px;">
     <div style="width: 20px; height: 20px;"></div>
@@ -120,9 +125,10 @@
     <div style="width: 10px; height: 10px;"></div>
   </div>
   <div style="width: 50px; height: 20px;"></div>
-</div>
+</div> -->
 
-<div id="align_baseline_multiline_column2" style="width: 100px; height: 100px; flex-direction:column; align-items: baseline;flex-wrap:wrap;">
+<!-- Broken after Chrome behavior change -->
+<!-- <div id="align_baseline_multiline_column2" style="width: 100px; height: 100px; flex-direction:column; align-items: baseline;flex-wrap:wrap;">
   <div style="width: 50px; height: 50px;flex-direction:column;"></div>
   <div style="width: 30px; height: 50px;flex-direction:column;">
     <div style="width: 20px; height: 20px;flex-direction:column;"></div>
@@ -131,7 +137,7 @@
     <div style="width: 10px; height: 10px;flex-direction:column;"></div>
   </div>
   <div style="width: 50px; height: 20px;flex-direction:column;"></div>
-</div>
+</div> -->
 
 <div id="align_baseline_multiline_row_and_column" style="width: 100px; height: 100px; flex-direction:row; align-items: baseline;flex-wrap:wrap;">
   <div style="width: 50px; height: 50px;"></div>
@@ -204,6 +210,32 @@
   <div style="align-items: flex-start;">
     <div style="flex-grow: 1; flex-shrink: 1; align-items: stretch;">
       <div style="flex-grow: 1; flex-shrink: 1;"></div>
+    </div>
+  </div>
+</div>
+
+<div id="align_items_center_justify_content_center" style="height: 500px; width: 500px">
+  <div style="align-items: center; justify-content: center; height: 50px">
+    <div style="align-items: center; justify-content: center; height: 100%; margin-left: 10px; margin-right: 10px;">
+      <div style="width: 10px; height: 10px;">
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="align_baseline_child_margin_percent" style="width: 100px; height: 100px; flex-direction:row; align-items: baseline;">
+  <div style="width: 50px; height: 50px;margin: 5%;"></div>
+  <div style="width: 50px; height: 20px;">
+    <div style="width: 50px; height: 10px;margin: 1%;"></div>
+  </div>
+</div>
+
+<div id="align_baseline_nested_column" style="width: 100px; height: 100px; flex-direction: row; align-items: baseline;">
+  <div style="width: 50px; height: 60px;"></div>
+  <div>
+    <div style="width: 50px; height: 80px; flex-direction: column;">
+      <div style="width: 50px; height: 30px;"></div>
+      <div style="width: 50px; height: 40px;"></div>
     </div>
   </div>
 </div>

--- a/gentest/fixtures/YGAlignSelfTest.html
+++ b/gentest/fixtures/YGAlignSelfTest.html
@@ -2,6 +2,11 @@
   <div style="height: 10px; width: 10px; align-self: center;"></div>
 </div>
 
+<div id="align_self_center_undefined_max_height" style="width: 280px; min-height: 52px; flex-direction: row;">
+  <div style="height: 44px; width: 240px;"></div>
+  <div style="height: 56px; width: 40px; align-self: center;"></div>
+</div>
+
 <div id="align_self_flex_end" style="width:100px; height: 100px;">
   <div style="height: 10px; width: 10px; align-self: flex-end;"></div>
 </div>

--- a/gentest/fixtures/YGBorderTest.html
+++ b/gentest/fixtures/YGBorderTest.html
@@ -13,6 +13,6 @@
   <div style="height: 10px;"></div>
 </div>
 
-<div id="border_center_child" style="width: 100px; height: 100px; border-start-width: 10px; border-top-width: 10; border-end-width: 20px; border-bottom-width: 20px; align-items: center; justify-content: center;">
+<div id="border_center_child" style="width: 100px; height: 100px; border-inline-start-width: 10px; border-top-width: 10; border-inline-end-width: 20px; border-bottom-width: 20px; align-items: center; justify-content: center;">
   <div style="height: 10px; width: 10px;"></div>
 </div>

--- a/gentest/fixtures/YGDisplayTest.html
+++ b/gentest/fixtures/YGDisplayTest.html
@@ -29,3 +29,8 @@
 <div id="display_none_with_position_absolute" style="width: 100px; height: 100px;">
   <div style="display:none; position: absolute; width: 100px; height: 100px"></div>
 </div>
+
+<div id="display_none_absolute_child" style="width: 100px; height: 100px; flex-direction: row;">
+  <div style="flex-grow: 1;"></div>
+  <div style="width: 20px; height: 20px; position: absolute; left: 10px; top: 10px; display:none;"></div>
+</div>

--- a/gentest/fixtures/YGFlexDirectionTest.html
+++ b/gentest/fixtures/YGFlexDirectionTest.html
@@ -33,3 +33,9 @@
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
+
+<div id="flex_direction_column_reverse_no_height" style="width: 100px; flex-direction: column-reverse;">
+  <div style="height: 10px;"></div>
+  <div style="height: 10px;"></div>
+  <div style="height: 10px;"></div>
+</div>

--- a/gentest/fixtures/YGFlexTest.html
+++ b/gentest/fixtures/YGFlexTest.html
@@ -51,3 +51,21 @@
   <div style="flex-grow:0.2; flex-shrink:0;"></div>
   <div style="flex-grow:0.4; flex-shrink:0;"></div>
 </div>
+
+<div id="single_flex_child_after_absolute_child" style="width: 428px; height: 845px">
+  <div style="width: 100%; height: 100%; position: absolute;"></div>
+  <div style="flex-grow: 1; flex-shrink: 1;"></div>
+  <div style="flex-shrink: 0; flex-basis: 174px;"></div>
+</div>
+
+<div id="flex_basis_zero_undefined_main_size" style="flex-direction: row;">
+  <div style="flex-basis: 0px;">
+    <div style="width: 100px; height: 50px;"></div>
+  </div>
+</div>
+
+<div id="only_shrinkable_item_with_flex_basis_zero" style="flex-direction: column; width: 480px; max-height: 764px;">
+  <div style="flex-basis: 0px; flex-shrink: 1;"></div>
+  <div style="margin-bottom: 6px; flex-shrink: 0; flex-basis: 93px;"></div>
+  <div style="flex-shrink: 0; flex-basis: 764px;"></div>
+</div>

--- a/gentest/fixtures/YGMarginTest.html
+++ b/gentest/fixtures/YGMarginTest.html
@@ -1,5 +1,5 @@
 <div id="margin_start" style="width: 100px; height: 100px; flex-direction: row;">
-  <div style="width: 10px; margin-start: 10px;"></div>
+  <div style="width: 10px; margin-inline-start: 10px;"></div>
 </div>
 
 <div id="margin_top" style="width: 100px; height: 100px;">
@@ -7,7 +7,7 @@
 </div>
 
 <div id="margin_end" style="width: 100px; height: 100px; flex-direction: row; justify-content: flex-end;">
-  <div style="width: 10px; margin-end: 10px;"></div>
+  <div style="width: 10px; margin-inline-end: 10px;"></div>
 </div>
 
 <div id="margin_bottom" style="width: 100px; height: 100px; justify-content: flex-end;">
@@ -15,7 +15,7 @@
 </div>
 
 <div id="margin_and_flex_row" style="width: 100px; height: 100px; flex-direction: row;">
-  <div style="margin-start: 10px; margin-end: 10px; flex-grow: 1;"></div>
+  <div style="margin-inline-start: 10px; margin-inline-end: 10px; flex-grow: 1;"></div>
 </div>
 
 <div id="margin_and_flex_column" style="width: 100px; height: 100px;">
@@ -27,11 +27,11 @@
 </div>
 
 <div id="margin_and_stretch_column" style="width: 100px; height: 100px;">
-  <div style="margin-start: 10px; margin-end: 10px; flex-grow: 1;"></div>
+  <div style="margin-inline-start: 10px; margin-inline-end: 10px; flex-grow: 1;"></div>
 </div>
 
 <div id="margin_with_sibling_row" style="width: 100px; height: 100px; flex-direction: row;">
-  <div style="margin-end: 10px; flex-grow: 1;"></div>
+  <div style="margin-inline-end: 10px; flex-grow: 1;"></div>
   <div style="flex-grow: 1;"></div>
 </div>
 
@@ -83,12 +83,12 @@
 </div>
 
 <div id="margin_auto_start_and_end_column" style="width: 200px; height: 200px; align-items: center; flex-direction: row;">
-  <div style="width: 50px; height: 50px; margin-start: auto; margin-end: auto;"></div>
+  <div style="width: 50px; height: 50px; margin-inline-start: auto; margin-inline-end: auto;"></div>
   <div style="width: 50px; height: 50px;"></div>
 </div>
 
 <div id="margin_auto_start_and_end" style="width: 200px; height: 200px; ">
-  <div style="width: 50px; height: 50px; margin-start: auto; margin-end: auto;"></div>
+  <div style="width: 50px; height: 50px; margin-inline-start: auto; margin-inline-end: auto;"></div>
   <div style="width: 50px; height: 50px;"></div>
 </div>
 

--- a/gentest/fixtures/YGMinMaxDimensionTest.html
+++ b/gentest/fixtures/YGMinMaxDimensionTest.html
@@ -2,8 +2,22 @@
   <div style="height: 10px; max-width: 50px;"></div>
 </div>
 
+<div id="min_width_larger_than_width" style="width: 100px; height: 100px;">
+  <div style="width: 25px; min-width: 50px;"></div>
+</div>
+
+<div id="min_height_larger_than_height" style="width: 100px; height: 100px; flex-direction: row;">
+  <div style="height: 25px; min-height: 50px;"></div>
+</div>
+
 <div id="max_height" style="width: 100px; height: 100px; flex-direction: row;">
   <div style="width: 10px; max-height: 50px;"></div>
+</div>
+
+<div id="min_height_with_nested_fixed_height" style="width: 320px; min-height: 44px; flex-direction: row; padding-left: 16px; padding-right: 16px;">
+  <div style="min-height: 28px; align-self: flex-start; flex-shrink: 0; margin-bottom: 9px; margin-top: 8px;">
+    <div style="width: 40px; height: 40px;"></div>
+  </div>
 </div>
 
 <!-- Chrome and Yoga disagree on the correct output -->
@@ -28,6 +42,11 @@
 
 <div id="align_items_min_max" style="max-width: 200px; min-width: 100px; height: 100px; align-items: center;">
   <div style="width: 60px; height: 60px;"></div>
+</div>
+
+<div id="align_items_center_min_max_with_padding"
+  style="flex-direction: row; max-width: 320px; min-width: 320px; min-height: 72px; max-height: 504px; align-items: center; padding-top: 8px; padding-bottom: 8px;">
+  <div style="width: 62px; height: 62px;"></div>
 </div>
 
 <div id="justify_content_overflow_min_max" style="min-height: 100px; max-height: 110px; justify-content: center;">
@@ -128,5 +147,24 @@
 
 <div id="min_max_percent_no_width_height" style="width: 100px; height: 100px; align-items: flex-start;">
   <div style="min-width: 10%; max-width: 10%; min-height: 10%; max-height: 10%;">
+  </div>
+</div>
+
+<div id="min_max_percent_different_width_height" style="width: 100px; height: 200px; align-items: flex-start;">
+  <div style="min-width: 10%; max-width: 10%; min-height: 10%; max-height: 10%;">
+  </div>
+</div>
+
+<div id="undefined_height_with_min_max" style="width: 320px; min-height: 0px;">
+  <div style="min-height: 0px; max-height: 100px;"></div>
+</div>
+
+<div id="undefined_width_with_min_max" style="height: 50px;">
+  <div style="min-width: 0px; max-width: 100px;"></div>
+</div>
+
+<div id="undefined_width_with_min_max_row" style="height: 50px; flex-direction: row;">
+  <div style="min-width: 60px; max-width: 300px;">
+    <div style="width: 30px; height: 20px;"></div>
   </div>
 </div>

--- a/gentest/fixtures/YGPaddingTest.html
+++ b/gentest/fixtures/YGPaddingTest.html
@@ -13,7 +13,7 @@
   <div style="height: 10px;"></div>
 </div>
 
-<div id="padding_center_child" style="width: 100px; height: 100px; padding-start: 10px; padding-top: 10; padding-end: 20px; padding-bottom: 20px; align-items: center; justify-content: center;">
+<div id="padding_center_child" style="width: 100px; height: 100px; padding-inline-start: 10px; padding-top: 10; padding-inline-end: 20px; padding-bottom: 20px; align-items: center; justify-content: center;">
   <div style="height: 10px; width: 10px;"></div>
 </div>
 

--- a/gentest/fixtures/YGPercentageTest.html
+++ b/gentest/fixtures/YGPercentageTest.html
@@ -59,6 +59,13 @@
   <div style="flex-grow: 4; flex-basis: 15%; min-width: 20%;"></div>
 </div>
 
+<div id="percentage_main_max_height" style="width: 71px;">
+  <div style="align-items: flex-start; height: 151px;">
+    <div style="flex-basis: 15px;"></div>
+    <div style="flex-basis: 48px; max-height: 33%;"></div>
+  </div>
+</div>
+
 <div id="percentage_multiple_nested_with_padding_margin_and_percentage_values" style="width: 200px; height: 200px; flex-direction: column;">
   <div style="flex-grow: 1; flex-basis: 10%; min-width: 60%; margin: 5px; padding: 3px;">
     <div style="width: 50%; margin: 5px; padding: 3%;">
@@ -91,14 +98,14 @@
 <div id="percent_within_flex_grow" style="flex-direction:row; width: 350px; height: 100px; align-items: stretch; ">
   <div style="width:100px;"></div>
   <div style="flex-grow: 1;">
-      <div style="width:100%;"></div>
+    <div style="width:100%;"></div>
   </div>
   <div style="width: 100px;"></div>
 </div>
 
 <div id="percentage_container_in_wrapping_container" style="align-items: center; width: 200px; height: 200px; justify-content: center;">
   <div>
-    <div style="alignItems: center; flex-direction: row; justify-content: center; width: 100%;">
+    <div style="align-items: center; flex-direction: row; justify-content: center; width: 100%;">
       <div style="width: 50px; height: 50px;"></div>
       <div style="width: 50px; height: 50px;"></div>
     </div>
@@ -110,4 +117,14 @@
     <div style="width: 100%;"></div>
     <div style="width: 100%;"></div>
   </div>
+</div>
+
+<div id="percentage_different_width_height" style="width: 200px; height: 300px; flex-direction: row;">
+  <div style="height: 30%; flex-grow: 1"></div>
+  <div style="height: 30%;"></div>
+</div>
+
+<div id="percentage_different_width_height_column" style="width: 200px; height: 300px; flex-direction: column;">
+  <div style="flex-grow: 1"></div>
+  <div style="height: 30%;"></div>
 </div>

--- a/java/tests/com/facebook/yoga/YGAbsolutePositionTest.java
+++ b/java/tests/com/facebook/yoga/YGAbsolutePositionTest.java
@@ -34,7 +34,6 @@ public class YGAbsolutePositionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setPositionType(YogaPositionType.ABSOLUTE);
-    root_child0.setPosition(YogaEdge.START, 10f);
     root_child0.setPosition(YogaEdge.TOP, 10f);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
@@ -47,7 +46,7 @@ public class YGAbsolutePositionTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(10f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
@@ -60,7 +59,7 @@ public class YGAbsolutePositionTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
     assertEquals(10f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
@@ -76,7 +75,6 @@ public class YGAbsolutePositionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setPositionType(YogaPositionType.ABSOLUTE);
-    root_child0.setPosition(YogaEdge.END, 10f);
     root_child0.setPosition(YogaEdge.BOTTOM, 10f);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
@@ -89,7 +87,7 @@ public class YGAbsolutePositionTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(80f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
@@ -102,7 +100,49 @@ public class YGAbsolutePositionTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(80f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_absolute_layout_row_width_height_end_bottom() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setPosition(YogaEdge.BOTTOM, 10f);
+    root_child0.setWidth(10f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(80f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
     assertEquals(80f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
@@ -118,9 +158,7 @@ public class YGAbsolutePositionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setPositionType(YogaPositionType.ABSOLUTE);
-    root_child0.setPosition(YogaEdge.START, 10f);
     root_child0.setPosition(YogaEdge.TOP, 10f);
-    root_child0.setPosition(YogaEdge.END, 10f);
     root_child0.setPosition(YogaEdge.BOTTOM, 10f);
     root.addChildAt(root_child0, 0);
     root.setDirection(YogaDirection.LTR);
@@ -131,9 +169,9 @@ public class YGAbsolutePositionTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(10f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(80f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(80f, root_child0.getLayoutHeight(), 0.0f);
 
     root.setDirection(YogaDirection.RTL);
@@ -144,9 +182,9 @@ public class YGAbsolutePositionTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutX(), 0.0f);
     assertEquals(10f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(80f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(80f, root_child0.getLayoutHeight(), 0.0f);
   }
 
@@ -160,9 +198,7 @@ public class YGAbsolutePositionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setPositionType(YogaPositionType.ABSOLUTE);
-    root_child0.setPosition(YogaEdge.START, 10f);
     root_child0.setPosition(YogaEdge.TOP, 10f);
-    root_child0.setPosition(YogaEdge.END, 10f);
     root_child0.setPosition(YogaEdge.BOTTOM, 10f);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
@@ -175,7 +211,7 @@ public class YGAbsolutePositionTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(10f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
@@ -188,7 +224,7 @@ public class YGAbsolutePositionTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
     assertEquals(10f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
@@ -206,7 +242,6 @@ public class YGAbsolutePositionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setPositionType(YogaPositionType.ABSOLUTE);
-    root_child0.setPosition(YogaEdge.START, 0f);
     root_child0.setPosition(YogaEdge.TOP, 0f);
     root.addChildAt(root_child0, 0);
 
@@ -1021,6 +1056,225 @@ public class YGAbsolutePositionTest {
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
     assertEquals(20f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(20f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_absolute_layout_percentage_height() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setWidth(200f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setPosition(YogaEdge.TOP, 10f);
+    root_child0.setWidth(10f);
+    root_child0.setHeightPercent(50f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(200f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(200f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(190f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_absolute_child_with_cross_margin() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setJustifyContent(YogaJustify.SPACE_BETWEEN);
+    root.setMinWidth(311f);
+    root.setMaxWidth(311f);
+    root.setMaxHeight(3.68935e+19f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW);
+    root_child0.setAlignContent(YogaAlign.STRETCH);
+    root_child0.setWidth(28f);
+    root_child0.setHeight(27f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setFlexDirection(YogaFlexDirection.ROW);
+    root_child1.setAlignContent(YogaAlign.STRETCH);
+    root_child1.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child1.setFlexShrink(1f);
+    root_child1.setMargin(YogaEdge.TOP, 4f);
+    root_child1.setWidthPercent(100f);
+    root_child1.setHeight(15f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = createNode(config);
+    root_child2.setFlexDirection(YogaFlexDirection.ROW);
+    root_child2.setAlignContent(YogaAlign.STRETCH);
+    root_child2.setWidth(25f);
+    root_child2.setHeight(27f);
+    root.addChildAt(root_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(311f, root.getLayoutWidth(), 0.0f);
+    assertEquals(27f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(28f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(27f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(4f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(311f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(15f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(286f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(27f, root_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(311f, root.getLayoutWidth(), 0.0f);
+    assertEquals(27f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(283f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(28f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(27f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(4f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(311f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(15f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(25f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(27f, root_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_absolute_child_with_main_margin() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setWidth(20f);
+    root.setHeight(37f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setMargin(YogaEdge.LEFT, 7f);
+    root_child0.setWidth(9f);
+    root_child0.setHeight(9f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(20f, root.getLayoutWidth(), 0.0f);
+    assertEquals(37f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(7f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(9f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(9f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(20f, root.getLayoutWidth(), 0.0f);
+    assertEquals(37f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(11f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(9f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(9f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_absolute_child_with_max_height() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setWidth(100f);
+    root.setHeight(200f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setPosition(YogaEdge.BOTTOM, 20f);
+    root_child0.setMaxHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidth(100f);
+    root_child0_child0.setHeight(30f);
+    root_child0.addChildAt(root_child0_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(200f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(150f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(200f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(150f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child0_child0.getLayoutHeight(), 0.0f);
   }
 
   private YogaNode createNode(YogaConfig config) {

--- a/java/tests/com/facebook/yoga/YGAlignContentTest.java
+++ b/java/tests/com/facebook/yoga/YGAlignContentTest.java
@@ -1872,6 +1872,88 @@ public class YGAlignContentTest {
     assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
   }
 
+  @Test
+  public void test_align_content_not_stretch_with_align_items_stretch() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setWrap(YogaWrap.WRAP);
+    root.setWidth(328f);
+    root.setHeight(52f);
+
+    final YogaNode root_child0 = createNode(config);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidth(272f);
+    root_child0_child0.setHeight(44f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child1_child0 = createNode(config);
+    root_child1_child0.setWidth(56f);
+    root_child1_child0.setHeight(44f);
+    root_child1.addChildAt(root_child1_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(328f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(272f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(44f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(272f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(44f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(272f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(56f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(44f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(56f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(44f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(328f, root.getLayoutWidth(), 0.0f);
+    assertEquals(52f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(56f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(272f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(44f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(272f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(44f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(56f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(44f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(56f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(44f, root_child1_child0.getLayoutHeight(), 0.0f);
+  }
+
   private YogaNode createNode(YogaConfig config) {
     return mNodeFactory.create(config);
   }

--- a/java/tests/com/facebook/yoga/YGAlignItemsTest.java
+++ b/java/tests/com/facebook/yoga/YGAlignItemsTest.java
@@ -63,6 +63,44 @@ public class YGAlignItemsTest {
   }
 
   @Test
+  public void test_align_items_stretch_min_cross() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setMinWidth(400f);
+    root.setMinHeight(50f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setHeight(36f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(400f, root.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(400f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(36f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(400f, root.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(400f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(36f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
   public void test_align_items_center() {
     YogaConfig config = YogaConfigFactory.create();
 
@@ -1227,238 +1265,6 @@ public class YGAlignItemsTest {
   }
 
   @Test
-  public void test_align_baseline_multiline_column() {
-    YogaConfig config = YogaConfigFactory.create();
-
-    final YogaNode root = createNode(config);
-    root.setAlignItems(YogaAlign.BASELINE);
-    root.setWrap(YogaWrap.WRAP);
-    root.setWidth(100f);
-    root.setHeight(100f);
-
-    final YogaNode root_child0 = createNode(config);
-    root_child0.setWidth(50f);
-    root_child0.setHeight(50f);
-    root.addChildAt(root_child0, 0);
-
-    final YogaNode root_child1 = createNode(config);
-    root_child1.setWidth(30f);
-    root_child1.setHeight(50f);
-    root.addChildAt(root_child1, 1);
-
-    final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setWidth(20f);
-    root_child1_child0.setHeight(20f);
-    root_child1.addChildAt(root_child1_child0, 0);
-
-    final YogaNode root_child2 = createNode(config);
-    root_child2.setWidth(40f);
-    root_child2.setHeight(70f);
-    root.addChildAt(root_child2, 2);
-
-    final YogaNode root_child2_child0 = createNode(config);
-    root_child2_child0.setWidth(10f);
-    root_child2_child0.setHeight(10f);
-    root_child2.addChildAt(root_child2_child0, 0);
-
-    final YogaNode root_child3 = createNode(config);
-    root_child3.setWidth(50f);
-    root_child3.setHeight(20f);
-    root.addChildAt(root_child3, 3);
-    root.setDirection(YogaDirection.LTR);
-    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
-
-    assertEquals(0f, root.getLayoutX(), 0.0f);
-    assertEquals(0f, root.getLayoutY(), 0.0f);
-    assertEquals(100f, root.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root.getLayoutHeight(), 0.0f);
-
-    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
-    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
-
-    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(50f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(50f, root_child1.getLayoutHeight(), 0.0f);
-
-    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
-    assertEquals(20f, root_child1_child0.getLayoutWidth(), 0.0f);
-    assertEquals(20f, root_child1_child0.getLayoutHeight(), 0.0f);
-
-    assertEquals(50f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(40f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(70f, root_child2.getLayoutHeight(), 0.0f);
-
-    assertEquals(0f, root_child2_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2_child0.getLayoutWidth(), 0.0f);
-    assertEquals(10f, root_child2_child0.getLayoutHeight(), 0.0f);
-
-    assertEquals(50f, root_child3.getLayoutX(), 0.0f);
-    assertEquals(70f, root_child3.getLayoutY(), 0.0f);
-    assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
-    assertEquals(20f, root_child3.getLayoutHeight(), 0.0f);
-
-    root.setDirection(YogaDirection.RTL);
-    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
-
-    assertEquals(0f, root.getLayoutX(), 0.0f);
-    assertEquals(0f, root.getLayoutY(), 0.0f);
-    assertEquals(100f, root.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root.getLayoutHeight(), 0.0f);
-
-    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
-    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
-
-    assertEquals(70f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(50f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(50f, root_child1.getLayoutHeight(), 0.0f);
-
-    assertEquals(10f, root_child1_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
-    assertEquals(20f, root_child1_child0.getLayoutWidth(), 0.0f);
-    assertEquals(20f, root_child1_child0.getLayoutHeight(), 0.0f);
-
-    assertEquals(10f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(40f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(70f, root_child2.getLayoutHeight(), 0.0f);
-
-    assertEquals(30f, root_child2_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2_child0.getLayoutWidth(), 0.0f);
-    assertEquals(10f, root_child2_child0.getLayoutHeight(), 0.0f);
-
-    assertEquals(0f, root_child3.getLayoutX(), 0.0f);
-    assertEquals(70f, root_child3.getLayoutY(), 0.0f);
-    assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
-    assertEquals(20f, root_child3.getLayoutHeight(), 0.0f);
-  }
-
-  @Test
-  public void test_align_baseline_multiline_column2() {
-    YogaConfig config = YogaConfigFactory.create();
-
-    final YogaNode root = createNode(config);
-    root.setAlignItems(YogaAlign.BASELINE);
-    root.setWrap(YogaWrap.WRAP);
-    root.setWidth(100f);
-    root.setHeight(100f);
-
-    final YogaNode root_child0 = createNode(config);
-    root_child0.setWidth(50f);
-    root_child0.setHeight(50f);
-    root.addChildAt(root_child0, 0);
-
-    final YogaNode root_child1 = createNode(config);
-    root_child1.setWidth(30f);
-    root_child1.setHeight(50f);
-    root.addChildAt(root_child1, 1);
-
-    final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setWidth(20f);
-    root_child1_child0.setHeight(20f);
-    root_child1.addChildAt(root_child1_child0, 0);
-
-    final YogaNode root_child2 = createNode(config);
-    root_child2.setWidth(40f);
-    root_child2.setHeight(70f);
-    root.addChildAt(root_child2, 2);
-
-    final YogaNode root_child2_child0 = createNode(config);
-    root_child2_child0.setWidth(10f);
-    root_child2_child0.setHeight(10f);
-    root_child2.addChildAt(root_child2_child0, 0);
-
-    final YogaNode root_child3 = createNode(config);
-    root_child3.setWidth(50f);
-    root_child3.setHeight(20f);
-    root.addChildAt(root_child3, 3);
-    root.setDirection(YogaDirection.LTR);
-    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
-
-    assertEquals(0f, root.getLayoutX(), 0.0f);
-    assertEquals(0f, root.getLayoutY(), 0.0f);
-    assertEquals(100f, root.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root.getLayoutHeight(), 0.0f);
-
-    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
-    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
-
-    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(50f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(50f, root_child1.getLayoutHeight(), 0.0f);
-
-    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
-    assertEquals(20f, root_child1_child0.getLayoutWidth(), 0.0f);
-    assertEquals(20f, root_child1_child0.getLayoutHeight(), 0.0f);
-
-    assertEquals(50f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(40f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(70f, root_child2.getLayoutHeight(), 0.0f);
-
-    assertEquals(0f, root_child2_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2_child0.getLayoutWidth(), 0.0f);
-    assertEquals(10f, root_child2_child0.getLayoutHeight(), 0.0f);
-
-    assertEquals(50f, root_child3.getLayoutX(), 0.0f);
-    assertEquals(70f, root_child3.getLayoutY(), 0.0f);
-    assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
-    assertEquals(20f, root_child3.getLayoutHeight(), 0.0f);
-
-    root.setDirection(YogaDirection.RTL);
-    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
-
-    assertEquals(0f, root.getLayoutX(), 0.0f);
-    assertEquals(0f, root.getLayoutY(), 0.0f);
-    assertEquals(100f, root.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root.getLayoutHeight(), 0.0f);
-
-    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
-    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
-
-    assertEquals(70f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(50f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(30f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(50f, root_child1.getLayoutHeight(), 0.0f);
-
-    assertEquals(10f, root_child1_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
-    assertEquals(20f, root_child1_child0.getLayoutWidth(), 0.0f);
-    assertEquals(20f, root_child1_child0.getLayoutHeight(), 0.0f);
-
-    assertEquals(10f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(40f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(70f, root_child2.getLayoutHeight(), 0.0f);
-
-    assertEquals(30f, root_child2_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2_child0.getLayoutWidth(), 0.0f);
-    assertEquals(10f, root_child2_child0.getLayoutHeight(), 0.0f);
-
-    assertEquals(0f, root_child3.getLayoutX(), 0.0f);
-    assertEquals(70f, root_child3.getLayoutY(), 0.0f);
-    assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
-    assertEquals(20f, root_child3.getLayoutHeight(), 0.0f);
-  }
-
-  @Test
   public void test_align_baseline_multiline_row_and_column() {
     YogaConfig config = YogaConfigFactory.create();
 
@@ -2141,6 +1947,257 @@ public class YGAlignItemsTest {
     assertEquals(0f, root_child0_child0_child0.getLayoutY(), 0.0f);
     assertEquals(0f, root_child0_child0_child0.getLayoutWidth(), 0.0f);
     assertEquals(0f, root_child0_child0_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_items_center_justify_content_center() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setWidth(500f);
+    root.setHeight(500f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0.setAlignItems(YogaAlign.CENTER);
+    root_child0.setHeight(50f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0_child0.setAlignItems(YogaAlign.CENTER);
+    root_child0_child0.setMargin(YogaEdge.LEFT, 10f);
+    root_child0_child0.setMargin(YogaEdge.RIGHT, 10f);
+    root_child0_child0.setHeightPercent(100f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0.setWidth(10f);
+    root_child0_child0_child0.setHeight(10f);
+    root_child0_child0.addChildAt(root_child0_child0_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(500f, root.getLayoutWidth(), 0.0f);
+    assertEquals(500f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(500f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(245f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child0_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(500f, root.getLayoutWidth(), 0.0f);
+    assertEquals(500f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(500f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(245f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child0_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_baseline_child_margin_percent() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignItems(YogaAlign.BASELINE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setMarginPercent(YogaEdge.LEFT, 5f);
+    root_child0.setMarginPercent(YogaEdge.TOP, 5f);
+    root_child0.setMarginPercent(YogaEdge.RIGHT, 5f);
+    root_child0.setMarginPercent(YogaEdge.BOTTOM, 5f);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(50f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(20f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child1_child0 = createNode(config);
+    root_child1_child0.setMarginPercent(YogaEdge.LEFT, 1f);
+    root_child1_child0.setMarginPercent(YogaEdge.TOP, 1f);
+    root_child1_child0.setMarginPercent(YogaEdge.RIGHT, 1f);
+    root_child1_child0.setMarginPercent(YogaEdge.BOTTOM, 1f);
+    root_child1_child0.setWidth(50f);
+    root_child1_child0.setHeight(10f);
+    root_child1.addChildAt(root_child1_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(5f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(5f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(45f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(1f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(1f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(45f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(5f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(-10f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(45f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(1f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_baseline_nested_column() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignItems(YogaAlign.BASELINE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(60f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child1_child0 = createNode(config);
+    root_child1_child0.setWidth(50f);
+    root_child1_child0.setHeight(80f);
+    root_child1.addChildAt(root_child1_child0, 0);
+
+    final YogaNode root_child1_child0_child0 = createNode(config);
+    root_child1_child0_child0.setWidth(50f);
+    root_child1_child0_child0.setHeight(30f);
+    root_child1_child0.addChildAt(root_child1_child0_child0, 0);
+
+    final YogaNode root_child1_child0_child1 = createNode(config);
+    root_child1_child0_child1.setWidth(50f);
+    root_child1_child0_child1.setHeight(40f);
+    root_child1_child0.addChildAt(root_child1_child0_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(80f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(80f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child1_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child1_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child1_child0_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(80f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0.getLayoutWidth(), 0.0f);
+    assertEquals(80f, root_child1_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root_child1_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child1_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child1_child0_child1.getLayoutHeight(), 0.0f);
   }
 
   private YogaNode createNode(YogaConfig config) {

--- a/java/tests/com/facebook/yoga/YGAlignSelfTest.java
+++ b/java/tests/com/facebook/yoga/YGAlignSelfTest.java
@@ -65,6 +65,62 @@ public class YGAlignSelfTest {
   }
 
   @Test
+  public void test_align_self_center_undefined_max_height() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setWidth(280f);
+    root.setMinHeight(52f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(240f);
+    root_child0.setHeight(44f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setAlignSelf(YogaAlign.CENTER);
+    root_child1.setWidth(40f);
+    root_child1.setHeight(56f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(280f, root.getLayoutWidth(), 0.0f);
+    assertEquals(56f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(240f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(44f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(240f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(56f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(280f, root.getLayoutWidth(), 0.0f);
+    assertEquals(56f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(240f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(44f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(56f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
   public void test_align_self_flex_end() {
     YogaConfig config = YogaConfigFactory.create();
 

--- a/java/tests/com/facebook/yoga/YGBorderTest.java
+++ b/java/tests/com/facebook/yoga/YGBorderTest.java
@@ -183,8 +183,6 @@ public class YGBorderTest {
     final YogaNode root = createNode(config);
     root.setJustifyContent(YogaJustify.CENTER);
     root.setAlignItems(YogaAlign.CENTER);
-    root.setBorder(YogaEdge.START, 10f);
-    root.setBorder(YogaEdge.END, 20f);
     root.setBorder(YogaEdge.BOTTOM, 20f);
     root.setWidth(100f);
     root.setHeight(100f);
@@ -201,7 +199,7 @@ public class YGBorderTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(40f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(45f, root_child0.getLayoutX(), 0.0f);
     assertEquals(35f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
@@ -214,7 +212,7 @@ public class YGBorderTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(45f, root_child0.getLayoutX(), 0.0f);
     assertEquals(35f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);

--- a/java/tests/com/facebook/yoga/YGDisplayTest.java
+++ b/java/tests/com/facebook/yoga/YGDisplayTest.java
@@ -379,6 +379,64 @@ public class YGDisplayTest {
     assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
   }
 
+  @Test
+  public void test_display_none_absolute_child() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexGrow(1f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child1.setPosition(YogaEdge.LEFT, 10f);
+    root_child1.setPosition(YogaEdge.TOP, 10f);
+    root_child1.setWidth(20f);
+    root_child1.setHeight(20f);
+    root_child1.setDisplay(YogaDisplay.NONE);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
   private YogaNode createNode(YogaConfig config) {
     return mNodeFactory.create(config);
   }

--- a/java/tests/com/facebook/yoga/YGFlexDirectionTest.java
+++ b/java/tests/com/facebook/yoga/YGFlexDirectionTest.java
@@ -422,6 +422,72 @@ public class YGFlexDirectionTest {
     assertEquals(100f, root_child2.getLayoutHeight(), 0.0f);
   }
 
+  @Test
+  public void test_flex_direction_column_reverse_no_height() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
+    root.setWidth(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = createNode(config);
+    root_child2.setHeight(10f);
+    root.addChildAt(root_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(30f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
+  }
+
   private YogaNode createNode(YogaConfig config) {
     return mNodeFactory.create(config);
   }

--- a/java/tests/com/facebook/yoga/YGFlexTest.java
+++ b/java/tests/com/facebook/yoga/YGFlexTest.java
@@ -611,6 +611,195 @@ public class YGFlexTest {
     assertEquals(184f, root_child2.getLayoutHeight(), 0.0f);
   }
 
+  @Test
+  public void test_single_flex_child_after_absolute_child() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setWidth(428f);
+    root.setHeight(845f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0.setWidthPercent(100f);
+    root_child0.setHeightPercent(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setFlexGrow(1f);
+    root_child1.setFlexShrink(1f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = createNode(config);
+    root_child2.setFlexBasis(174f);
+    root.addChildAt(root_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(428f, root.getLayoutWidth(), 0.0f);
+    assertEquals(845f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(428f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(845f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(428f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(671f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(671f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(428f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(174f, root_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(428f, root.getLayoutWidth(), 0.0f);
+    assertEquals(845f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(428f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(845f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(428f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(671f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(671f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(428f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(174f, root_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_basis_zero_undefined_main_size() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexBasis(0f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidth(100f);
+    root_child0_child0.setHeight(50f);
+    root_child0.addChildAt(root_child0_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_only_shrinkable_item_with_flex_basis_zero() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setWidth(480f);
+    root.setMaxHeight(764f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexShrink(1f);
+    root_child0.setFlexBasis(0f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setFlexBasis(93f);
+    root_child1.setMargin(YogaEdge.BOTTOM, 6f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = createNode(config);
+    root_child2.setFlexBasis(764f);
+    root.addChildAt(root_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(480f, root.getLayoutWidth(), 0.0f);
+    assertEquals(764f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(480f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(480f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(93f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(99f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(480f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(764f, root_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(480f, root.getLayoutWidth(), 0.0f);
+    assertEquals(764f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(480f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(480f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(93f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(99f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(480f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(764f, root_child2.getLayoutHeight(), 0.0f);
+  }
+
   private YogaNode createNode(YogaConfig config) {
     return mNodeFactory.create(config);
   }

--- a/java/tests/com/facebook/yoga/YGMarginTest.java
+++ b/java/tests/com/facebook/yoga/YGMarginTest.java
@@ -34,7 +34,6 @@ public class YGMarginTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setMargin(YogaEdge.START, 10f);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
     root.setDirection(YogaDirection.LTR);
@@ -45,7 +44,7 @@ public class YGMarginTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
@@ -58,7 +57,7 @@ public class YGMarginTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
@@ -114,7 +113,6 @@ public class YGMarginTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setMargin(YogaEdge.END, 10f);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
     root.setDirection(YogaDirection.LTR);
@@ -125,7 +123,7 @@ public class YGMarginTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
@@ -138,7 +136,7 @@ public class YGMarginTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
@@ -195,8 +193,6 @@ public class YGMarginTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexGrow(1f);
-    root_child0.setMargin(YogaEdge.START, 10f);
-    root_child0.setMargin(YogaEdge.END, 10f);
     root.addChildAt(root_child0, 0);
     root.setDirection(YogaDirection.LTR);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
@@ -206,9 +202,9 @@ public class YGMarginTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(80f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
     root.setDirection(YogaDirection.RTL);
@@ -219,9 +215,9 @@ public class YGMarginTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(80f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
   }
 
@@ -316,8 +312,6 @@ public class YGMarginTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexGrow(1f);
-    root_child0.setMargin(YogaEdge.START, 10f);
-    root_child0.setMargin(YogaEdge.END, 10f);
     root.addChildAt(root_child0, 0);
     root.setDirection(YogaDirection.LTR);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
@@ -327,9 +321,9 @@ public class YGMarginTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(80f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
     root.setDirection(YogaDirection.RTL);
@@ -340,9 +334,9 @@ public class YGMarginTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(80f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
   }
 
@@ -357,7 +351,6 @@ public class YGMarginTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexGrow(1f);
-    root_child0.setMargin(YogaEdge.END, 10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
@@ -373,12 +366,12 @@ public class YGMarginTest {
 
     assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(45f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(55f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
     assertEquals(0f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(45f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child1.getLayoutHeight(), 0.0f);
 
     root.setDirection(YogaDirection.RTL);
@@ -389,14 +382,14 @@ public class YGMarginTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(55f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(45f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child1.getLayoutX(), 0.0f);
     assertEquals(0f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(45f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child1.getLayoutHeight(), 0.0f);
   }
 
@@ -949,8 +942,6 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setMarginAuto(YogaEdge.START);
-    root_child0.setMarginAuto(YogaEdge.END);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
@@ -967,12 +958,12 @@ public class YGMarginTest {
     assertEquals(200f, root.getLayoutWidth(), 0.0f);
     assertEquals(200f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(75f, root_child0.getLayoutY(), 0.0f);
     assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(150f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
     assertEquals(75f, root_child1.getLayoutY(), 0.0f);
     assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
     assertEquals(50f, root_child1.getLayoutHeight(), 0.0f);
@@ -985,12 +976,12 @@ public class YGMarginTest {
     assertEquals(200f, root.getLayoutWidth(), 0.0f);
     assertEquals(200f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(100f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(150f, root_child0.getLayoutX(), 0.0f);
     assertEquals(75f, root_child0.getLayoutY(), 0.0f);
     assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child1.getLayoutX(), 0.0f);
     assertEquals(75f, root_child1.getLayoutY(), 0.0f);
     assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
     assertEquals(50f, root_child1.getLayoutHeight(), 0.0f);
@@ -1005,8 +996,6 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setMarginAuto(YogaEdge.START);
-    root_child0.setMarginAuto(YogaEdge.END);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
@@ -1023,7 +1012,7 @@ public class YGMarginTest {
     assertEquals(200f, root.getLayoutWidth(), 0.0f);
     assertEquals(200f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(75f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
     assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
@@ -1041,7 +1030,7 @@ public class YGMarginTest {
     assertEquals(200f, root.getLayoutWidth(), 0.0f);
     assertEquals(200f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(75f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(150f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
     assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);

--- a/java/tests/com/facebook/yoga/YGMinMaxDimensionTest.java
+++ b/java/tests/com/facebook/yoga/YGMinMaxDimensionTest.java
@@ -64,6 +64,85 @@ public class YGMinMaxDimensionTest {
   }
 
   @Test
+  public void test_min_width_larger_than_width() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(25f);
+    root_child0.setMinWidth(50f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_min_height_larger_than_height() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setHeight(25f);
+    root_child0.setMinHeight(50f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(100f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
   public void test_max_height() {
     YogaConfig config = YogaConfigFactory.create();
 
@@ -101,6 +180,65 @@ public class YGMinMaxDimensionTest {
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_min_height_with_nested_fixed_height() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setPadding(YogaEdge.LEFT, 16);
+    root.setPadding(YogaEdge.RIGHT, 16);
+    root.setWidth(320f);
+    root.setMinHeight(44f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setAlignSelf(YogaAlign.FLEX_START);
+    root_child0.setMargin(YogaEdge.TOP, 8f);
+    root_child0.setMargin(YogaEdge.BOTTOM, 9f);
+    root_child0.setMinHeight(28f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidth(40f);
+    root_child0_child0.setHeight(40f);
+    root_child0.addChildAt(root_child0_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(57f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(16f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(8f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(40f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(57f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(264f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(8f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(40f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(40f, root_child0_child0.getLayoutHeight(), 0.0f);
   }
 
   @Test
@@ -183,6 +321,51 @@ public class YGMinMaxDimensionTest {
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
     assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(60f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_items_center_min_max_with_padding() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignItems(YogaAlign.CENTER);
+    root.setPadding(YogaEdge.TOP, 8);
+    root.setPadding(YogaEdge.BOTTOM, 8);
+    root.setMinWidth(320f);
+    root.setMaxWidth(320f);
+    root.setMinHeight(72f);
+    root.setMaxHeight(504f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(62f);
+    root_child0.setHeight(62f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(78f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(8f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(62f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(62f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(78f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(258f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(8f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(62f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(62f, root_child0.getLayoutHeight(), 0.0f);
   }
 
   @Test
@@ -1175,6 +1358,176 @@ public class YGMinMaxDimensionTest {
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_min_max_percent_different_width_height() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setAlignItems(YogaAlign.FLEX_START);
+    root.setWidth(100f);
+    root.setHeight(200f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setMinWidthPercent(10f);
+    root_child0.setMaxWidthPercent(10f);
+    root_child0.setMinHeightPercent(10f);
+    root_child0.setMaxHeightPercent(10f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(200f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(200f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_undefined_height_with_min_max() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setWidth(320f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setMaxHeight(100f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(320f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(320f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_undefined_width_with_min_max() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setHeight(50f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setMaxWidth(100f);
+    root.addChildAt(root_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(0f, root.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(0f, root.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_undefined_width_with_min_max_row() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setHeight(50f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setMinWidth(60f);
+    root_child0.setMaxWidth(300f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidth(30f);
+    root_child0_child0.setHeight(20f);
+    root_child0.addChildAt(root_child0_child0, 0);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(60f, root.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(60f, root.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(30f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
   }
 
   private YogaNode createNode(YogaConfig config) {

--- a/java/tests/com/facebook/yoga/YGPaddingTest.java
+++ b/java/tests/com/facebook/yoga/YGPaddingTest.java
@@ -183,8 +183,6 @@ public class YGPaddingTest {
     final YogaNode root = createNode(config);
     root.setJustifyContent(YogaJustify.CENTER);
     root.setAlignItems(YogaAlign.CENTER);
-    root.setPadding(YogaEdge.START, 10);
-    root.setPadding(YogaEdge.END, 20);
     root.setPadding(YogaEdge.BOTTOM, 20);
     root.setWidth(100f);
     root.setHeight(100f);
@@ -201,7 +199,7 @@ public class YGPaddingTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(40f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(45f, root_child0.getLayoutX(), 0.0f);
     assertEquals(35f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
@@ -214,7 +212,7 @@ public class YGPaddingTest {
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(45f, root_child0.getLayoutX(), 0.0f);
     assertEquals(35f, root_child0.getLayoutY(), 0.0f);
     assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);

--- a/java/tests/com/facebook/yoga/YGPercentageTest.java
+++ b/java/tests/com/facebook/yoga/YGPercentageTest.java
@@ -597,6 +597,73 @@ public class YGPercentageTest {
   }
 
   @Test
+  public void test_percentage_main_max_height() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setWidth(71f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setAlignItems(YogaAlign.FLEX_START);
+    root_child0.setHeight(151f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setFlexBasis(15f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setFlexBasis(48f);
+    root_child0_child1.setMaxHeightPercent(33f);
+    root_child0.addChildAt(root_child0_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(71f, root.getLayoutWidth(), 0.0f);
+    assertEquals(151f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(71f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(151f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(15f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(15f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(48f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(71f, root.getLayoutWidth(), 0.0f);
+    assertEquals(151f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(71f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(151f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(71f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(15f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(71f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(15f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(48f, root_child0_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
   public void test_percentage_multiple_nested_with_padding_margin_and_percentage_values() {
     YogaConfig config = YogaConfigFactory.create();
 
@@ -994,6 +1061,7 @@ public class YGPercentageTest {
     final YogaNode root_child0_child0 = createNode(config);
     root_child0_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0_child0.setAlignItems(YogaAlign.CENTER);
     root_child0_child0.setWidthPercent(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
@@ -1131,6 +1199,112 @@ public class YGPercentageTest {
     assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
     assertEquals(60f, root_child0_child1.getLayoutWidth(), 0.0f);
     assertEquals(50f, root_child0_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_percentage_different_width_height() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setWidth(200f);
+    root.setHeight(300f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexGrow(1f);
+    root_child0.setHeightPercent(30f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setHeightPercent(30f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(200f, root.getLayoutWidth(), 0.0f);
+    assertEquals(300f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(200f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(200f, root.getLayoutWidth(), 0.0f);
+    assertEquals(300f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_percentage_different_width_height_column() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setWidth(200f);
+    root.setHeight(300f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexGrow(1f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setHeightPercent(30f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(200f, root.getLayoutWidth(), 0.0f);
+    assertEquals(300f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(210f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(210f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(200f, root.getLayoutWidth(), 0.0f);
+    assertEquals(300f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(210f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(210f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child1.getLayoutHeight(), 0.0f);
   }
 
   private YogaNode createNode(YogaConfig config) {

--- a/javascript/tests/Facebook.Yoga/YGAbsolutePositionTest.js
+++ b/javascript/tests/Facebook.Yoga/YGAbsolutePositionTest.js
@@ -19,7 +19,6 @@ it("absolute_layout_width_height_start_top", function () {
 
     var root_child0 = Yoga.Node.create(config);
     root_child0.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
-    root_child0.setPosition(Yoga.EDGE_START, 10);
     root_child0.setPosition(Yoga.EDGE_TOP, 10);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
@@ -31,7 +30,7 @@ it("absolute_layout_width_height_start_top", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(10 === root_child0.getComputedLeft(), "10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(10 === root_child0.getComputedTop(), "10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
@@ -43,7 +42,7 @@ it("absolute_layout_width_height_start_top", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(80 === root_child0.getComputedLeft(), "80 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(90 === root_child0.getComputedLeft(), "90 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(10 === root_child0.getComputedTop(), "10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
@@ -65,7 +64,6 @@ it("absolute_layout_width_height_end_bottom", function () {
 
     var root_child0 = Yoga.Node.create(config);
     root_child0.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
-    root_child0.setPosition(Yoga.EDGE_END, 10);
     root_child0.setPosition(Yoga.EDGE_BOTTOM, 10);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
@@ -77,7 +75,7 @@ it("absolute_layout_width_height_end_bottom", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(80 === root_child0.getComputedLeft(), "80 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(80 === root_child0.getComputedTop(), "80 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
@@ -89,7 +87,53 @@ it("absolute_layout_width_height_end_bottom", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(10 === root_child0.getComputedLeft(), "10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(90 === root_child0.getComputedLeft(), "90 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(80 === root_child0.getComputedTop(), "80 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("absolute_layout_row_width_height_end_bottom", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root_child0.setPosition(Yoga.EDGE_BOTTOM, 10);
+    root_child0.setWidth(10);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(80 === root_child0.getComputedTop(), "80 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(90 === root_child0.getComputedLeft(), "90 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(80 === root_child0.getComputedTop(), "80 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
@@ -111,9 +155,7 @@ it("absolute_layout_start_top_end_bottom", function () {
 
     var root_child0 = Yoga.Node.create(config);
     root_child0.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
-    root_child0.setPosition(Yoga.EDGE_START, 10);
     root_child0.setPosition(Yoga.EDGE_TOP, 10);
-    root_child0.setPosition(Yoga.EDGE_END, 10);
     root_child0.setPosition(Yoga.EDGE_BOTTOM, 10);
     root.insertChild(root_child0, 0);
     root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
@@ -123,9 +165,9 @@ it("absolute_layout_start_top_end_bottom", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(10 === root_child0.getComputedLeft(), "10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(10 === root_child0.getComputedTop(), "10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
-    console.assert(80 === root_child0.getComputedWidth(), "80 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(0 === root_child0.getComputedWidth(), "0 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(80 === root_child0.getComputedHeight(), "80 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
 
     root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
@@ -135,9 +177,9 @@ it("absolute_layout_start_top_end_bottom", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(10 === root_child0.getComputedLeft(), "10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(100 === root_child0.getComputedLeft(), "100 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(10 === root_child0.getComputedTop(), "10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
-    console.assert(80 === root_child0.getComputedWidth(), "80 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(0 === root_child0.getComputedWidth(), "0 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(80 === root_child0.getComputedHeight(), "80 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
   } finally {
     if (typeof root !== "undefined") {
@@ -157,9 +199,7 @@ it("absolute_layout_width_height_start_top_end_bottom", function () {
 
     var root_child0 = Yoga.Node.create(config);
     root_child0.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
-    root_child0.setPosition(Yoga.EDGE_START, 10);
     root_child0.setPosition(Yoga.EDGE_TOP, 10);
-    root_child0.setPosition(Yoga.EDGE_END, 10);
     root_child0.setPosition(Yoga.EDGE_BOTTOM, 10);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
@@ -171,7 +211,7 @@ it("absolute_layout_width_height_start_top_end_bottom", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(10 === root_child0.getComputedLeft(), "10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(10 === root_child0.getComputedTop(), "10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
@@ -183,7 +223,7 @@ it("absolute_layout_width_height_start_top_end_bottom", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(80 === root_child0.getComputedLeft(), "80 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(90 === root_child0.getComputedLeft(), "90 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(10 === root_child0.getComputedTop(), "10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
@@ -207,7 +247,6 @@ it("do_not_clamp_height_of_absolute_node_to_height_of_its_overflow_hidden_parent
 
     var root_child0 = Yoga.Node.create(config);
     root_child0.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
-    root_child0.setPosition(Yoga.EDGE_START, 0);
     root_child0.setPosition(Yoga.EDGE_TOP, 0);
     root.insertChild(root_child0, 0);
 
@@ -1084,6 +1123,241 @@ it("absolute_layout_in_wrap_reverse_row_container_flex_end", function () {
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(20 === root_child0.getComputedWidth(), "20 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(20 === root_child0.getComputedHeight(), "20 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("absolute_layout_percentage_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setWidth(200);
+    root.setHeight(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root_child0.setPosition(Yoga.EDGE_TOP, 10);
+    root_child0.setWidth(10);
+    root_child0.setHeight("50%");
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(200 === root.getComputedWidth(), "200 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(10 === root_child0.getComputedTop(), "10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(200 === root.getComputedWidth(), "200 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(190 === root_child0.getComputedLeft(), "190 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(10 === root_child0.getComputedTop(), "10 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("absolute_child_with_cross_margin", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setJustifyContent(Yoga.JUSTIFY_SPACE_BETWEEN);
+    root.setMinWidth(311);
+    root.setMaxWidth(311);
+    root.setMaxHeight(36893500000000000000);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root_child0.setAlignContent(Yoga.ALIGN_STRETCH);
+    root_child0.setWidth(28);
+    root_child0.setHeight(27);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root_child1.setAlignContent(Yoga.ALIGN_STRETCH);
+    root_child1.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root_child1.setFlexShrink(1);
+    root_child1.setMargin(Yoga.EDGE_TOP, 4);
+    root_child1.setWidth("100%");
+    root_child1.setHeight(15);
+    root.insertChild(root_child1, 1);
+
+    var root_child2 = Yoga.Node.create(config);
+    root_child2.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root_child2.setAlignContent(Yoga.ALIGN_STRETCH);
+    root_child2.setWidth(25);
+    root_child2.setHeight(27);
+    root.insertChild(root_child2, 2);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(311 === root.getComputedWidth(), "311 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(27 === root.getComputedHeight(), "27 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(28 === root_child0.getComputedWidth(), "28 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(27 === root_child0.getComputedHeight(), "27 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(4 === root_child1.getComputedTop(), "4 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(311 === root_child1.getComputedWidth(), "311 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(15 === root_child1.getComputedHeight(), "15 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(286 === root_child2.getComputedLeft(), "286 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(25 === root_child2.getComputedWidth(), "25 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(27 === root_child2.getComputedHeight(), "27 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(311 === root.getComputedWidth(), "311 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(27 === root.getComputedHeight(), "27 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(283 === root_child0.getComputedLeft(), "283 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(28 === root_child0.getComputedWidth(), "28 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(27 === root_child0.getComputedHeight(), "27 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(4 === root_child1.getComputedTop(), "4 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(311 === root_child1.getComputedWidth(), "311 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(15 === root_child1.getComputedHeight(), "15 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child2.getComputedLeft(), "0 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(25 === root_child2.getComputedWidth(), "25 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(27 === root_child2.getComputedHeight(), "27 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("absolute_child_with_main_margin", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setWidth(20);
+    root.setHeight(37);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root_child0.setMargin(Yoga.EDGE_LEFT, 7);
+    root_child0.setWidth(9);
+    root_child0.setHeight(9);
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(20 === root.getComputedWidth(), "20 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(37 === root.getComputedHeight(), "37 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(7 === root_child0.getComputedLeft(), "7 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(9 === root_child0.getComputedWidth(), "9 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(9 === root_child0.getComputedHeight(), "9 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(20 === root.getComputedWidth(), "20 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(37 === root.getComputedHeight(), "37 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(11 === root_child0.getComputedLeft(), "11 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(9 === root_child0.getComputedWidth(), "9 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(9 === root_child0.getComputedHeight(), "9 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("absolute_child_with_max_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setWidth(100);
+    root.setHeight(200);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root_child0.setPosition(Yoga.EDGE_BOTTOM, 20);
+    root_child0.setMaxHeight(100);
+    root.insertChild(root_child0, 0);
+
+    var root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth(100);
+    root_child0_child0.setHeight(30);
+    root_child0.insertChild(root_child0_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(200 === root.getComputedHeight(), "200 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(150 === root_child0.getComputedTop(), "150 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(100 === root_child0.getComputedWidth(), "100 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(30 === root_child0.getComputedHeight(), "30 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(100 === root_child0_child0.getComputedWidth(), "100 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(30 === root_child0_child0.getComputedHeight(), "30 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(200 === root.getComputedHeight(), "200 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(150 === root_child0.getComputedTop(), "150 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(100 === root_child0.getComputedWidth(), "100 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(30 === root_child0.getComputedHeight(), "30 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(100 === root_child0_child0.getComputedWidth(), "100 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(30 === root_child0_child0.getComputedHeight(), "30 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
   } finally {
     if (typeof root !== "undefined") {
       root.freeRecursive();

--- a/javascript/tests/Facebook.Yoga/YGAlignContentTest.js
+++ b/javascript/tests/Facebook.Yoga/YGAlignContentTest.js
@@ -1933,3 +1933,89 @@ it("align_content_stretch_is_not_overriding_align_items", function () {
     config.free();
   }
 });
+it("align_content_not_stretch_with_align_items_stretch", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setFlexWrap(Yoga.WRAP_WRAP);
+    root.setWidth(328);
+    root.setHeight(52);
+
+    var root_child0 = Yoga.Node.create(config);
+    root.insertChild(root_child0, 0);
+
+    var root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth(272);
+    root_child0_child0.setHeight(44);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root.insertChild(root_child1, 1);
+
+    var root_child1_child0 = Yoga.Node.create(config);
+    root_child1_child0.setWidth(56);
+    root_child1_child0.setHeight(44);
+    root_child1.insertChild(root_child1_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(328 === root.getComputedWidth(), "328 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(272 === root_child0.getComputedWidth(), "272 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(44 === root_child0.getComputedHeight(), "44 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(272 === root_child0_child0.getComputedWidth(), "272 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(44 === root_child0_child0.getComputedHeight(), "44 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    console.assert(272 === root_child1.getComputedLeft(), "272 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(56 === root_child1.getComputedWidth(), "56 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(44 === root_child1.getComputedHeight(), "44 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(56 === root_child1_child0.getComputedWidth(), "56 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(44 === root_child1_child0.getComputedHeight(), "44 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(328 === root.getComputedWidth(), "328 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(52 === root.getComputedHeight(), "52 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(56 === root_child0.getComputedLeft(), "56 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(272 === root_child0.getComputedWidth(), "272 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(44 === root_child0.getComputedHeight(), "44 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(272 === root_child0_child0.getComputedWidth(), "272 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(44 === root_child0_child0.getComputedHeight(), "44 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(56 === root_child1.getComputedWidth(), "56 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(44 === root_child1.getComputedHeight(), "44 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(56 === root_child1_child0.getComputedWidth(), "56 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(44 === root_child1_child0.getComputedHeight(), "44 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});

--- a/javascript/tests/Facebook.Yoga/YGAlignItemsTest.js
+++ b/javascript/tests/Facebook.Yoga/YGAlignItemsTest.js
@@ -51,6 +51,48 @@ it("align_items_stretch", function () {
     config.free();
   }
 });
+it("align_items_stretch_min_cross", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setMinWidth(400);
+    root.setMinHeight(50);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setHeight(36);
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(400 === root.getComputedWidth(), "400 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(50 === root.getComputedHeight(), "50 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(400 === root_child0.getComputedWidth(), "400 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(36 === root_child0.getComputedHeight(), "36 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(400 === root.getComputedWidth(), "400 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(50 === root.getComputedHeight(), "50 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(400 === root_child0.getComputedWidth(), "400 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(36 === root_child0.getComputedHeight(), "36 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
 it("align_items_center", function () {
   var config = Yoga.Config.create();
 
@@ -1275,246 +1317,6 @@ it("align_baseline_multiline", function () {
     config.free();
   }
 });
-it("align_baseline_multiline_column", function () {
-  var config = Yoga.Config.create();
-
-  try {
-    var root = Yoga.Node.create(config);
-    root.setAlignItems(Yoga.ALIGN_BASELINE);
-    root.setFlexWrap(Yoga.WRAP_WRAP);
-    root.setWidth(100);
-    root.setHeight(100);
-
-    var root_child0 = Yoga.Node.create(config);
-    root_child0.setWidth(50);
-    root_child0.setHeight(50);
-    root.insertChild(root_child0, 0);
-
-    var root_child1 = Yoga.Node.create(config);
-    root_child1.setWidth(30);
-    root_child1.setHeight(50);
-    root.insertChild(root_child1, 1);
-
-    var root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setWidth(20);
-    root_child1_child0.setHeight(20);
-    root_child1.insertChild(root_child1_child0, 0);
-
-    var root_child2 = Yoga.Node.create(config);
-    root_child2.setWidth(40);
-    root_child2.setHeight(70);
-    root.insertChild(root_child2, 2);
-
-    var root_child2_child0 = Yoga.Node.create(config);
-    root_child2_child0.setWidth(10);
-    root_child2_child0.setHeight(10);
-    root_child2.insertChild(root_child2_child0, 0);
-
-    var root_child3 = Yoga.Node.create(config);
-    root_child3.setWidth(50);
-    root_child3.setHeight(20);
-    root.insertChild(root_child3, 3);
-    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
-
-    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
-    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
-    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
-    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
-
-    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
-    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
-    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
-    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
-
-    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
-    console.assert(50 === root_child1.getComputedTop(), "50 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
-    console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
-    console.assert(50 === root_child1.getComputedHeight(), "50 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
-
-    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
-    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
-    console.assert(20 === root_child1_child0.getComputedWidth(), "20 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
-    console.assert(20 === root_child1_child0.getComputedHeight(), "20 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
-
-    console.assert(50 === root_child2.getComputedLeft(), "50 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
-    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
-    console.assert(40 === root_child2.getComputedWidth(), "40 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
-    console.assert(70 === root_child2.getComputedHeight(), "70 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
-
-    console.assert(0 === root_child2_child0.getComputedLeft(), "0 === root_child2_child0.getComputedLeft() (" + root_child2_child0.getComputedLeft() + ")");
-    console.assert(0 === root_child2_child0.getComputedTop(), "0 === root_child2_child0.getComputedTop() (" + root_child2_child0.getComputedTop() + ")");
-    console.assert(10 === root_child2_child0.getComputedWidth(), "10 === root_child2_child0.getComputedWidth() (" + root_child2_child0.getComputedWidth() + ")");
-    console.assert(10 === root_child2_child0.getComputedHeight(), "10 === root_child2_child0.getComputedHeight() (" + root_child2_child0.getComputedHeight() + ")");
-
-    console.assert(50 === root_child3.getComputedLeft(), "50 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
-    console.assert(70 === root_child3.getComputedTop(), "70 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
-    console.assert(50 === root_child3.getComputedWidth(), "50 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
-    console.assert(20 === root_child3.getComputedHeight(), "20 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
-
-    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
-
-    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
-    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
-    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
-    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
-
-    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
-    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
-    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
-    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
-
-    console.assert(70 === root_child1.getComputedLeft(), "70 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
-    console.assert(50 === root_child1.getComputedTop(), "50 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
-    console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
-    console.assert(50 === root_child1.getComputedHeight(), "50 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
-
-    console.assert(10 === root_child1_child0.getComputedLeft(), "10 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
-    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
-    console.assert(20 === root_child1_child0.getComputedWidth(), "20 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
-    console.assert(20 === root_child1_child0.getComputedHeight(), "20 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
-
-    console.assert(10 === root_child2.getComputedLeft(), "10 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
-    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
-    console.assert(40 === root_child2.getComputedWidth(), "40 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
-    console.assert(70 === root_child2.getComputedHeight(), "70 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
-
-    console.assert(30 === root_child2_child0.getComputedLeft(), "30 === root_child2_child0.getComputedLeft() (" + root_child2_child0.getComputedLeft() + ")");
-    console.assert(0 === root_child2_child0.getComputedTop(), "0 === root_child2_child0.getComputedTop() (" + root_child2_child0.getComputedTop() + ")");
-    console.assert(10 === root_child2_child0.getComputedWidth(), "10 === root_child2_child0.getComputedWidth() (" + root_child2_child0.getComputedWidth() + ")");
-    console.assert(10 === root_child2_child0.getComputedHeight(), "10 === root_child2_child0.getComputedHeight() (" + root_child2_child0.getComputedHeight() + ")");
-
-    console.assert(0 === root_child3.getComputedLeft(), "0 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
-    console.assert(70 === root_child3.getComputedTop(), "70 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
-    console.assert(50 === root_child3.getComputedWidth(), "50 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
-    console.assert(20 === root_child3.getComputedHeight(), "20 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
-  } finally {
-    if (typeof root !== "undefined") {
-      root.freeRecursive();
-    }
-
-    config.free();
-  }
-});
-it("align_baseline_multiline_column2", function () {
-  var config = Yoga.Config.create();
-
-  try {
-    var root = Yoga.Node.create(config);
-    root.setAlignItems(Yoga.ALIGN_BASELINE);
-    root.setFlexWrap(Yoga.WRAP_WRAP);
-    root.setWidth(100);
-    root.setHeight(100);
-
-    var root_child0 = Yoga.Node.create(config);
-    root_child0.setWidth(50);
-    root_child0.setHeight(50);
-    root.insertChild(root_child0, 0);
-
-    var root_child1 = Yoga.Node.create(config);
-    root_child1.setWidth(30);
-    root_child1.setHeight(50);
-    root.insertChild(root_child1, 1);
-
-    var root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setWidth(20);
-    root_child1_child0.setHeight(20);
-    root_child1.insertChild(root_child1_child0, 0);
-
-    var root_child2 = Yoga.Node.create(config);
-    root_child2.setWidth(40);
-    root_child2.setHeight(70);
-    root.insertChild(root_child2, 2);
-
-    var root_child2_child0 = Yoga.Node.create(config);
-    root_child2_child0.setWidth(10);
-    root_child2_child0.setHeight(10);
-    root_child2.insertChild(root_child2_child0, 0);
-
-    var root_child3 = Yoga.Node.create(config);
-    root_child3.setWidth(50);
-    root_child3.setHeight(20);
-    root.insertChild(root_child3, 3);
-    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
-
-    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
-    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
-    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
-    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
-
-    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
-    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
-    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
-    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
-
-    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
-    console.assert(50 === root_child1.getComputedTop(), "50 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
-    console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
-    console.assert(50 === root_child1.getComputedHeight(), "50 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
-
-    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
-    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
-    console.assert(20 === root_child1_child0.getComputedWidth(), "20 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
-    console.assert(20 === root_child1_child0.getComputedHeight(), "20 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
-
-    console.assert(50 === root_child2.getComputedLeft(), "50 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
-    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
-    console.assert(40 === root_child2.getComputedWidth(), "40 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
-    console.assert(70 === root_child2.getComputedHeight(), "70 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
-
-    console.assert(0 === root_child2_child0.getComputedLeft(), "0 === root_child2_child0.getComputedLeft() (" + root_child2_child0.getComputedLeft() + ")");
-    console.assert(0 === root_child2_child0.getComputedTop(), "0 === root_child2_child0.getComputedTop() (" + root_child2_child0.getComputedTop() + ")");
-    console.assert(10 === root_child2_child0.getComputedWidth(), "10 === root_child2_child0.getComputedWidth() (" + root_child2_child0.getComputedWidth() + ")");
-    console.assert(10 === root_child2_child0.getComputedHeight(), "10 === root_child2_child0.getComputedHeight() (" + root_child2_child0.getComputedHeight() + ")");
-
-    console.assert(50 === root_child3.getComputedLeft(), "50 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
-    console.assert(70 === root_child3.getComputedTop(), "70 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
-    console.assert(50 === root_child3.getComputedWidth(), "50 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
-    console.assert(20 === root_child3.getComputedHeight(), "20 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
-
-    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
-
-    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
-    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
-    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
-    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
-
-    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
-    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
-    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
-    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
-
-    console.assert(70 === root_child1.getComputedLeft(), "70 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
-    console.assert(50 === root_child1.getComputedTop(), "50 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
-    console.assert(30 === root_child1.getComputedWidth(), "30 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
-    console.assert(50 === root_child1.getComputedHeight(), "50 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
-
-    console.assert(10 === root_child1_child0.getComputedLeft(), "10 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
-    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
-    console.assert(20 === root_child1_child0.getComputedWidth(), "20 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
-    console.assert(20 === root_child1_child0.getComputedHeight(), "20 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
-
-    console.assert(10 === root_child2.getComputedLeft(), "10 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
-    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
-    console.assert(40 === root_child2.getComputedWidth(), "40 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
-    console.assert(70 === root_child2.getComputedHeight(), "70 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
-
-    console.assert(30 === root_child2_child0.getComputedLeft(), "30 === root_child2_child0.getComputedLeft() (" + root_child2_child0.getComputedLeft() + ")");
-    console.assert(0 === root_child2_child0.getComputedTop(), "0 === root_child2_child0.getComputedTop() (" + root_child2_child0.getComputedTop() + ")");
-    console.assert(10 === root_child2_child0.getComputedWidth(), "10 === root_child2_child0.getComputedWidth() (" + root_child2_child0.getComputedWidth() + ")");
-    console.assert(10 === root_child2_child0.getComputedHeight(), "10 === root_child2_child0.getComputedHeight() (" + root_child2_child0.getComputedHeight() + ")");
-
-    console.assert(0 === root_child3.getComputedLeft(), "0 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
-    console.assert(70 === root_child3.getComputedTop(), "70 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
-    console.assert(50 === root_child3.getComputedWidth(), "50 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
-    console.assert(20 === root_child3.getComputedHeight(), "20 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
-  } finally {
-    if (typeof root !== "undefined") {
-      root.freeRecursive();
-    }
-
-    config.free();
-  }
-});
 it("align_baseline_multiline_row_and_column", function () {
   var config = Yoga.Config.create();
 
@@ -2232,6 +2034,269 @@ it("align_flex_start_with_shrinking_children_with_stretch", function () {
     console.assert(0 === root_child0_child0_child0.getComputedTop(), "0 === root_child0_child0_child0.getComputedTop() (" + root_child0_child0_child0.getComputedTop() + ")");
     console.assert(0 === root_child0_child0_child0.getComputedWidth(), "0 === root_child0_child0_child0.getComputedWidth() (" + root_child0_child0_child0.getComputedWidth() + ")");
     console.assert(0 === root_child0_child0_child0.getComputedHeight(), "0 === root_child0_child0_child0.getComputedHeight() (" + root_child0_child0_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("align_items_center_justify_content_center", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setWidth(500);
+    root.setHeight(500);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setJustifyContent(Yoga.JUSTIFY_CENTER);
+    root_child0.setAlignItems(Yoga.ALIGN_CENTER);
+    root_child0.setHeight(50);
+    root.insertChild(root_child0, 0);
+
+    var root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setJustifyContent(Yoga.JUSTIFY_CENTER);
+    root_child0_child0.setAlignItems(Yoga.ALIGN_CENTER);
+    root_child0_child0.setMargin(Yoga.EDGE_LEFT, 10);
+    root_child0_child0.setMargin(Yoga.EDGE_RIGHT, 10);
+    root_child0_child0.setHeight("100%");
+    root_child0.insertChild(root_child0_child0, 0);
+
+    var root_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0.setWidth(10);
+    root_child0_child0_child0.setHeight(10);
+    root_child0_child0.insertChild(root_child0_child0_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(500 === root.getComputedWidth(), "500 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(500 === root.getComputedHeight(), "500 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(500 === root_child0.getComputedWidth(), "500 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(245 === root_child0_child0.getComputedLeft(), "245 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(10 === root_child0_child0.getComputedWidth(), "10 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0_child0.getComputedHeight(), "50 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0_child0.getComputedLeft(), "0 === root_child0_child0_child0.getComputedLeft() (" + root_child0_child0_child0.getComputedLeft() + ")");
+    console.assert(20 === root_child0_child0_child0.getComputedTop(), "20 === root_child0_child0_child0.getComputedTop() (" + root_child0_child0_child0.getComputedTop() + ")");
+    console.assert(10 === root_child0_child0_child0.getComputedWidth(), "10 === root_child0_child0_child0.getComputedWidth() (" + root_child0_child0_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child0_child0_child0.getComputedHeight(), "10 === root_child0_child0_child0.getComputedHeight() (" + root_child0_child0_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(500 === root.getComputedWidth(), "500 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(500 === root.getComputedHeight(), "500 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(500 === root_child0.getComputedWidth(), "500 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(245 === root_child0_child0.getComputedLeft(), "245 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(10 === root_child0_child0.getComputedWidth(), "10 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0_child0.getComputedHeight(), "50 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0_child0.getComputedLeft(), "0 === root_child0_child0_child0.getComputedLeft() (" + root_child0_child0_child0.getComputedLeft() + ")");
+    console.assert(20 === root_child0_child0_child0.getComputedTop(), "20 === root_child0_child0_child0.getComputedTop() (" + root_child0_child0_child0.getComputedTop() + ")");
+    console.assert(10 === root_child0_child0_child0.getComputedWidth(), "10 === root_child0_child0_child0.getComputedWidth() (" + root_child0_child0_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child0_child0_child0.getComputedHeight(), "10 === root_child0_child0_child0.getComputedHeight() (" + root_child0_child0_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("align_baseline_child_margin_percent", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setAlignItems(Yoga.ALIGN_BASELINE);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setMargin(Yoga.EDGE_LEFT, "5%");
+    root_child0.setMargin(Yoga.EDGE_TOP, "5%");
+    root_child0.setMargin(Yoga.EDGE_RIGHT, "5%");
+    root_child0.setMargin(Yoga.EDGE_BOTTOM, "5%");
+    root_child0.setWidth(50);
+    root_child0.setHeight(50);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(20);
+    root.insertChild(root_child1, 1);
+
+    var root_child1_child0 = Yoga.Node.create(config);
+    root_child1_child0.setMargin(Yoga.EDGE_LEFT, "1%");
+    root_child1_child0.setMargin(Yoga.EDGE_TOP, "1%");
+    root_child1_child0.setMargin(Yoga.EDGE_RIGHT, "1%");
+    root_child1_child0.setMargin(Yoga.EDGE_BOTTOM, "1%");
+    root_child1_child0.setWidth(50);
+    root_child1_child0.setHeight(10);
+    root_child1.insertChild(root_child1_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(5 === root_child0.getComputedLeft(), "5 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(5 === root_child0.getComputedTop(), "5 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(60 === root_child1.getComputedLeft(), "60 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(45 === root_child1.getComputedTop(), "45 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(1 === root_child1_child0.getComputedLeft(), "1 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(1 === root_child1_child0.getComputedTop(), "1 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0.getComputedWidth(), "50 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child0.getComputedHeight(), "10 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(45 === root_child0.getComputedLeft(), "45 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(5 === root_child0.getComputedTop(), "5 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(-10 === root_child1.getComputedLeft(), "-10 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(45 === root_child1.getComputedTop(), "45 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(20 === root_child1.getComputedHeight(), "20 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(1 === root_child1_child0.getComputedTop(), "1 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0.getComputedWidth(), "50 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child1_child0.getComputedHeight(), "10 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("align_baseline_nested_column", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setAlignItems(Yoga.ALIGN_BASELINE);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(60);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root.insertChild(root_child1, 1);
+
+    var root_child1_child0 = Yoga.Node.create(config);
+    root_child1_child0.setWidth(50);
+    root_child1_child0.setHeight(80);
+    root_child1.insertChild(root_child1_child0, 0);
+
+    var root_child1_child0_child0 = Yoga.Node.create(config);
+    root_child1_child0_child0.setWidth(50);
+    root_child1_child0_child0.setHeight(30);
+    root_child1_child0.insertChild(root_child1_child0_child0, 0);
+
+    var root_child1_child0_child1 = Yoga.Node.create(config);
+    root_child1_child0_child1.setWidth(50);
+    root_child1_child0_child1.setHeight(40);
+    root_child1_child0.insertChild(root_child1_child0_child1, 1);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(60 === root_child0.getComputedHeight(), "60 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(50 === root_child1.getComputedLeft(), "50 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(30 === root_child1.getComputedTop(), "30 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(80 === root_child1.getComputedHeight(), "80 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0.getComputedWidth(), "50 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(80 === root_child1_child0.getComputedHeight(), "80 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0_child0.getComputedLeft(), "0 === root_child1_child0_child0.getComputedLeft() (" + root_child1_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0_child0.getComputedTop(), "0 === root_child1_child0_child0.getComputedTop() (" + root_child1_child0_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0_child0.getComputedWidth(), "50 === root_child1_child0_child0.getComputedWidth() (" + root_child1_child0_child0.getComputedWidth() + ")");
+    console.assert(30 === root_child1_child0_child0.getComputedHeight(), "30 === root_child1_child0_child0.getComputedHeight() (" + root_child1_child0_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0_child1.getComputedLeft(), "0 === root_child1_child0_child1.getComputedLeft() (" + root_child1_child0_child1.getComputedLeft() + ")");
+    console.assert(30 === root_child1_child0_child1.getComputedTop(), "30 === root_child1_child0_child1.getComputedTop() (" + root_child1_child0_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0_child1.getComputedWidth(), "50 === root_child1_child0_child1.getComputedWidth() (" + root_child1_child0_child1.getComputedWidth() + ")");
+    console.assert(40 === root_child1_child0_child1.getComputedHeight(), "40 === root_child1_child0_child1.getComputedHeight() (" + root_child1_child0_child1.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(60 === root_child0.getComputedHeight(), "60 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(30 === root_child1.getComputedTop(), "30 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(80 === root_child1.getComputedHeight(), "80 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0.getComputedLeft(), "0 === root_child1_child0.getComputedLeft() (" + root_child1_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0.getComputedTop(), "0 === root_child1_child0.getComputedTop() (" + root_child1_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0.getComputedWidth(), "50 === root_child1_child0.getComputedWidth() (" + root_child1_child0.getComputedWidth() + ")");
+    console.assert(80 === root_child1_child0.getComputedHeight(), "80 === root_child1_child0.getComputedHeight() (" + root_child1_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0_child0.getComputedLeft(), "0 === root_child1_child0_child0.getComputedLeft() (" + root_child1_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child1_child0_child0.getComputedTop(), "0 === root_child1_child0_child0.getComputedTop() (" + root_child1_child0_child0.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0_child0.getComputedWidth(), "50 === root_child1_child0_child0.getComputedWidth() (" + root_child1_child0_child0.getComputedWidth() + ")");
+    console.assert(30 === root_child1_child0_child0.getComputedHeight(), "30 === root_child1_child0_child0.getComputedHeight() (" + root_child1_child0_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1_child0_child1.getComputedLeft(), "0 === root_child1_child0_child1.getComputedLeft() (" + root_child1_child0_child1.getComputedLeft() + ")");
+    console.assert(30 === root_child1_child0_child1.getComputedTop(), "30 === root_child1_child0_child1.getComputedTop() (" + root_child1_child0_child1.getComputedTop() + ")");
+    console.assert(50 === root_child1_child0_child1.getComputedWidth(), "50 === root_child1_child0_child1.getComputedWidth() (" + root_child1_child0_child1.getComputedWidth() + ")");
+    console.assert(40 === root_child1_child0_child1.getComputedHeight(), "40 === root_child1_child0_child1.getComputedHeight() (" + root_child1_child0_child1.getComputedHeight() + ")");
   } finally {
     if (typeof root !== "undefined") {
       root.freeRecursive();

--- a/javascript/tests/Facebook.Yoga/YGAlignSelfTest.js
+++ b/javascript/tests/Facebook.Yoga/YGAlignSelfTest.js
@@ -53,6 +53,66 @@ it("align_self_center", function () {
     config.free();
   }
 });
+it("align_self_center_undefined_max_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setWidth(280);
+    root.setMinHeight(52);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(240);
+    root_child0.setHeight(44);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setAlignSelf(Yoga.ALIGN_CENTER);
+    root_child1.setWidth(40);
+    root_child1.setHeight(56);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(280 === root.getComputedWidth(), "280 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(56 === root.getComputedHeight(), "56 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(240 === root_child0.getComputedWidth(), "240 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(44 === root_child0.getComputedHeight(), "44 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(240 === root_child1.getComputedLeft(), "240 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(40 === root_child1.getComputedWidth(), "40 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(56 === root_child1.getComputedHeight(), "56 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(280 === root.getComputedWidth(), "280 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(56 === root.getComputedHeight(), "56 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(40 === root_child0.getComputedLeft(), "40 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(240 === root_child0.getComputedWidth(), "240 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(44 === root_child0.getComputedHeight(), "44 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(40 === root_child1.getComputedWidth(), "40 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(56 === root_child1.getComputedHeight(), "56 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
 it("align_self_flex_end", function () {
   var config = Yoga.Config.create();
 

--- a/javascript/tests/Facebook.Yoga/YGBorderTest.js
+++ b/javascript/tests/Facebook.Yoga/YGBorderTest.js
@@ -184,8 +184,6 @@ it("border_center_child", function () {
     var root = Yoga.Node.create(config);
     root.setJustifyContent(Yoga.JUSTIFY_CENTER);
     root.setAlignItems(Yoga.ALIGN_CENTER);
-    root.setBorder(Yoga.EDGE_START, 10);
-    root.setBorder(Yoga.EDGE_END, 20);
     root.setBorder(Yoga.EDGE_BOTTOM, 20);
     root.setWidth(100);
     root.setHeight(100);
@@ -201,7 +199,7 @@ it("border_center_child", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(40 === root_child0.getComputedLeft(), "40 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(45 === root_child0.getComputedLeft(), "45 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(35 === root_child0.getComputedTop(), "35 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
@@ -213,7 +211,7 @@ it("border_center_child", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(45 === root_child0.getComputedLeft(), "45 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(35 === root_child0.getComputedTop(), "35 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");

--- a/javascript/tests/Facebook.Yoga/YGDisplayTest.js
+++ b/javascript/tests/Facebook.Yoga/YGDisplayTest.js
@@ -388,3 +388,65 @@ it("display_none_with_position_absolute", function () {
     config.free();
   }
 });
+it("display_none_absolute_child", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexGrow(1);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root_child1.setPosition(Yoga.EDGE_LEFT, 10);
+    root_child1.setPosition(Yoga.EDGE_TOP, 10);
+    root_child1.setWidth(20);
+    root_child1.setHeight(20);
+    root_child1.setDisplay(Yoga.DISPLAY_NONE);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(100 === root_child0.getComputedWidth(), "100 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(100 === root_child0.getComputedHeight(), "100 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(0 === root_child1.getComputedWidth(), "0 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(0 === root_child1.getComputedHeight(), "0 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(100 === root_child0.getComputedWidth(), "100 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(100 === root_child0.getComputedHeight(), "100 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(0 === root_child1.getComputedWidth(), "0 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(0 === root_child1.getComputedHeight(), "0 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});

--- a/javascript/tests/Facebook.Yoga/YGFlexDirectionTest.js
+++ b/javascript/tests/Facebook.Yoga/YGFlexDirectionTest.js
@@ -431,3 +431,73 @@ it("flex_direction_row_reverse", function () {
     config.free();
   }
 });
+it("flex_direction_column_reverse_no_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_COLUMN_REVERSE);
+    root.setWidth(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+
+    var root_child2 = Yoga.Node.create(config);
+    root_child2.setHeight(10);
+    root.insertChild(root_child2, 2);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(30 === root.getComputedHeight(), "30 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(20 === root_child0.getComputedTop(), "20 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(100 === root_child0.getComputedWidth(), "100 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(10 === root_child1.getComputedTop(), "10 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(100 === root_child1.getComputedWidth(), "100 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(10 === root_child1.getComputedHeight(), "10 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child2.getComputedLeft(), "0 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(100 === root_child2.getComputedWidth(), "100 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(10 === root_child2.getComputedHeight(), "10 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(30 === root.getComputedHeight(), "30 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(20 === root_child0.getComputedTop(), "20 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(100 === root_child0.getComputedWidth(), "100 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(10 === root_child1.getComputedTop(), "10 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(100 === root_child1.getComputedWidth(), "100 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(10 === root_child1.getComputedHeight(), "10 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child2.getComputedLeft(), "0 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(100 === root_child2.getComputedWidth(), "100 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(10 === root_child2.getComputedHeight(), "10 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});

--- a/javascript/tests/Facebook.Yoga/YGFlexTest.js
+++ b/javascript/tests/Facebook.Yoga/YGFlexTest.js
@@ -636,3 +636,204 @@ it("flex_grow_less_than_factor_one", function () {
     config.free();
   }
 });
+it("single_flex_child_after_absolute_child", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setWidth(428);
+    root.setHeight(845);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+    root_child0.setWidth("100%");
+    root_child0.setHeight("100%");
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setFlexGrow(1);
+    root_child1.setFlexShrink(1);
+    root.insertChild(root_child1, 1);
+
+    var root_child2 = Yoga.Node.create(config);
+    root_child2.setFlexBasis(174);
+    root.insertChild(root_child2, 2);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(428 === root.getComputedWidth(), "428 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(845 === root.getComputedHeight(), "845 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(428 === root_child0.getComputedWidth(), "428 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(845 === root_child0.getComputedHeight(), "845 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(428 === root_child1.getComputedWidth(), "428 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(671 === root_child1.getComputedHeight(), "671 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child2.getComputedLeft(), "0 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(671 === root_child2.getComputedTop(), "671 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(428 === root_child2.getComputedWidth(), "428 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(174 === root_child2.getComputedHeight(), "174 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(428 === root.getComputedWidth(), "428 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(845 === root.getComputedHeight(), "845 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(428 === root_child0.getComputedWidth(), "428 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(845 === root_child0.getComputedHeight(), "845 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(428 === root_child1.getComputedWidth(), "428 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(671 === root_child1.getComputedHeight(), "671 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child2.getComputedLeft(), "0 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(671 === root_child2.getComputedTop(), "671 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(428 === root_child2.getComputedWidth(), "428 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(174 === root_child2.getComputedHeight(), "174 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("flex_basis_zero_undefined_main_size", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexBasis(0);
+    root.insertChild(root_child0, 0);
+
+    var root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth(100);
+    root_child0_child0.setHeight(50);
+    root_child0.insertChild(root_child0_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(50 === root.getComputedHeight(), "50 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(100 === root_child0.getComputedWidth(), "100 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(100 === root_child0_child0.getComputedWidth(), "100 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0_child0.getComputedHeight(), "50 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(50 === root.getComputedHeight(), "50 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(100 === root_child0.getComputedWidth(), "100 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(100 === root_child0_child0.getComputedWidth(), "100 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0_child0.getComputedHeight(), "50 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("only_shrinkable_item_with_flex_basis_zero", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setWidth(480);
+    root.setMaxHeight(764);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexShrink(1);
+    root_child0.setFlexBasis(0);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setFlexBasis(93);
+    root_child1.setMargin(Yoga.EDGE_BOTTOM, 6);
+    root.insertChild(root_child1, 1);
+
+    var root_child2 = Yoga.Node.create(config);
+    root_child2.setFlexBasis(764);
+    root.insertChild(root_child2, 2);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(480 === root.getComputedWidth(), "480 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(764 === root.getComputedHeight(), "764 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(480 === root_child0.getComputedWidth(), "480 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(0 === root_child0.getComputedHeight(), "0 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(480 === root_child1.getComputedWidth(), "480 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(93 === root_child1.getComputedHeight(), "93 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child2.getComputedLeft(), "0 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(99 === root_child2.getComputedTop(), "99 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(480 === root_child2.getComputedWidth(), "480 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(764 === root_child2.getComputedHeight(), "764 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(480 === root.getComputedWidth(), "480 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(764 === root.getComputedHeight(), "764 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(480 === root_child0.getComputedWidth(), "480 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(0 === root_child0.getComputedHeight(), "0 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(480 === root_child1.getComputedWidth(), "480 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(93 === root_child1.getComputedHeight(), "93 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(0 === root_child2.getComputedLeft(), "0 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(99 === root_child2.getComputedTop(), "99 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(480 === root_child2.getComputedWidth(), "480 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(764 === root_child2.getComputedHeight(), "764 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});

--- a/javascript/tests/Facebook.Yoga/YGMarginTest.js
+++ b/javascript/tests/Facebook.Yoga/YGMarginTest.js
@@ -19,7 +19,6 @@ it("margin_start", function () {
     root.setHeight(100);
 
     var root_child0 = Yoga.Node.create(config);
-    root_child0.setMargin(Yoga.EDGE_START, 10);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
     root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
@@ -29,7 +28,7 @@ it("margin_start", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(10 === root_child0.getComputedLeft(), "10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(100 === root_child0.getComputedHeight(), "100 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
@@ -41,7 +40,7 @@ it("margin_start", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(80 === root_child0.getComputedLeft(), "80 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(90 === root_child0.getComputedLeft(), "90 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(100 === root_child0.getComputedHeight(), "100 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
@@ -107,7 +106,6 @@ it("margin_end", function () {
     root.setHeight(100);
 
     var root_child0 = Yoga.Node.create(config);
-    root_child0.setMargin(Yoga.EDGE_END, 10);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
     root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
@@ -117,7 +115,7 @@ it("margin_end", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(80 === root_child0.getComputedLeft(), "80 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(90 === root_child0.getComputedLeft(), "90 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(100 === root_child0.getComputedHeight(), "100 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
@@ -129,7 +127,7 @@ it("margin_end", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(10 === root_child0.getComputedLeft(), "10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(100 === root_child0.getComputedHeight(), "100 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
@@ -196,8 +194,6 @@ it("margin_and_flex_row", function () {
 
     var root_child0 = Yoga.Node.create(config);
     root_child0.setFlexGrow(1);
-    root_child0.setMargin(Yoga.EDGE_START, 10);
-    root_child0.setMargin(Yoga.EDGE_END, 10);
     root.insertChild(root_child0, 0);
     root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
 
@@ -206,9 +202,9 @@ it("margin_and_flex_row", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(10 === root_child0.getComputedLeft(), "10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
-    console.assert(80 === root_child0.getComputedWidth(), "80 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(100 === root_child0.getComputedWidth(), "100 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(100 === root_child0.getComputedHeight(), "100 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
 
     root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
@@ -218,9 +214,9 @@ it("margin_and_flex_row", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(10 === root_child0.getComputedLeft(), "10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
-    console.assert(80 === root_child0.getComputedWidth(), "80 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(100 === root_child0.getComputedWidth(), "100 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(100 === root_child0.getComputedHeight(), "100 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
   } finally {
     if (typeof root !== "undefined") {
@@ -329,8 +325,6 @@ it("margin_and_stretch_column", function () {
 
     var root_child0 = Yoga.Node.create(config);
     root_child0.setFlexGrow(1);
-    root_child0.setMargin(Yoga.EDGE_START, 10);
-    root_child0.setMargin(Yoga.EDGE_END, 10);
     root.insertChild(root_child0, 0);
     root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
 
@@ -339,9 +333,9 @@ it("margin_and_stretch_column", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(10 === root_child0.getComputedLeft(), "10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
-    console.assert(80 === root_child0.getComputedWidth(), "80 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(100 === root_child0.getComputedWidth(), "100 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(100 === root_child0.getComputedHeight(), "100 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
 
     root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
@@ -351,9 +345,9 @@ it("margin_and_stretch_column", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(10 === root_child0.getComputedLeft(), "10 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
-    console.assert(80 === root_child0.getComputedWidth(), "80 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(100 === root_child0.getComputedWidth(), "100 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(100 === root_child0.getComputedHeight(), "100 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
   } finally {
     if (typeof root !== "undefined") {
@@ -374,7 +368,6 @@ it("margin_with_sibling_row", function () {
 
     var root_child0 = Yoga.Node.create(config);
     root_child0.setFlexGrow(1);
-    root_child0.setMargin(Yoga.EDGE_END, 10);
     root.insertChild(root_child0, 0);
 
     var root_child1 = Yoga.Node.create(config);
@@ -389,12 +382,12 @@ it("margin_with_sibling_row", function () {
 
     console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
-    console.assert(45 === root_child0.getComputedWidth(), "45 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(100 === root_child0.getComputedHeight(), "100 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
 
-    console.assert(55 === root_child1.getComputedLeft(), "55 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(50 === root_child1.getComputedLeft(), "50 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
     console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
-    console.assert(45 === root_child1.getComputedWidth(), "45 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
     console.assert(100 === root_child1.getComputedHeight(), "100 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
 
     root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
@@ -404,14 +397,14 @@ it("margin_with_sibling_row", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(55 === root_child0.getComputedLeft(), "55 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
-    console.assert(45 === root_child0.getComputedWidth(), "45 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(100 === root_child0.getComputedHeight(), "100 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
 
     console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
     console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
-    console.assert(45 === root_child1.getComputedWidth(), "45 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
     console.assert(100 === root_child1.getComputedHeight(), "100 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
   } finally {
     if (typeof root !== "undefined") {
@@ -1006,8 +999,6 @@ it("margin_auto_start_and_end_column", function () {
     root.setHeight(200);
 
     var root_child0 = Yoga.Node.create(config);
-    root_child0.setMargin(Yoga.EDGE_START, "auto");
-    root_child0.setMargin(Yoga.EDGE_END, "auto");
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
@@ -1023,12 +1014,12 @@ it("margin_auto_start_and_end_column", function () {
     console.assert(200 === root.getComputedWidth(), "200 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(200 === root.getComputedHeight(), "200 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(75 === root_child0.getComputedTop(), "75 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
 
-    console.assert(150 === root_child1.getComputedLeft(), "150 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(50 === root_child1.getComputedLeft(), "50 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
     console.assert(75 === root_child1.getComputedTop(), "75 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
     console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
     console.assert(50 === root_child1.getComputedHeight(), "50 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
@@ -1040,12 +1031,12 @@ it("margin_auto_start_and_end_column", function () {
     console.assert(200 === root.getComputedWidth(), "200 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(200 === root.getComputedHeight(), "200 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(100 === root_child0.getComputedLeft(), "100 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(150 === root_child0.getComputedLeft(), "150 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(75 === root_child0.getComputedTop(), "75 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
 
-    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(100 === root_child1.getComputedLeft(), "100 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
     console.assert(75 === root_child1.getComputedTop(), "75 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
     console.assert(50 === root_child1.getComputedWidth(), "50 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
     console.assert(50 === root_child1.getComputedHeight(), "50 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
@@ -1066,8 +1057,6 @@ it("margin_auto_start_and_end", function () {
     root.setHeight(200);
 
     var root_child0 = Yoga.Node.create(config);
-    root_child0.setMargin(Yoga.EDGE_START, "auto");
-    root_child0.setMargin(Yoga.EDGE_END, "auto");
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
@@ -1083,7 +1072,7 @@ it("margin_auto_start_and_end", function () {
     console.assert(200 === root.getComputedWidth(), "200 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(200 === root.getComputedHeight(), "200 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(75 === root_child0.getComputedLeft(), "75 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
@@ -1100,7 +1089,7 @@ it("margin_auto_start_and_end", function () {
     console.assert(200 === root.getComputedWidth(), "200 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(200 === root.getComputedHeight(), "200 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(75 === root_child0.getComputedLeft(), "75 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(150 === root_child0.getComputedLeft(), "150 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");

--- a/javascript/tests/Facebook.Yoga/YGMinMaxDimensionTest.js
+++ b/javascript/tests/Facebook.Yoga/YGMinMaxDimensionTest.js
@@ -52,6 +52,93 @@ it("max_width", function () {
     config.free();
   }
 });
+it("min_width_larger_than_width", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(25);
+    root_child0.setMinWidth(50);
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(0 === root_child0.getComputedHeight(), "0 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(50 === root_child0.getComputedWidth(), "50 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(0 === root_child0.getComputedHeight(), "0 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("min_height_larger_than_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setHeight(25);
+    root_child0.setMinHeight(50);
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(0 === root_child0.getComputedWidth(), "0 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(100 === root_child0.getComputedLeft(), "100 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(0 === root_child0.getComputedWidth(), "0 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
 it("max_height", function () {
   var config = Yoga.Config.create();
 
@@ -88,6 +175,69 @@ it("max_height", function () {
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("min_height_with_nested_fixed_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setPadding(Yoga.EDGE_LEFT, 16);
+    root.setPadding(Yoga.EDGE_RIGHT, 16);
+    root.setWidth(320);
+    root.setMinHeight(44);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setAlignSelf(Yoga.ALIGN_FLEX_START);
+    root_child0.setMargin(Yoga.EDGE_TOP, 8);
+    root_child0.setMargin(Yoga.EDGE_BOTTOM, 9);
+    root_child0.setMinHeight(28);
+    root.insertChild(root_child0, 0);
+
+    var root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth(40);
+    root_child0_child0.setHeight(40);
+    root_child0.insertChild(root_child0_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(320 === root.getComputedWidth(), "320 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(57 === root.getComputedHeight(), "57 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(16 === root_child0.getComputedLeft(), "16 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(8 === root_child0.getComputedTop(), "8 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(40 === root_child0.getComputedWidth(), "40 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(40 === root_child0.getComputedHeight(), "40 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(40 === root_child0_child0.getComputedWidth(), "40 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(40 === root_child0_child0.getComputedHeight(), "40 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(320 === root.getComputedWidth(), "320 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(57 === root.getComputedHeight(), "57 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(264 === root_child0.getComputedLeft(), "264 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(8 === root_child0.getComputedTop(), "8 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(40 === root_child0.getComputedWidth(), "40 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(40 === root_child0.getComputedHeight(), "40 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(40 === root_child0_child0.getComputedWidth(), "40 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(40 === root_child0_child0.getComputedHeight(), "40 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
   } finally {
     if (typeof root !== "undefined") {
       root.freeRecursive();
@@ -178,6 +328,55 @@ it("align_items_min_max", function () {
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(60 === root_child0.getComputedWidth(), "60 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(60 === root_child0.getComputedHeight(), "60 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("align_items_center_min_max_with_padding", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setAlignItems(Yoga.ALIGN_CENTER);
+    root.setPadding(Yoga.EDGE_TOP, 8);
+    root.setPadding(Yoga.EDGE_BOTTOM, 8);
+    root.setMinWidth(320);
+    root.setMaxWidth(320);
+    root.setMinHeight(72);
+    root.setMaxHeight(504);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(62);
+    root_child0.setHeight(62);
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(320 === root.getComputedWidth(), "320 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(78 === root.getComputedHeight(), "78 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(8 === root_child0.getComputedTop(), "8 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(62 === root_child0.getComputedWidth(), "62 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(62 === root_child0.getComputedHeight(), "62 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(320 === root.getComputedWidth(), "320 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(78 === root.getComputedHeight(), "78 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(258 === root_child0.getComputedLeft(), "258 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(8 === root_child0.getComputedTop(), "8 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(62 === root_child0.getComputedWidth(), "62 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(62 === root_child0.getComputedHeight(), "62 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
   } finally {
     if (typeof root !== "undefined") {
       root.freeRecursive();
@@ -1250,6 +1449,192 @@ it("min_max_percent_no_width_height", function () {
     console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("min_max_percent_different_width_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setAlignItems(Yoga.ALIGN_FLEX_START);
+    root.setWidth(100);
+    root.setHeight(200);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setMinWidth("10%");
+    root_child0.setMaxWidth("10%");
+    root_child0.setMinHeight("10%");
+    root_child0.setMaxHeight("10%");
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(200 === root.getComputedHeight(), "200 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(20 === root_child0.getComputedHeight(), "20 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(200 === root.getComputedHeight(), "200 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(90 === root_child0.getComputedLeft(), "90 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(20 === root_child0.getComputedHeight(), "20 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("undefined_height_with_min_max", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setWidth(320);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setMaxHeight(100);
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(320 === root.getComputedWidth(), "320 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(0 === root.getComputedHeight(), "0 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(320 === root_child0.getComputedWidth(), "320 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(0 === root_child0.getComputedHeight(), "0 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(320 === root.getComputedWidth(), "320 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(0 === root.getComputedHeight(), "0 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(320 === root_child0.getComputedWidth(), "320 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(0 === root_child0.getComputedHeight(), "0 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("undefined_width_with_min_max", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setHeight(50);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setMaxWidth(100);
+    root.insertChild(root_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(0 === root.getComputedWidth(), "0 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(50 === root.getComputedHeight(), "50 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(0 === root_child0.getComputedWidth(), "0 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(0 === root_child0.getComputedHeight(), "0 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(0 === root.getComputedWidth(), "0 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(50 === root.getComputedHeight(), "50 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(0 === root_child0.getComputedWidth(), "0 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(0 === root_child0.getComputedHeight(), "0 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("undefined_width_with_min_max_row", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setHeight(50);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setMinWidth(60);
+    root_child0.setMaxWidth(300);
+    root.insertChild(root_child0, 0);
+
+    var root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth(30);
+    root_child0_child0.setHeight(20);
+    root_child0.insertChild(root_child0_child0, 0);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(60 === root.getComputedWidth(), "60 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(50 === root.getComputedHeight(), "50 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(60 === root_child0.getComputedWidth(), "60 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(30 === root_child0_child0.getComputedWidth(), "30 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(20 === root_child0_child0.getComputedHeight(), "20 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(60 === root.getComputedWidth(), "60 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(50 === root.getComputedHeight(), "50 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(60 === root_child0.getComputedWidth(), "60 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(50 === root_child0.getComputedHeight(), "50 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(30 === root_child0_child0.getComputedLeft(), "30 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(30 === root_child0_child0.getComputedWidth(), "30 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(20 === root_child0_child0.getComputedHeight(), "20 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
   } finally {
     if (typeof root !== "undefined") {
       root.freeRecursive();

--- a/javascript/tests/Facebook.Yoga/YGPaddingTest.js
+++ b/javascript/tests/Facebook.Yoga/YGPaddingTest.js
@@ -184,8 +184,6 @@ it("padding_center_child", function () {
     var root = Yoga.Node.create(config);
     root.setJustifyContent(Yoga.JUSTIFY_CENTER);
     root.setAlignItems(Yoga.ALIGN_CENTER);
-    root.setPadding(Yoga.EDGE_START, 10);
-    root.setPadding(Yoga.EDGE_END, 20);
     root.setPadding(Yoga.EDGE_BOTTOM, 20);
     root.setWidth(100);
     root.setHeight(100);
@@ -201,7 +199,7 @@ it("padding_center_child", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(40 === root_child0.getComputedLeft(), "40 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(45 === root_child0.getComputedLeft(), "45 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(35 === root_child0.getComputedTop(), "35 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
@@ -213,7 +211,7 @@ it("padding_center_child", function () {
     console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
     console.assert(100 === root.getComputedHeight(), "100 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
 
-    console.assert(50 === root_child0.getComputedLeft(), "50 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(45 === root_child0.getComputedLeft(), "45 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
     console.assert(35 === root_child0.getComputedTop(), "35 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
     console.assert(10 === root_child0.getComputedWidth(), "10 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
     console.assert(10 === root_child0.getComputedHeight(), "10 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");

--- a/javascript/tests/Facebook.Yoga/YGPercentageTest.js
+++ b/javascript/tests/Facebook.Yoga/YGPercentageTest.js
@@ -625,6 +625,77 @@ it("percentage_flex_basis_cross_min_width", function () {
     config.free();
   }
 });
+it("percentage_main_max_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setWidth(71);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setAlignItems(Yoga.ALIGN_FLEX_START);
+    root_child0.setHeight(151);
+    root.insertChild(root_child0, 0);
+
+    var root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setFlexBasis(15);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    var root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setFlexBasis(48);
+    root_child0_child1.setMaxHeight("33%");
+    root_child0.insertChild(root_child0_child1, 1);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(71 === root.getComputedWidth(), "71 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(151 === root.getComputedHeight(), "151 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(71 === root_child0.getComputedWidth(), "71 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(151 === root_child0.getComputedHeight(), "151 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child0.getComputedLeft(), "0 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(0 === root_child0_child0.getComputedWidth(), "0 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(15 === root_child0_child0.getComputedHeight(), "15 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0_child1.getComputedLeft(), "0 === root_child0_child1.getComputedLeft() (" + root_child0_child1.getComputedLeft() + ")");
+    console.assert(15 === root_child0_child1.getComputedTop(), "15 === root_child0_child1.getComputedTop() (" + root_child0_child1.getComputedTop() + ")");
+    console.assert(0 === root_child0_child1.getComputedWidth(), "0 === root_child0_child1.getComputedWidth() (" + root_child0_child1.getComputedWidth() + ")");
+    console.assert(48 === root_child0_child1.getComputedHeight(), "48 === root_child0_child1.getComputedHeight() (" + root_child0_child1.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(71 === root.getComputedWidth(), "71 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(151 === root.getComputedHeight(), "151 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(71 === root_child0.getComputedWidth(), "71 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(151 === root_child0.getComputedHeight(), "151 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(71 === root_child0_child0.getComputedLeft(), "71 === root_child0_child0.getComputedLeft() (" + root_child0_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0_child0.getComputedTop(), "0 === root_child0_child0.getComputedTop() (" + root_child0_child0.getComputedTop() + ")");
+    console.assert(0 === root_child0_child0.getComputedWidth(), "0 === root_child0_child0.getComputedWidth() (" + root_child0_child0.getComputedWidth() + ")");
+    console.assert(15 === root_child0_child0.getComputedHeight(), "15 === root_child0_child0.getComputedHeight() (" + root_child0_child0.getComputedHeight() + ")");
+
+    console.assert(71 === root_child0_child1.getComputedLeft(), "71 === root_child0_child1.getComputedLeft() (" + root_child0_child1.getComputedLeft() + ")");
+    console.assert(15 === root_child0_child1.getComputedTop(), "15 === root_child0_child1.getComputedTop() (" + root_child0_child1.getComputedTop() + ")");
+    console.assert(0 === root_child0_child1.getComputedWidth(), "0 === root_child0_child1.getComputedWidth() (" + root_child0_child1.getComputedWidth() + ")");
+    console.assert(48 === root_child0_child1.getComputedHeight(), "48 === root_child0_child1.getComputedHeight() (" + root_child0_child1.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
 it("percentage_multiple_nested_with_padding_margin_and_percentage_values", function () {
   var config = Yoga.Config.create();
 
@@ -1047,6 +1118,7 @@ it("percentage_container_in_wrapping_container", function () {
     var root_child0_child0 = Yoga.Node.create(config);
     root_child0_child0.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
     root_child0_child0.setJustifyContent(Yoga.JUSTIFY_CENTER);
+    root_child0_child0.setAlignItems(Yoga.ALIGN_CENTER);
     root_child0_child0.setWidth("100%");
     root_child0.insertChild(root_child0_child0, 0);
 
@@ -1186,6 +1258,120 @@ it("percent_absolute_position", function () {
     console.assert(0 === root_child0_child1.getComputedTop(), "0 === root_child0_child1.getComputedTop() (" + root_child0_child1.getComputedTop() + ")");
     console.assert(60 === root_child0_child1.getComputedWidth(), "60 === root_child0_child1.getComputedWidth() (" + root_child0_child1.getComputedWidth() + ")");
     console.assert(50 === root_child0_child1.getComputedHeight(), "50 === root_child0_child1.getComputedHeight() (" + root_child0_child1.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("percentage_different_width_height", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setWidth(200);
+    root.setHeight(300);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexGrow(1);
+    root_child0.setHeight("30%");
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setHeight("30%");
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(200 === root.getComputedWidth(), "200 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(300 === root.getComputedHeight(), "300 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(200 === root_child0.getComputedWidth(), "200 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(90 === root_child0.getComputedHeight(), "90 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(200 === root_child1.getComputedLeft(), "200 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(0 === root_child1.getComputedWidth(), "0 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(90 === root_child1.getComputedHeight(), "90 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(200 === root.getComputedWidth(), "200 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(300 === root.getComputedHeight(), "300 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(200 === root_child0.getComputedWidth(), "200 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(90 === root_child0.getComputedHeight(), "90 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(0 === root_child1.getComputedWidth(), "0 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(90 === root_child1.getComputedHeight(), "90 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("percentage_different_width_height_column", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setWidth(200);
+    root.setHeight(300);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexGrow(1);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setHeight("30%");
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(200 === root.getComputedWidth(), "200 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(300 === root.getComputedHeight(), "300 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(200 === root_child0.getComputedWidth(), "200 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(210 === root_child0.getComputedHeight(), "210 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(210 === root_child1.getComputedTop(), "210 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(200 === root_child1.getComputedWidth(), "200 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(90 === root_child1.getComputedHeight(), "90 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(200 === root.getComputedWidth(), "200 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(300 === root.getComputedHeight(), "300 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(200 === root_child0.getComputedWidth(), "200 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(210 === root_child0.getComputedHeight(), "210 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(0 === root_child1.getComputedLeft(), "0 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(210 === root_child1.getComputedTop(), "210 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(200 === root_child1.getComputedWidth(), "200 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(90 === root_child1.getComputedHeight(), "90 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
   } finally {
     if (typeof root !== "undefined") {
       root.freeRecursive();

--- a/tests/YGAbsolutePositionTest.cpp
+++ b/tests/YGAbsolutePositionTest.cpp
@@ -20,7 +20,6 @@ TEST(YogaTest, absolute_layout_width_height_start_top) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
-  YGNodeStyleSetPosition(root_child0, YGEdgeStart, 10);
   YGNodeStyleSetPosition(root_child0, YGEdgeTop, 10);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
@@ -32,7 +31,7 @@ TEST(YogaTest, absolute_layout_width_height_start_top) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
@@ -44,7 +43,7 @@ TEST(YogaTest, absolute_layout_width_height_start_top) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
@@ -63,7 +62,6 @@ TEST(YogaTest, absolute_layout_width_height_end_bottom) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
-  YGNodeStyleSetPosition(root_child0, YGEdgeEnd, 10);
   YGNodeStyleSetPosition(root_child0, YGEdgeBottom, 10);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
@@ -75,7 +73,7 @@ TEST(YogaTest, absolute_layout_width_height_end_bottom) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(80, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
@@ -87,7 +85,50 @@ TEST(YogaTest, absolute_layout_width_height_end_bottom) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, absolute_layout_row_width_height_end_bottom) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child0, YGEdgeBottom, 10);
+  YGNodeStyleSetWidth(root_child0, 10);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(80, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
@@ -106,9 +147,7 @@ TEST(YogaTest, absolute_layout_start_top_end_bottom) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
-  YGNodeStyleSetPosition(root_child0, YGEdgeStart, 10);
   YGNodeStyleSetPosition(root_child0, YGEdgeTop, 10);
-  YGNodeStyleSetPosition(root_child0, YGEdgeEnd, 10);
   YGNodeStyleSetPosition(root_child0, YGEdgeBottom, 10);
   YGNodeInsertChild(root, root_child0, 0);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -118,9 +157,9 @@ TEST(YogaTest, absolute_layout_start_top_end_bottom) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root_child0));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
@@ -130,9 +169,9 @@ TEST(YogaTest, absolute_layout_start_top_end_bottom) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root_child0));
 
   YGNodeFreeRecursive(root);
@@ -149,9 +188,7 @@ TEST(YogaTest, absolute_layout_width_height_start_top_end_bottom) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
-  YGNodeStyleSetPosition(root_child0, YGEdgeStart, 10);
   YGNodeStyleSetPosition(root_child0, YGEdgeTop, 10);
-  YGNodeStyleSetPosition(root_child0, YGEdgeEnd, 10);
   YGNodeStyleSetPosition(root_child0, YGEdgeBottom, 10);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
@@ -163,7 +200,7 @@ TEST(YogaTest, absolute_layout_width_height_start_top_end_bottom) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
@@ -175,7 +212,7 @@ TEST(YogaTest, absolute_layout_width_height_start_top_end_bottom) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
@@ -196,7 +233,6 @@ TEST(YogaTest, do_not_clamp_height_of_absolute_node_to_height_of_its_overflow_hi
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
-  YGNodeStyleSetPosition(root_child0, YGEdgeStart, 0);
   YGNodeStyleSetPosition(root_child0, YGEdgeTop, 0);
   YGNodeInsertChild(root, root_child0, 0);
 
@@ -1025,6 +1061,229 @@ TEST(YogaTest, absolute_layout_in_wrap_reverse_row_container_flex_end) {
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, absolute_layout_percentage_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root, 200);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child0, YGEdgeTop, 10);
+  YGNodeStyleSetWidth(root_child0, 10);
+  YGNodeStyleSetHeightPercent(root_child0, 50);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(190, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, absolute_child_with_cross_margin) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetJustifyContent(root, YGJustifySpaceBetween);
+  YGNodeStyleSetMinWidth(root, 311);
+  YGNodeStyleSetMaxWidth(root, 311);
+  YGNodeStyleSetMaxHeight(root, 3.68935e+19);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root_child0, YGAlignStretch);
+  YGNodeStyleSetWidth(root_child0, 28);
+  YGNodeStyleSetHeight(root_child0, 27);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child1, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root_child1, YGAlignStretch);
+  YGNodeStyleSetPositionType(root_child1, YGPositionTypeAbsolute);
+  YGNodeStyleSetFlexShrink(root_child1, 1);
+  YGNodeStyleSetMargin(root_child1, YGEdgeTop, 4);
+  YGNodeStyleSetWidthPercent(root_child1, 100);
+  YGNodeStyleSetHeight(root_child1, 15);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child2, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root_child2, YGAlignStretch);
+  YGNodeStyleSetWidth(root_child2, 25);
+  YGNodeStyleSetHeight(root_child2, 27);
+  YGNodeInsertChild(root, root_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(311, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(27, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(28, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(27, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(4, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(311, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(286, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(27, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(311, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(27, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(283, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(28, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(27, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(4, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(311, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(27, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, absolute_child_with_main_margin) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetWidth(root, 20);
+  YGNodeStyleSetHeight(root, 37);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetMargin(root_child0, YGEdgeLeft, 7);
+  YGNodeStyleSetWidth(root_child0, 9);
+  YGNodeStyleSetHeight(root_child0, 9);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(37, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(7, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(9, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(9, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(37, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(11, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(9, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(9, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, absolute_child_with_max_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 200);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child0, YGEdgeBottom, 20);
+  YGNodeStyleSetMaxHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0, 100);
+  YGNodeStyleSetHeight(root_child0_child0, 30);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(150, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child0_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(150, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child0_child0));
 
   YGNodeFreeRecursive(root);
 

--- a/tests/YGAlignContentTest.cpp
+++ b/tests/YGAlignContentTest.cpp
@@ -1877,3 +1877,86 @@ TEST(YogaTest, align_content_stretch_is_not_overriding_align_items) {
 
   YGConfigFree(config);
 }
+
+TEST(YogaTest, align_content_not_stretch_with_align_items_stretch) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 328);
+  YGNodeStyleSetHeight(root, 52);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0, 272);
+  YGNodeStyleSetHeight(root_child0_child0, 44);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child0, 56);
+  YGNodeStyleSetHeight(root_child1_child0, 44);
+  YGNodeInsertChild(root_child1, root_child1_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(328, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(272, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(44, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(272, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(44, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(272, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(56, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(44, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(56, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(44, YGNodeLayoutGetHeight(root_child1_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(328, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(52, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(56, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(272, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(44, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(272, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(44, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(56, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(44, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(56, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(44, YGNodeLayoutGetHeight(root_child1_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}

--- a/tests/YGAlignItemsTest.cpp
+++ b/tests/YGAlignItemsTest.cpp
@@ -50,6 +50,45 @@ TEST(YogaTest, align_items_stretch) {
   YGConfigFree(config);
 }
 
+TEST(YogaTest, align_items_stretch_min_cross) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMinWidth(root, 400);
+  YGNodeStyleSetMinHeight(root, 50);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetHeight(root_child0, 36);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(400, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(400, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(36, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(400, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(400, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(36, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
 TEST(YogaTest, align_items_center) {
   const YGConfigRef config = YGConfigNew();
 
@@ -1229,240 +1268,6 @@ TEST(YogaTest, align_baseline_multiline) {
   YGConfigFree(config);
 }
 
-TEST(YogaTest, align_baseline_multiline_column) {
-  const YGConfigRef config = YGConfigNew();
-
-  const YGNodeRef root = YGNodeNewWithConfig(config);
-  YGNodeStyleSetAlignItems(root, YGAlignBaseline);
-  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
-  YGNodeStyleSetWidth(root, 100);
-  YGNodeStyleSetHeight(root, 100);
-
-  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child0, 50);
-  YGNodeStyleSetHeight(root_child0, 50);
-  YGNodeInsertChild(root, root_child0, 0);
-
-  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child1, 30);
-  YGNodeStyleSetHeight(root_child1, 50);
-  YGNodeInsertChild(root, root_child1, 1);
-
-  const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child1_child0, 20);
-  YGNodeStyleSetHeight(root_child1_child0, 20);
-  YGNodeInsertChild(root_child1, root_child1_child0, 0);
-
-  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child2, 40);
-  YGNodeStyleSetHeight(root_child2, 70);
-  YGNodeInsertChild(root, root_child2, 2);
-
-  const YGNodeRef root_child2_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child2_child0, 10);
-  YGNodeStyleSetHeight(root_child2_child0, 10);
-  YGNodeInsertChild(root_child2, root_child2_child0, 0);
-
-  const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child3, 50);
-  YGNodeStyleSetHeight(root_child3, 20);
-  YGNodeInsertChild(root, root_child3, 3);
-  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child1));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child1_child0));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child0));
-
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetHeight(root_child2));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2_child0));
-
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child3));
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetTop(root_child3));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child3));
-
-  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
-
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
-
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child1));
-
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child1_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child1_child0));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child0));
-
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetHeight(root_child2));
-
-  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child2_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2_child0));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child3));
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetTop(root_child3));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child3));
-
-  YGNodeFreeRecursive(root);
-
-  YGConfigFree(config);
-}
-
-TEST(YogaTest, align_baseline_multiline_column2) {
-  const YGConfigRef config = YGConfigNew();
-
-  const YGNodeRef root = YGNodeNewWithConfig(config);
-  YGNodeStyleSetAlignItems(root, YGAlignBaseline);
-  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
-  YGNodeStyleSetWidth(root, 100);
-  YGNodeStyleSetHeight(root, 100);
-
-  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child0, 50);
-  YGNodeStyleSetHeight(root_child0, 50);
-  YGNodeInsertChild(root, root_child0, 0);
-
-  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child1, 30);
-  YGNodeStyleSetHeight(root_child1, 50);
-  YGNodeInsertChild(root, root_child1, 1);
-
-  const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child1_child0, 20);
-  YGNodeStyleSetHeight(root_child1_child0, 20);
-  YGNodeInsertChild(root_child1, root_child1_child0, 0);
-
-  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child2, 40);
-  YGNodeStyleSetHeight(root_child2, 70);
-  YGNodeInsertChild(root, root_child2, 2);
-
-  const YGNodeRef root_child2_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child2_child0, 10);
-  YGNodeStyleSetHeight(root_child2_child0, 10);
-  YGNodeInsertChild(root_child2, root_child2_child0, 0);
-
-  const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child3, 50);
-  YGNodeStyleSetHeight(root_child3, 20);
-  YGNodeInsertChild(root, root_child3, 3);
-  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child1));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child1_child0));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child0));
-
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetHeight(root_child2));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2_child0));
-
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child3));
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetTop(root_child3));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child3));
-
-  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
-
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
-
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child1));
-
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child1_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child1_child0));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1_child0));
-
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetHeight(root_child2));
-
-  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child2_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2_child0));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child3));
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetTop(root_child3));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child3));
-
-  YGNodeFreeRecursive(root);
-
-  YGConfigFree(config);
-}
-
 TEST(YogaTest, align_baseline_multiline_row_and_column) {
   const YGConfigRef config = YGConfigNew();
 
@@ -2152,6 +1957,260 @@ TEST(YogaTest, align_flex_start_with_shrinking_children_with_stretch) {
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_items_center_justify_content_center) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root, 500);
+  YGNodeStyleSetHeight(root, 500);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
+  YGNodeStyleSetAlignItems(root_child0, YGAlignCenter);
+  YGNodeStyleSetHeight(root_child0, 50);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetJustifyContent(root_child0_child0, YGJustifyCenter);
+  YGNodeStyleSetAlignItems(root_child0_child0, YGAlignCenter);
+  YGNodeStyleSetMargin(root_child0_child0, YGEdgeLeft, 10);
+  YGNodeStyleSetMargin(root_child0_child0, YGEdgeRight, 10);
+  YGNodeStyleSetHeightPercent(root_child0_child0, 100);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0_child0, 10);
+  YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(500, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(500, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(500, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(245, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(500, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(500, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(500, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(245, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_baseline_child_margin_percent) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignBaseline);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMarginPercent(root_child0, YGEdgeLeft, 5);
+  YGNodeStyleSetMarginPercent(root_child0, YGEdgeTop, 5);
+  YGNodeStyleSetMarginPercent(root_child0, YGEdgeRight, 5);
+  YGNodeStyleSetMarginPercent(root_child0, YGEdgeBottom, 5);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 50);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMarginPercent(root_child1_child0, YGEdgeLeft, 1);
+  YGNodeStyleSetMarginPercent(root_child1_child0, YGEdgeTop, 1);
+  YGNodeStyleSetMarginPercent(root_child1_child0, YGEdgeRight, 1);
+  YGNodeStyleSetMarginPercent(root_child1_child0, YGEdgeBottom, 1);
+  YGNodeStyleSetWidth(root_child1_child0, 50);
+  YGNodeStyleSetHeight(root_child1_child0, 10);
+  YGNodeInsertChild(root_child1, root_child1_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(1, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(1, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(5, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(1, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_baseline_nested_column) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignBaseline);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 60);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child0, 50);
+  YGNodeStyleSetHeight(root_child1_child0, 80);
+  YGNodeInsertChild(root_child1, root_child1_child0, 0);
+
+  const YGNodeRef root_child1_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child0_child0, 50);
+  YGNodeStyleSetHeight(root_child1_child0_child0, 30);
+  YGNodeInsertChild(root_child1_child0, root_child1_child0_child0, 0);
+
+  const YGNodeRef root_child1_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1_child0_child1, 50);
+  YGNodeStyleSetHeight(root_child1_child0_child1, 40);
+  YGNodeInsertChild(root_child1_child0, root_child1_child0_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root_child1_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child1_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child1_child0_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child1_child0_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetHeight(root_child1_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1_child0_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root_child1_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1_child0_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child1_child0_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1_child0_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child1_child0_child1));
 
   YGNodeFreeRecursive(root);
 

--- a/tests/YGAlignSelfTest.cpp
+++ b/tests/YGAlignSelfTest.cpp
@@ -52,6 +52,63 @@ TEST(YogaTest, align_self_center) {
   YGConfigFree(config);
 }
 
+TEST(YogaTest, align_self_center_undefined_max_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetWidth(root, 280);
+  YGNodeStyleSetMinHeight(root, 52);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 240);
+  YGNodeStyleSetHeight(root_child0, 44);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignSelf(root_child1, YGAlignCenter);
+  YGNodeStyleSetWidth(root_child1, 40);
+  YGNodeStyleSetHeight(root_child1, 56);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(280, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(56, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(240, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(44, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(240, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(56, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(280, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(56, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(240, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(44, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(56, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
 TEST(YogaTest, align_self_flex_end) {
   const YGConfigRef config = YGConfigNew();
 

--- a/tests/YGBorderTest.cpp
+++ b/tests/YGBorderTest.cpp
@@ -173,8 +173,6 @@ TEST(YogaTest, border_center_child) {
   const YGNodeRef root = YGNodeNewWithConfig(config);
   YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
   YGNodeStyleSetAlignItems(root, YGAlignCenter);
-  YGNodeStyleSetBorder(root, YGEdgeStart, 10);
-  YGNodeStyleSetBorder(root, YGEdgeEnd, 20);
   YGNodeStyleSetBorder(root, YGEdgeBottom, 20);
   YGNodeStyleSetWidth(root, 100);
   YGNodeStyleSetHeight(root, 100);
@@ -190,7 +188,7 @@ TEST(YogaTest, border_center_child) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(35, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
@@ -202,7 +200,7 @@ TEST(YogaTest, border_center_child) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(35, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));

--- a/tests/YGDisplayTest.cpp
+++ b/tests/YGDisplayTest.cpp
@@ -371,3 +371,62 @@ TEST(YogaTest, display_none_with_position_absolute) {
 
   YGConfigFree(config);
 }
+
+TEST(YogaTest, display_none_absolute_child) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexGrow(root_child0, 1);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child1, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child1, YGEdgeLeft, 10);
+  YGNodeStyleSetPosition(root_child1, YGEdgeTop, 10);
+  YGNodeStyleSetWidth(root_child1, 20);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeStyleSetDisplay(root_child1, YGDisplayNone);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}

--- a/tests/YGFlexDirectionTest.cpp
+++ b/tests/YGFlexDirectionTest.cpp
@@ -414,3 +414,70 @@ TEST(YogaTest, flex_direction_row_reverse) {
 
   YGConfigFree(config);
 }
+
+TEST(YogaTest, flex_direction_column_reverse_no_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionColumnReverse);
+  YGNodeStyleSetWidth(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetHeight(root_child2, 10);
+  YGNodeInsertChild(root, root_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}

--- a/tests/YGFlexTest.cpp
+++ b/tests/YGFlexTest.cpp
@@ -607,3 +607,195 @@ TEST(YogaTest, flex_grow_less_than_factor_one) {
 
   YGConfigFree(config);
 }
+
+TEST(YogaTest, single_flex_child_after_absolute_child) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root, 428);
+  YGNodeStyleSetHeight(root, 845);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidthPercent(root_child0, 100);
+  YGNodeStyleSetHeightPercent(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexGrow(root_child1, 1);
+  YGNodeStyleSetFlexShrink(root_child1, 1);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexBasis(root_child2, 174);
+  YGNodeInsertChild(root, root_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(428, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(845, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(428, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(845, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(428, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(671, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(671, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(428, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(174, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(428, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(845, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(428, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(845, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(428, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(671, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(671, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(428, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(174, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_basis_zero_undefined_main_size) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexBasis(root_child0, 0);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0, 100);
+  YGNodeStyleSetHeight(root_child0_child0, 50);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, only_shrinkable_item_with_flex_basis_zero) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root, 480);
+  YGNodeStyleSetMaxHeight(root, 764);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexShrink(root_child0, 1);
+  YGNodeStyleSetFlexBasis(root_child0, 0);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexBasis(root_child1, 93);
+  YGNodeStyleSetMargin(root_child1, YGEdgeBottom, 6);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexBasis(root_child2, 764);
+  YGNodeInsertChild(root, root_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(480, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(764, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(480, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(480, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(99, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(480, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(764, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(480, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(764, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(480, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(480, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(99, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(480, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(764, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}

--- a/tests/YGMarginTest.cpp
+++ b/tests/YGMarginTest.cpp
@@ -20,7 +20,6 @@ TEST(YogaTest, margin_start) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetMargin(root_child0, YGEdgeStart, 10);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -30,7 +29,7 @@ TEST(YogaTest, margin_start) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
@@ -42,7 +41,7 @@ TEST(YogaTest, margin_start) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
@@ -102,7 +101,6 @@ TEST(YogaTest, margin_end) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetMargin(root_child0, YGEdgeEnd, 10);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -112,7 +110,7 @@ TEST(YogaTest, margin_end) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
@@ -124,7 +122,7 @@ TEST(YogaTest, margin_end) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
@@ -185,8 +183,6 @@ TEST(YogaTest, margin_and_flex_row) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexGrow(root_child0, 1);
-  YGNodeStyleSetMargin(root_child0, YGEdgeStart, 10);
-  YGNodeStyleSetMargin(root_child0, YGEdgeEnd, 10);
   YGNodeInsertChild(root, root_child0, 0);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
@@ -195,9 +191,9 @@ TEST(YogaTest, margin_and_flex_row) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
@@ -207,9 +203,9 @@ TEST(YogaTest, margin_and_flex_row) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
   YGNodeFreeRecursive(root);
@@ -309,8 +305,6 @@ TEST(YogaTest, margin_and_stretch_column) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexGrow(root_child0, 1);
-  YGNodeStyleSetMargin(root_child0, YGEdgeStart, 10);
-  YGNodeStyleSetMargin(root_child0, YGEdgeEnd, 10);
   YGNodeInsertChild(root, root_child0, 0);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
@@ -319,9 +313,9 @@ TEST(YogaTest, margin_and_stretch_column) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
@@ -331,9 +325,9 @@ TEST(YogaTest, margin_and_stretch_column) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
   YGNodeFreeRecursive(root);
@@ -351,7 +345,6 @@ TEST(YogaTest, margin_with_sibling_row) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexGrow(root_child0, 1);
-  YGNodeStyleSetMargin(root_child0, YGEdgeEnd, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
@@ -366,12 +359,12 @@ TEST(YogaTest, margin_with_sibling_row) {
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
@@ -381,14 +374,14 @@ TEST(YogaTest, margin_with_sibling_row) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
 
   YGNodeFreeRecursive(root);
@@ -953,8 +946,6 @@ TEST(YogaTest, margin_auto_start_and_end_column) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetMarginAuto(root_child0, YGEdgeStart);
-  YGNodeStyleSetMarginAuto(root_child0, YGEdgeEnd);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
@@ -970,12 +961,12 @@ TEST(YogaTest, margin_auto_start_and_end_column) {
   ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(200, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(75, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(150, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
   ASSERT_FLOAT_EQ(75, YGNodeLayoutGetTop(root_child1));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child1));
@@ -987,12 +978,12 @@ TEST(YogaTest, margin_auto_start_and_end_column) {
   ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(200, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(150, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(75, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetLeft(root_child1));
   ASSERT_FLOAT_EQ(75, YGNodeLayoutGetTop(root_child1));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child1));
@@ -1010,8 +1001,6 @@ TEST(YogaTest, margin_auto_start_and_end) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetMarginAuto(root_child0, YGEdgeStart);
-  YGNodeStyleSetMarginAuto(root_child0, YGEdgeEnd);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
@@ -1027,7 +1016,7 @@ TEST(YogaTest, margin_auto_start_and_end) {
   ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(200, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(75, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
@@ -1044,7 +1033,7 @@ TEST(YogaTest, margin_auto_start_and_end) {
   ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(200, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(75, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(150, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));

--- a/tests/YGMinMaxDimensionTest.cpp
+++ b/tests/YGMinMaxDimensionTest.cpp
@@ -51,6 +51,87 @@ TEST(YogaTest, max_width) {
   YGConfigFree(config);
 }
 
+TEST(YogaTest, min_width_larger_than_width) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 25);
+  YGNodeStyleSetMinWidth(root_child0, 50);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, min_height_larger_than_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetHeight(root_child0, 25);
+  YGNodeStyleSetMinHeight(root_child0, 50);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
 TEST(YogaTest, max_height) {
   const YGConfigRef config = YGConfigNew();
 
@@ -86,6 +167,66 @@ TEST(YogaTest, max_height) {
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, min_height_with_nested_fixed_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetPadding(root, YGEdgeLeft, 16);
+  YGNodeStyleSetPadding(root, YGEdgeRight, 16);
+  YGNodeStyleSetWidth(root, 320);
+  YGNodeStyleSetMinHeight(root, 44);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignSelf(root_child0, YGAlignFlexStart);
+  YGNodeStyleSetMargin(root_child0, YGEdgeTop, 8);
+  YGNodeStyleSetMargin(root_child0, YGEdgeBottom, 9);
+  YGNodeStyleSetMinHeight(root_child0, 28);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0, 40);
+  YGNodeStyleSetHeight(root_child0_child0, 40);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(57, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(16, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(8, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(57, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(264, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(8, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetHeight(root_child0_child0));
 
   YGNodeFreeRecursive(root);
 
@@ -170,6 +311,52 @@ TEST(YogaTest, align_items_min_max) {
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(60, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_items_center_min_max_with_padding) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignCenter);
+  YGNodeStyleSetPadding(root, YGEdgeTop, 8);
+  YGNodeStyleSetPadding(root, YGEdgeBottom, 8);
+  YGNodeStyleSetMinWidth(root, 320);
+  YGNodeStyleSetMaxWidth(root, 320);
+  YGNodeStyleSetMinHeight(root, 72);
+  YGNodeStyleSetMaxHeight(root, 504);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 62);
+  YGNodeStyleSetHeight(root_child0, 62);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(78, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(8, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(62, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(62, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(78, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(258, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(8, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(62, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(62, YGNodeLayoutGetHeight(root_child0));
 
   YGNodeFreeRecursive(root);
 
@@ -1182,6 +1369,180 @@ TEST(YogaTest, min_max_percent_no_width_height) {
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, min_max_percent_different_width_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignItems(root, YGAlignFlexStart);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 200);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMinWidthPercent(root_child0, 10);
+  YGNodeStyleSetMaxWidthPercent(root_child0, 10);
+  YGNodeStyleSetMinHeightPercent(root_child0, 10);
+  YGNodeStyleSetMaxHeightPercent(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, undefined_height_with_min_max) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root, 320);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMaxHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, undefined_width_with_min_max) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetHeight(root, 50);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMaxWidth(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, undefined_width_with_min_max_row) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetHeight(root, 50);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetMinWidth(root_child0, 60);
+  YGNodeStyleSetMaxWidth(root_child0, 300);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0, 30);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
 
   YGNodeFreeRecursive(root);
 

--- a/tests/YGPaddingTest.cpp
+++ b/tests/YGPaddingTest.cpp
@@ -173,8 +173,6 @@ TEST(YogaTest, padding_center_child) {
   const YGNodeRef root = YGNodeNewWithConfig(config);
   YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
   YGNodeStyleSetAlignItems(root, YGAlignCenter);
-  YGNodeStyleSetPadding(root, YGEdgeStart, 10);
-  YGNodeStyleSetPadding(root, YGEdgeEnd, 20);
   YGNodeStyleSetPadding(root, YGEdgeBottom, 20);
   YGNodeStyleSetWidth(root, 100);
   YGNodeStyleSetHeight(root, 100);
@@ -190,7 +188,7 @@ TEST(YogaTest, padding_center_child) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(35, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
@@ -202,7 +200,7 @@ TEST(YogaTest, padding_center_child) {
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(35, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));

--- a/tests/YGPercentageTest.cpp
+++ b/tests/YGPercentageTest.cpp
@@ -594,6 +594,74 @@ TEST(YogaTest, percentage_flex_basis_cross_min_width) {
   YGConfigFree(config);
 }
 
+TEST(YogaTest, percentage_main_max_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root, 71);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetAlignItems(root_child0, YGAlignFlexStart);
+  YGNodeStyleSetHeight(root_child0, 151);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexBasis(root_child0_child0, 15);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexBasis(root_child0_child1, 48);
+  YGNodeStyleSetMaxHeightPercent(root_child0_child1, 33);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(71, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(151, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(71, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(151, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(48, YGNodeLayoutGetHeight(root_child0_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(71, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(151, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(71, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(151, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(71, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(71, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(48, YGNodeLayoutGetHeight(root_child0_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
 TEST(YogaTest, percentage_multiple_nested_with_padding_margin_and_percentage_values) {
   const YGConfigRef config = YGConfigNew();
 
@@ -997,6 +1065,7 @@ TEST(YogaTest, percentage_container_in_wrapping_container) {
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0_child0, YGJustifyCenter);
+  YGNodeStyleSetAlignItems(root_child0_child0, YGAlignCenter);
   YGNodeStyleSetWidthPercent(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
@@ -1133,6 +1202,114 @@ TEST(YogaTest, percent_absolute_position) {
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
   ASSERT_FLOAT_EQ(60, YGNodeLayoutGetWidth(root_child0_child1));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetHeight(root_child0_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, percentage_different_width_height) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetWidth(root, 200);
+  YGNodeStyleSetHeight(root, 300);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexGrow(root_child0, 1);
+  YGNodeStyleSetHeightPercent(root_child0, 30);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetHeightPercent(root_child1, 30);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(300, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(300, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, percentage_different_width_height_column) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root, 200);
+  YGNodeStyleSetHeight(root, 300);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexGrow(root_child0, 1);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetHeightPercent(root_child1, 30);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(300, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(210, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(210, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(300, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(210, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(210, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child1));
 
   YGNodeFreeRecursive(root);
 


### PR DESCRIPTION
Summary:
flexlayout has the same fixtures forked from Yoga, with some disabled, and some added. This syncs that list to Yoga, adding the fixes made to it along with new fixtures.

One new test absolute_child_with_max_height_larger_shrinkable_grandchild is failing, along with two fixtures where Chrome had recently changed its behaviors. These are commented out at the moment before I do something smarter with the test runner to allow more fixtures.

Differential Revision: D42242096

