### PR TITLE
Typescript: improve enum types and setMargin type

### DIFF
--- a/javascript/src_js/wrapAsm.d.ts
+++ b/javascript/src_js/wrapAsm.d.ts
@@ -135,7 +135,7 @@ export type Node = {
   setHeightPercent(height: number): void,
   setJustifyContent(justifyContent: Justify): void,
   setGap(gutter: Gutter, gapLength: number): Value,
-  setMargin(edge: Edge, margin: number): void,
+  setMargin(edge: Edge, margin: number | string): void,
   setMarginAuto(edge: Edge): void,
   setMarginPercent(edge: Edge, margin: number): void,
   setMaxHeight(maxHeight: number | string): void,


### PR DESCRIPTION
Currently, it is impossible to write `node.setPositionType(2)` instead of `node.setPositionType(POSITION_TYPE_ABSOLUTE)`. I understand that the idea is to force explicit usage of the enums. However, declaring `type POSITION_TYPE_ABSOLUTE = 2 & ['POSITION_TYPE']` artificially limits use cases, where, for example, the state should be serialized typesafe.

Additionally, this PR fixes the incorrect typing of `setMargin(edge: Edge, margin: number)` by extending the type to `margin: number | string`