### PR TITLE
Add C# bindings for Errata API

### DIFF
--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -175,6 +175,7 @@ static YGConfigRef globalConfig;
   globalConfig = YGConfigNew();
   YGConfigSetExperimentalFeatureEnabled(
       globalConfig, YGExperimentalFeatureWebFlexBasis, true);
+  YGConfigSetErrata(globalConfig, YGErrataClassic);
   YGConfigSetPointScaleFactor(globalConfig, [UIScreen mainScreen].scale);
 }
 

--- a/csharp/Facebook.Yoga/Native.cs
+++ b/csharp/Facebook.Yoga/Native.cs
@@ -74,6 +74,12 @@ namespace Facebook.Yoga
         public static extern bool YGConfigGetUseLegacyStretchBehaviour(YGConfigHandle config);
 
         [DllImport(DllName, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void YGConfigSetErrata(YGConfigHandle config, YogaErrata errata);
+
+        [DllImport(DllName, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern YogaErrata YGConfigGetErrata(YGConfigHandle config);
+
+        [DllImport(DllName, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         public static extern void YGConfigSetPointScaleFactor(
             YGConfigHandle config,
             float pixelsInPoint);

--- a/csharp/Facebook.Yoga/YogaConfig.cs
+++ b/csharp/Facebook.Yoga/YogaConfig.cs
@@ -117,8 +117,12 @@ namespace Facebook.Yoga
             }
         }
 
-        public bool UseLegacyStretchBehaviour
-        {
+        [ObsoleteAttribute("\"UseLegacyStretchBehaviour\" will be removed in the next release. " +
+          "Usage should be replaced with \"Errata\" set to \"YogaErrata.All\" to opt out of all " +
+          "future breaking conformance fixes, or \"YogaErrata.StretchFlexBasis\" toopt out of " +
+          "the specific conformance fix previously disabled by \"UseLegacyStretchBehaviour\".",
+          true /*error*/)]
+        public bool UseLegacyStretchBehaviour {
             get
             {
                 return Native.YGConfigGetUseLegacyStretchBehaviour(_ygConfig);
@@ -127,6 +131,19 @@ namespace Facebook.Yoga
             set
             {
                 Native.YGConfigSetUseLegacyStretchBehaviour(_ygConfig, value);
+            }
+        }
+
+        public YogaErrata Errata
+        {
+            get
+            {
+                return Native.YGConfigGetErrata(_ygConfig);
+            }
+
+            set
+            {
+                Native.YGConfigSetErrata(_ygConfig, value);
             }
         }
 

--- a/java/com/facebook/yoga/YogaConfig.java
+++ b/java/com/facebook/yoga/YogaConfig.java
@@ -22,7 +22,13 @@ public abstract class YogaConfig {
    * Yoga previously had an error where containers would take the maximum space possible instead of the minimum
    * like they are supposed to. In practice this resulted in implicit behaviour similar to align-self: stretch;
    * Because this was such a long-standing bug we must allow legacy users to switch back to this behaviour.
+   *
+   * @deprecated "setUseLegacyStretchBehaviour" will be removed in the next release. Usage should be replaced with
+   * "setErrata(YogaErrata.ALL)" to opt out of all future breaking conformance fixes, or
+   * "setErrata(YogaErrata.STRETCH_FLEX_BASIS)" to opt out of the specific conformance fix previously disabled by
+   * "UseLegacyStretchBehaviour".
    */
+  @Deprecated
   public abstract void setUseLegacyStretchBehaviour(boolean useLegacyStretchBehaviour);
 
   public abstract void setErrata(YogaErrata errata);


### PR DESCRIPTION
Summary: Wires C ABI to C# bindings using `System.Runtime.InteropServices`. Note that we don't have a working C# build right now, but there is [effort to address that](https://github.com/facebook/yoga/pull/1207) which may get some more effort before the Yoga release, so this keeps the bindings up to date.

Differential Revision: D45297676

