### PR TITLE
Fix typo "encmake" in emcmakeGenerateTask()

### DIFF
--- a/javascript/just.config.js
+++ b/javascript/just.config.js
@@ -108,7 +108,7 @@ function emcmakeGenerateTask() {
       "build",
       ...(ninja ? ["-G", "Ninja"] : []),
     ];
-    logger.info(["encmake", ...args].join(" "));
+    logger.info(["emcmake", ...args].join(" "));
 
     return spawn(emcmake, args);
   };


### PR DESCRIPTION
Summary: The task definitions in the (OSS-specific) build for Yoga's JS bindings expose `emcmakeGenerateTask()` to run Emscripten's `emcmake` wrapper over `cmake`'s project generator. This fixes a typo in its log output, where it will output "e*n*cmake" instead of "e*m*cmake".

Differential Revision: D42279467

