### PR TITLE
Deprecate Java YogaConfig.setUseLegacyStretchBehaviour()

### DIFF
--- a/java/com/facebook/yoga/YogaConfig.java
+++ b/java/com/facebook/yoga/YogaConfig.java
@@ -22,7 +22,13 @@ public abstract class YogaConfig {
    * Yoga previously had an error where containers would take the maximum space possible instead of the minimum
    * like they are supposed to. In practice this resulted in implicit behaviour similar to align-self: stretch;
    * Because this was such a long-standing bug we must allow legacy users to switch back to this behaviour.
+   *
+   * @deprecated "setUseLegacyStretchBehaviour" will be removed in the next release. Usage should be replaced with
+   * "setErrata(YogaErrata.ALL)" to opt out of all future breaking conformance fixes, or
+   * "setErrata(YogaErrata.STRETCH_FLEX_BASIS)" to opt out of the specific conformance fix previously disabled by
+   * "UseLegacyStretchBehaviour".
    */
+  @Deprecated
   public abstract void setUseLegacyStretchBehaviour(boolean useLegacyStretchBehaviour);
 
   public abstract void setErrata(YogaErrata errata);


### PR DESCRIPTION
Summary: Now that our own usages are removed, mark this as deprecated to encourage users to move to the errata API. The same will be done to variants of this function on other platforms before releasing, and the functions will be removed after releasing.

Differential Revision: D45300343

