### PR TITLE
Colorize GTest Output in GitHub Actions

### DIFF
--- a/.github/workflows/validate-cpp.yml
+++ b/.github/workflows/validate-cpp.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  GTEST_COLOR: 1
+
 jobs:
   test:
     name: Build and Test [${{ matrix.os }}][${{ matrix.mode }}]


### PR DESCRIPTION
GitHub Actions supports terminal colors, but most programs won't output color to a non-interactive terminal. We can control this via env variable, so that GTest output in GitHub actions is colorized.

Before:
<img width="755" alt="image" src="https://user-images.githubusercontent.com/835219/212755266-0d31636e-3ea3-4efb-a767-f71e969166df.png">

After:
<img width="765" alt="image" src="https://user-images.githubusercontent.com/835219/212755136-5cdc9a0a-cab9-4f4a-896d-b48eb8cfb128.png">
