### PR TITLE
Remove BitUtils Usage in YGNode (#36988)

### DIFF
--- a/yoga/YGMacros.h
+++ b/yoga/YGMacros.h
@@ -82,15 +82,3 @@ constexpr int n() {
 #else
 #define YG_ENUM_SEQ_DECL YG_ENUM_DECL
 #endif
-
-#ifdef __GNUC__
-#define YG_DEPRECATED __attribute__((deprecated))
-#elif defined(_MSC_VER)
-#define YG_DEPRECATED __declspec(deprecated)
-#elif __cplusplus >= 201402L
-#if defined(__has_cpp_attribute)
-#if __has_cpp_attribute(deprecated)
-#define YG_DEPRECATED [[deprecated]]
-#endif
-#endif
-#endif

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -16,7 +16,6 @@
 #include "YGConfig.h"
 #include "YGLayout.h"
 #include "YGStyle.h"
-#include "YGMacros.h"
 #include "Yoga-internal.h"
 
 YGConfigRef YGConfigGetDefault();
@@ -307,7 +306,7 @@ public:
 
   // TODO: rvalue override for setChildren
 
-  YG_DEPRECATED void setConfig(YGConfigRef config) { config_ = config; }
+  void setConfig(YGConfigRef config) { config_ = config; }
 
   void setDirty(bool isDirty);
   void setLayoutLastOwnerDirection(YGDirection direction);

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -122,6 +122,14 @@ YOGA_EXPORT void YGNodeSetContext(YGNodeRef node, void* context) {
   return node->setContext(context);
 }
 
+YOGA_EXPORT YGConfigRef YGNodeGetConfig(YGNodeRef node) {
+  return node->getConfig();
+}
+
+YOGA_EXPORT void YGNodeSetConfig(YGNodeRef node, YGConfigRef config) {
+  node->setConfig(config);
+}
+
 YOGA_EXPORT bool YGNodeHasMeasureFunc(YGNodeRef node) {
   return node->hasMeasureFunc();
 }

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -134,6 +134,10 @@ WIN_EXPORT void YGNodeCopyStyle(YGNodeRef dstNode, YGNodeRef srcNode);
 
 WIN_EXPORT void* YGNodeGetContext(YGNodeRef node);
 WIN_EXPORT void YGNodeSetContext(YGNodeRef node, void* context);
+
+WIN_EXPORT YGConfigRef YGNodeGetConfig(YGNodeRef node);
+WIN_EXPORT void YGNodeSetConfig(YGNodeRef node, YGConfigRef config);
+
 void YGConfigSetPrintTreeFlag(YGConfigRef config, bool enabled);
 bool YGNodeHasMeasureFunc(YGNodeRef node);
 WIN_EXPORT void YGNodeSetMeasureFunc(YGNodeRef node, YGMeasureFunc measureFunc);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/react-native/pull/36988

BitUtils functions in Yoga are like bit fields, with more steps, and more error prone (you need to work with explicit offsets). Replace usage with a bitfield struct.

Differential Revision: D45133645

