### PR TITLE
Minor: removed extra semicolon

### DIFF
--- a/yoga/event/event.h
+++ b/yoga/event/event.h
@@ -80,7 +80,7 @@ struct YOGA_EXPORT Event {
     template <Type E>
     const TypedData<E>& get() const {
       return *static_cast<const TypedData<E>*>(data_);
-    };
+    }
   };
 
   static void reset();


### PR DESCRIPTION
Latest `emscripten` compiler shows the next warning:
```
yoga/event/event.h:83:6: warning: extra ‘;’ [-Wpedantic]
   83 |     };
      |      ^
```

This small PR fixes it