### PR TITLE
Round pixel values of `intrinsicSize` with `YGRoundPixelValue`

### DIFF
--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -320,11 +320,15 @@ YG_EDGE_PROPERTY(gap, Gap, Gap, YGGutterAll)
 }
 
 - (CGSize)intrinsicSize {
-  const CGSize constrainedSize = {
+  CGSize constrainedSize = {
       .width = YGUndefined,
       .height = YGUndefined,
   };
-  return [self calculateLayoutWithSize:constrainedSize];
+  constrainedSize = [self calculateLayoutWithSize:constrainedSize];
+  return (CGSize){
+      .width = YGRoundPixelValue(constrainedSize.width),
+      .height = YGRoundPixelValue(constrainedSize.height),
+  };
 }
 
 - (CGSize)calculateLayoutWithSize:(CGSize)size {


### PR DESCRIPTION
This PR makes `intrinsicSize` return rounded pixel values using `YGRoundPixelValue` as `YGApplyLayoutToViewHierarchy` does.

This change prevents text truncation due to the low precision of C++ `float` when sizing the view containing `UILabel` using `intinsicSize`.

```swift
override func sizeToFit() {
  self.bounds.size = self.yoga.intrinsicSize
}
```