### PR TITLE
Typescript: Fix typo in type defintions

### DIFF
--- a/javascript/src_js/wrapAsm.d.ts
+++ b/javascript/src_js/wrapAsm.d.ts
@@ -156,7 +156,7 @@ export type Node = {
   setWidth(width: number | string): void,
   setWidthAuto(): void,
   setWidthPercent(width: number): void,
-  unsetMeasureFun(): void,
+  unsetMeasureFunc(): void,
 };
 
 export type Yoga = {


### PR DESCRIPTION
Extracted the typo fix from https://github.com/facebook/yoga/pull/1228