### PR TITLE
Flex basis auto is mysteriously missed again

### DIFF
--- a/javascript/src_native/embind.cc
+++ b/javascript/src_native/embind.cc
@@ -89,6 +89,7 @@ EMSCRIPTEN_BINDINGS(YOGA_LAYOUT) {
       .function("setFlex", &Node::setFlex)
       .function("setFlexBasis", &Node::setFlexBasis)
       .function("setFlexBasisPercent", &Node::setFlexBasisPercent)
+      .function("setFlexBasisAuto", &Node::setFlexBasisAuto)
       .function("setFlexGrow", &Node::setFlexGrow)
       .function("setFlexShrink", &Node::setFlexShrink)
 

--- a/javascript/tests/YGFlexBasisAuto.test.js
+++ b/javascript/tests/YGFlexBasisAuto.test.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+test("flex_basis_auto", () => {
+  const root = Yoga.Node.create();
+
+  expect(root.getFlexBasis().unit).toBe(Yoga.UNIT_AUTO);
+
+  root.setFlexBasis(10);
+  expect(root.getFlexBasis().unit).toBe(Yoga.UNIT_POINT);
+  expect(root.getFlexBasis().value).toBe(10);
+
+  root.setFlexBasisAuto();
+  expect(root.getFlexBasis().unit).toBe(Yoga.UNIT_AUTO);
+
+  root.freeRecursive();
+});


### PR DESCRIPTION
- adds a test to check that `setFlexBasisAuto` is here