### PR TITLE
Testing: Remove private headers from podspecs (#36993)

### DIFF
--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |spec|
       '-std=c++14',
       '-fPIC'
   ]
-  spec.source_files = 'yoga/**/*.{c,h,cpp}'
-  spec.public_header_files = 'yoga/*.h'
+  spec.source_files = 'yoga/**/*.{h,cpp}'
+  spec.public_header_files = 'yoga/{Yoga,YGEnums,YGMacros,YGValue}.h'
 
 end

--- a/yoga/BitUtils.h
+++ b/yoga/BitUtils.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-
 #include <cstdio>
 #include <cstdint>
 #include "YGEnums.h"
@@ -67,5 +65,3 @@ inline void setBooleanData(uint8_t& flags, size_t index, bool value) {
 } // namespace detail
 } // namespace yoga
 } // namespace facebook
-
-#endif

--- a/yoga/CompactValue.h
+++ b/yoga/CompactValue.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-
 #if defined(__has_include) && __has_include(<version>)
 // needed to be able to evaluate defined(__cpp_lib_bit_cast)
 #include <version>
@@ -212,5 +210,3 @@ constexpr bool operator!=(CompactValue a, CompactValue b) noexcept {
 } // namespace detail
 } // namespace yoga
 } // namespace facebook
-
-#endif

--- a/yoga/Utils.h
+++ b/yoga/Utils.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-
 #include "YGNode.h"
 #include "Yoga-internal.h"
 #include "CompactValue.h"
@@ -146,5 +144,3 @@ inline YGFloatOptional YGResolveValueMargin(
     const float ownerSize) {
   return value.isAuto() ? YGFloatOptional{0} : YGResolveValue(value, ownerSize);
 }
-
-#endif

--- a/yoga/YGConfig.h
+++ b/yoga/YGConfig.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-
 #include "Yoga-internal.h"
 #include "Yoga.h"
 
@@ -77,5 +75,3 @@ public:
     setCloneNodeCallback(YGCloneNodeFunc{nullptr});
   }
 };
-
-#endif

--- a/yoga/YGFloatOptional.h
+++ b/yoga/YGFloatOptional.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-
 #include <cmath>
 #include <limits>
 #include "Yoga-internal.h"
@@ -70,5 +68,3 @@ inline bool operator>=(YGFloatOptional lhs, YGFloatOptional rhs) {
 inline bool operator<=(YGFloatOptional lhs, YGFloatOptional rhs) {
   return lhs < rhs || lhs == rhs;
 }
-
-#endif

--- a/yoga/YGLayout.h
+++ b/yoga/YGLayout.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-
 #include "BitUtils.h"
 #include "YGFloatOptional.h"
 #include "Yoga-internal.h"
@@ -63,5 +61,3 @@ public:
   bool operator==(YGLayout layout) const;
   bool operator!=(YGLayout layout) const { return !(*this == layout); }
 };
-
-#endif

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-
 #include <cstdint>
 #include <stdio.h>
 #include "CompactValue.h"
@@ -344,5 +342,3 @@ public:
   bool isNodeFlexible();
   void reset();
 };
-
-#endif

--- a/yoga/YGNodePrint.h
+++ b/yoga/YGNodePrint.h
@@ -9,8 +9,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-
 #include <string>
 
 #include "Yoga.h"
@@ -26,7 +24,5 @@ void YGNodeToString(
 
 } // namespace yoga
 } // namespace facebook
-
-#endif
 
 #endif

--- a/yoga/YGStyle.h
+++ b/yoga/YGStyle.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-
 #include <algorithm>
 #include <array>
 #include <cstdint>
@@ -237,5 +235,3 @@ YOGA_EXPORT bool operator==(const YGStyle& lhs, const YGStyle& rhs);
 YOGA_EXPORT inline bool operator!=(const YGStyle& lhs, const YGStyle& rhs) {
   return !(lhs == rhs);
 }
-
-#endif

--- a/yoga/Yoga-internal.h
+++ b/yoga/Yoga-internal.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -154,5 +152,3 @@ static const float kDefaultFlexShrink = 0.0f;
 static const float kWebDefaultFlexShrink = 1.0f;
 
 extern bool YGFloatsEqual(const float a, const float b);
-
-#endif

--- a/yoga/log.h
+++ b/yoga/log.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-
 #include "YGEnums.h"
 
 struct YGNode;
@@ -38,5 +36,3 @@ struct Log {
 } // namespace detail
 } // namespace yoga
 } // namespace facebook
-
-#endif


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/react-native/pull/36993

Fabric relies on the private C++ internals of Yoga. This creates a conundrum in the open source build due to how header creation in Cocoapods works.

1. The default mechanism of specifying public headers needs to include the private headers for them to be made usable by fabric (by default)
2. Cocoapods will roll up all of the public headers when importing a module

https://github.com/facebook/react-native/pull/33381 fixed the Fabric Cocoapods build which ran into this. React Native relies on FlipperKit which relies on YogaKit, which in turn finally imports the Yoga podspec. Because YogaKit may use Swift, we can only expose the public Yoga C ABI.

The first solution in that PR was to allow RN to access Yoga private headers, but this was changed to instead make all Yoga headers public, and to add ifdefs to all of them to no-op when included outside of a C++ environment.

Talking to Kudo, we should be able to change back to the earlier approach in the PR, to instead expose the private headers to only RN. This lets us avoid exposing headers that we ideally wouldn't be, and lets us avoid the messy ifdefs in every Yoga header.

But also I have no idea what I'm doing here, so this will be exported and built.

Changelog: [Internal]

Differential Revision: D45139075

