### PR TITLE
fix breaking change in setMeasureFunc after emscripten migration

### DIFF
--- a/javascript/tests/YGMeasureTest.test.js
+++ b/javascript/tests/YGMeasureTest.test.js
@@ -23,3 +23,33 @@ test("dont_measure_single_grow_shrink_child", () => {
 
   root.freeRecursive();
 });
+
+test("dont_fail_with_incomplete_measure_dimensions", () => {
+  const heightOnlyCallback = getMeasureCounter(Yoga, () => ({ height: 10 }));
+  const widthOnlyCallback = getMeasureCounter(Yoga, () => ({ width: 10 }));
+  const emptyCallback = getMeasureCounter(Yoga, () => ({}));
+
+  const root = Yoga.Node.create();
+  root.setWidth(100);
+  root.setHeight(100);
+
+  const node1 = Yoga.Node.create();
+  const node2 = Yoga.Node.create();
+  const node3 = Yoga.Node.create();
+
+  root.insertChild(node1, root.getChildCount());
+  root.insertChild(node2, root.getChildCount());
+  root.insertChild(node3, root.getChildCount());
+
+  node1.setMeasureFunc(heightOnlyCallback);
+  node1.setMeasureFunc(widthOnlyCallback);
+  node1.setMeasureFunc(emptyCallback);
+
+  root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+  expect(heightOnlyCallback.get()).toBe(1);
+  expect(widthOnlyCallback.get()).toBe(1);
+  expect(emptyCallback.get()).toBe(1);
+
+  root.freeRecursive();
+});

--- a/javascript/tests/YGMeasureTest.test.js
+++ b/javascript/tests/YGMeasureTest.test.js
@@ -42,8 +42,8 @@ test("dont_fail_with_incomplete_measure_dimensions", () => {
   root.insertChild(node3, root.getChildCount());
 
   node1.setMeasureFunc(heightOnlyCallback.inc);
-  node1.setMeasureFunc(widthOnlyCallback.inc);
-  node1.setMeasureFunc(emptyCallback.inc);
+  node2.setMeasureFunc(widthOnlyCallback.inc);
+  node3.setMeasureFunc(emptyCallback.inc);
 
   root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
 

--- a/javascript/tests/YGMeasureTest.test.js
+++ b/javascript/tests/YGMeasureTest.test.js
@@ -41,9 +41,9 @@ test("dont_fail_with_incomplete_measure_dimensions", () => {
   root.insertChild(node2, root.getChildCount());
   root.insertChild(node3, root.getChildCount());
 
-  node1.setMeasureFunc(heightOnlyCallback);
-  node1.setMeasureFunc(widthOnlyCallback);
-  node1.setMeasureFunc(emptyCallback);
+  node1.setMeasureFunc(heightOnlyCallback.inc);
+  node1.setMeasureFunc(widthOnlyCallback.inc);
+  node1.setMeasureFunc(emptyCallback.inc);
 
   root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
 

--- a/javascript/tests/YGMeasureTest.test.js
+++ b/javascript/tests/YGMeasureTest.test.js
@@ -51,5 +51,14 @@ test("dont_fail_with_incomplete_measure_dimensions", () => {
   expect(widthOnlyCallback.get()).toBe(1);
   expect(emptyCallback.get()).toBe(1);
 
+  expect(node1.getComputedWidth()).toBe(100);
+  expect(node1.getComputedHeight()).toBe(10);
+
+  expect(node2.getComputedWidth()).toBe(100);
+  expect(node2.getComputedHeight()).toBe(0);
+
+  expect(node3.getComputedWidth()).toBe(100);
+  expect(node3.getComputedHeight()).toBe(0);
+
   root.freeRecursive();
 });


### PR DESCRIPTION
current `MeasureFunc` is stricter than the previous one and when it returns only one dimension object yoga throw `TypeError: Missing field:  "height"` or `TypeError: Missing field:  "width"`

this is a breaking change and `@react-pdf` use this feature a lot, so i wanna return the previous behavior back

codesandbox with reproduction on `yoga-layout-prebuilt`: https://codesandbox.io/s/yoga-layout-measure-callback-wrong-data-1l9133