### PR TITLE
Remove config variant copy ctor from YGNode

### DIFF
--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -23,17 +23,6 @@ YGNode::YGNode(const YGConfigRef config) : config_{config} {
   }
 };
 
-YGNode::YGNode(const YGNode& node, YGConfigRef config) : YGNode{node} {
-  YGAssert(
-      config != nullptr, "Attempting to construct YGNode with null config");
-
-  config_ = config;
-  flags_.hasNewLayout = true;
-  if (config->useWebDefaults) {
-    useWebDefaults();
-  }
-}
-
 YGNode::YGNode(YGNode&& node) {
   context_ = node.context_;
   flags_ = node.flags_;

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -93,10 +93,6 @@ public:
   // Should we remove this?
   YGNode(const YGNode& node) = default;
 
-  [[deprecated("Will be removed imminently")]] YGNode(
-      const YGNode& node,
-      YGConfigRef config);
-
   // assignment means potential leaks of existing children, or alternatively
   // freeing unowned memory, double free, or freeing stack memory.
   YGNode& operator=(const YGNode&) = delete;


### PR DESCRIPTION
Summary: This private constructor was added specifically for Fabric when config setting was deprecated, but that is undeprecated now. Fbsource fabric was moved off of it, and the RN desktop for was in the last diff in the stack, so we can remove it now.

Differential Revision: D45292729

