### PR TITLE
fix type for getFlexBasis

### DIFF
--- a/javascript/src_js/wrapAsm.d.ts
+++ b/javascript/src_js/wrapAsm.d.ts
@@ -92,7 +92,7 @@ export type Node = {
   getComputedTop(): number,
   getComputedWidth(): number,
   getDisplay(): Display,
-  getFlexBasis(): number,
+  getFlexBasis(): Value,
   getFlexDirection(): FlexDirection,
   getFlexGrow(): number,
   getFlexShrink(): number,


### PR DESCRIPTION
`getFlexBasis` returns `Value` not a `number`


source:
https://github.com/facebook/yoga/blob/main/javascript/src_native/Node.hh#L145
