### PR TITLE
Move YogaKit to YGErrataClassic

### DIFF
--- a/YogaKit/Source/YGLayout.m
+++ b/YogaKit/Source/YGLayout.m
@@ -175,6 +175,7 @@ static YGConfigRef globalConfig;
   globalConfig = YGConfigNew();
   YGConfigSetExperimentalFeatureEnabled(
       globalConfig, YGExperimentalFeatureWebFlexBasis, true);
+  YGConfigSetErrata(globalConfig, YGErrataClassic);
   YGConfigSetPointScaleFactor(globalConfig, [UIScreen mainScreen].scale);
 }
 

--- a/java/com/facebook/yoga/YogaConfig.java
+++ b/java/com/facebook/yoga/YogaConfig.java
@@ -22,7 +22,13 @@ public abstract class YogaConfig {
    * Yoga previously had an error where containers would take the maximum space possible instead of the minimum
    * like they are supposed to. In practice this resulted in implicit behaviour similar to align-self: stretch;
    * Because this was such a long-standing bug we must allow legacy users to switch back to this behaviour.
+   *
+   * @deprecated "setUseLegacyStretchBehaviour" will be removed in the next release. Usage should be replaced with
+   * "setErrata(YogaErrata.ALL)" to opt out of all future breaking conformance fixes, or
+   * "setErrata(YogaErrata.STRETCH_FLEX_BASIS)" to opt out of the specific conformance fix previously disabled by
+   * "UseLegacyStretchBehaviour".
    */
+  @Deprecated
   public abstract void setUseLegacyStretchBehaviour(boolean useLegacyStretchBehaviour);
 
   public abstract void setErrata(YogaErrata errata);


### PR DESCRIPTION
Summary:
YogaKit integrates Yoga with UIKit as a higher level framework. It does not expose config setting to users.

We set YGErrataClassic for now to prioritize compatibility instead of conformance (YogaKit is relatively used in fbsource as well).

I'm also tempted to remove the usage of ExperimentalWebFlexBasis since last I heard rozelle thought it was generally broken, but I am a bit afraid to if it has been enabled so long, and is used in many cases in Meta.

Differential Revision: D45298803

