### PR TITLE
Make cmakeBuildTask accept opts instead of array

### DIFF
--- a/javascript/.eslintrc.js
+++ b/javascript/.eslintrc.js
@@ -8,6 +8,7 @@
  */
 
 module.exports = {
+  root: true,
   ignorePatterns: ["dist/**", "**/*.d.ts"],
   parser: "@babel/eslint-parser",
   extends: [

--- a/javascript/.prettierrc.js
+++ b/javascript/.prettierrc.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+ module.exports = {
+    trailingComma: "es5",
+    tabWidth: 2,
+    semi: true,
+    singleQuote: false,
+  };

--- a/javascript/just.config.js
+++ b/javascript/just.config.js
@@ -37,7 +37,7 @@ task(
 );
 
 function defineFlavor(flavor, env) {
-  task(`cmake-build:${flavor}`, cmakeBuildTask([flavor]));
+  task(`cmake-build:${flavor}`, cmakeBuildTask({ targets: [flavor] }));
   task(`jest:${flavor}`, jestTask({ env }));
   task(
     `test:${flavor}`,
@@ -51,8 +51,14 @@ defineFlavor("wasm-async", { WASM: 1, SYNC: 0 });
 defineFlavor("wasm-sync", { WASM: 1, SYNC: 1 });
 
 task("cmake-build:all", cmakeBuildTask());
-task("cmake-build:async", cmakeBuildTask(["asmjs-async", "wasm-async"]));
-task("cmake-build:sync", cmakeBuildTask(["asmjs-sync", "wasm-sync"]));
+task(
+  "cmake-build:async",
+  cmakeBuildTask({ targets: ["asmjs-async", "wasm-async"] })
+);
+task(
+  "cmake-build:sync",
+  cmakeBuildTask({ targets: ["asmjs-sync", "wasm-sync"] })
+);
 
 task("build", series("prepare-for-build", "cmake-build:all"));
 
@@ -114,13 +120,13 @@ function emcmakeGenerateTask() {
   };
 }
 
-function cmakeBuildTask(targets) {
+function cmakeBuildTask(opts) {
   return () => {
     const cmake = which.sync("cmake");
     const args = [
       "--build",
       "build",
-      ...(targets ? ["--target", ...targets] : []),
+      ...(opts?.targets ? ["--target", ...opts.targets] : []),
     ];
     logger.info(["cmake", ...args].join(" "));
 


### PR DESCRIPTION
Summary: For expandability, consistency with other tasks, and added explicitness.

Differential Revision: D42285129

