### PR TITLE
Use more specific enums types where previously using number

### DIFF
--- a/javascript/src_js/wrapAsm.d.ts
+++ b/javascript/src_js/wrapAsm.d.ts
@@ -8,17 +8,19 @@
  */
 
 import type {
-  Edge,
-  Wrap,
   Align,
+  Direction,
+  Display,
+  Edge,
+  ExperimentalFeature,
   FlexDirection,
   Gutter,
-  Direction,
-  PositionType,
-  Overflow,
   Justify,
-  Display,
-  ExperimentalFeature,
+  MeasureMode,
+  Overflow,
+  PositionType,
+  Unit,
+  Wrap,
 } from './generated/YGEnums';
 
 import type * as YGEnums from './generated/YGEnums';
@@ -38,7 +40,7 @@ type Size = {
 }
 
 type Value = {
-  unit: number;
+  unit: Unit;
   value: number;
 }
 
@@ -53,14 +55,14 @@ export type Config = {
   useLegacyStretchBehaviour(): boolean,
   setUseLegacyStretchBehaviour(useLegacyStretchBehaviour: boolean): void,
   useWebDefaults(): boolean,
-  setUseWebDefaults(useWebDefaults): void,
+  setUseWebDefaults(useWebDefaults: boolean): void,
 };
 
 export type MeasureFunction = (
   width: number,
-  widthMode: number,
+  widthMode: MeasureMode,
   height: number,
-  heightMode: number
+  heightMode: MeasureMode
 ) => Size;
 
 export type Node = {


### PR DESCRIPTION
Summary: The Yoga JS bindings converted a previous Flow type directly to TypeScript. The enum types we expose are safer than accepting raw ordinal numbers, and we should replace the places in the typings where an ordinal was accepted instead of the specific type.


Differential Revision: D42265824

