### PR TITLE
Don't export private headers from Buck target (#37127)

### DIFF
--- a/java/com/facebook/yoga/YogaNative.java
+++ b/java/com/facebook/yoga/YogaNative.java
@@ -38,7 +38,7 @@ public class YogaNative {
   static native void jni_YGNodeSwapChildJNI(long nativePointer, long childPointer, int index);
   static native void jni_YGNodeSetIsReferenceBaselineJNI(long nativePointer, boolean isReferenceBaseline);
   static native boolean jni_YGNodeIsReferenceBaselineJNI(long nativePointer);
-  static native void jni_YGNodeClearChildrenJNI(long nativePointer);
+  static native void jni_YGNodeRemoveAllChildrenJNI(long nativePointer);
   static native void jni_YGNodeRemoveChildJNI(long nativePointer, long childPointer);
   static native void jni_YGNodeCalculateLayoutJNI(long nativePointer, float width, float height, long[] nativePointers, YogaNodeJNIBase[] nodes);
   static native void jni_YGNodeMarkDirtyJNI(long nativePointer);

--- a/java/com/facebook/yoga/YogaNodeJNIBase.java
+++ b/java/com/facebook/yoga/YogaNodeJNIBase.java
@@ -155,7 +155,7 @@ public abstract class YogaNodeJNIBase extends YogaNode implements Cloneable {
 
   private void clearChildren() {
     mChildren = null;
-    YogaNative.jni_YGNodeClearChildrenJNI(mNativePointer);
+    YogaNative.jni_YGNodeRemoveAllChildrenJNI(mNativePointer);
   }
 
   public YogaNodeJNIBase removeChildAt(int i) {

--- a/java/jni/YGJNI.h
+++ b/java/jni/YGJNI.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <yoga/Yoga.h>
+
 const short int LAYOUT_EDGE_SET_FLAG_INDEX = 0;
 const short int LAYOUT_WIDTH_INDEX = 1;
 const short int LAYOUT_HEIGHT_INDEX = 2;
@@ -36,14 +38,14 @@ public:
 
   YGNodeEdges(YGNodeRef node) {
     auto context = YGNodeContext{};
-    context.asVoidPtr = node->getContext();
+    context.asVoidPtr = YGNodeGetContext(node);
     edges_ = context.edgesSet;
   }
 
   void setOn(YGNodeRef node) {
     auto context = YGNodeContext{};
     context.edgesSet = edges_;
-    node->setContext(context.asVoidPtr);
+    YGNodeSetContext(node, context.asVoidPtr);
   }
 
   bool has(Edge edge) { return (edges_ & edge) == edge; }

--- a/java/jni/YGJNIVanilla.cpp
+++ b/java/jni/YGJNIVanilla.cpp
@@ -7,18 +7,19 @@
 
 #include "jni.h"
 #include "YGJNIVanilla.h"
-#include <yoga/YGNode.h>
 #include <cstring>
 #include "YGJNI.h"
 #include "common.h"
 #include "YGJTypesVanilla.h"
-#include <yoga/log.h>
 #include <iostream>
 #include <memory>
 #include "YogaJniException.h"
 
+// TODO: Reconcile missing layoutContext functionality from callbacks in the C
+// API and use that
+#include <yoga/YGNode.h>
+
 using namespace facebook::yoga::vanillajni;
-using facebook::yoga::detail::Log;
 
 static inline ScopedLocalRef<jobject> YGNodeJobject(
     YGNodeRef node,
@@ -84,18 +85,6 @@ static void jni_YGConfigSetPointScaleFactorJNI(
   YGConfigSetPointScaleFactor(config, pixelsInPoint);
 }
 
-static void YGPrint(YGNodeRef node, void* layoutContext) {
-  if (auto obj = YGNodeJobject(node, layoutContext)) {
-    // TODO cout << obj.get()->toString() << endl;
-  } else {
-    Log::log(
-        node,
-        YGLogLevelError,
-        nullptr,
-        "Java YGNode was GCed during layout calculation\n");
-  }
-}
-
 static void jni_YGConfigSetUseLegacyStretchBehaviourJNI(
     JNIEnv* env,
     jobject obj,
@@ -127,8 +116,7 @@ static jint jni_YGConfigGetErrataJNI(
 
 static jlong jni_YGNodeNewJNI(JNIEnv* env, jobject obj) {
   const YGNodeRef node = YGNodeNew();
-  node->setContext(YGNodeContext{}.asVoidPtr);
-  node->setPrintFunc(YGPrint);
+  YGNodeSetContext(node, YGNodeContext{}.asVoidPtr);
   return reinterpret_cast<jlong>(node);
 }
 
@@ -137,7 +125,7 @@ static jlong jni_YGNodeNewWithConfigJNI(
     jobject obj,
     jlong configPointer) {
   const YGNodeRef node = YGNodeNewWithConfig(_jlong2YGConfigRef(configPointer));
-  node->setContext(YGNodeContext{}.asVoidPtr);
+  YGNodeSetContext(node, YGNodeContext{}.asVoidPtr);
   return reinterpret_cast<jlong>(node);
 }
 
@@ -221,9 +209,9 @@ static void jni_YGNodeFreeJNI(JNIEnv* env, jobject obj, jlong nativePointer) {
 
 static void jni_YGNodeResetJNI(JNIEnv* env, jobject obj, jlong nativePointer) {
   const YGNodeRef node = _jlong2YGNodeRef(nativePointer);
-  void* context = node->getContext();
+  void* context = YGNodeGetContext(node);
   YGNodeReset(node);
-  node->setContext(context);
+  YGNodeSetContext(node, context);
 }
 
 static void jni_YGNodeInsertChildJNI(
@@ -262,12 +250,12 @@ static jboolean jni_YGNodeIsReferenceBaselineJNI(
   return YGNodeIsReferenceBaseline(_jlong2YGNodeRef(nativePointer));
 }
 
-static void jni_YGNodeClearChildrenJNI(
+static void jni_YGNodeRemoveAllChildrenJNI(
     JNIEnv* env,
     jobject obj,
     jlong nativePointer) {
   const YGNodeRef node = _jlong2YGNodeRef(nativePointer);
-  node->clearChildren();
+  YGNodeRemoveAllChildren(node);
 }
 
 static void jni_YGNodeRemoveChildJNI(
@@ -284,16 +272,11 @@ static void YGTransferLayoutOutputsRecursive(
     jobject thiz,
     YGNodeRef root,
     void* layoutContext) {
-  if (!root->getHasNewLayout()) {
+  if (!YGNodeGetHasNewLayout(root)) {
     return;
   }
   auto obj = YGNodeJobject(root, layoutContext);
   if (!obj) {
-    Log::log(
-        root,
-        YGLogLevelError,
-        nullptr,
-        "Java YGNode was GCed during layout calculation\n");
     return;
   }
 
@@ -354,7 +337,7 @@ static void YGTransferLayoutOutputsRecursive(
   env->SetFloatArrayRegion(arrFinal.get(), 0, arrSize, arr);
   env->SetObjectField(obj.get(), arrField, arrFinal.get());
 
-  root->setHasNewLayout(false);
+  YGNodeSetHasNewLayout(root, false);
 
   for (uint32_t i = 0; i < YGNodeGetChildCount(root); i++) {
     YGTransferLayoutOutputsRecursive(
@@ -420,7 +403,7 @@ static jboolean jni_YGNodeIsDirtyJNI(
     JNIEnv* env,
     jobject obj,
     jlong nativePointer) {
-  return (jboolean) _jlong2YGNodeRef(nativePointer)->isDirty();
+  return (jboolean) YGNodeIsDirty(_jlong2YGNodeRef(nativePointer));
 }
 
 static void jni_YGNodeCopyStyleJNI(
@@ -677,11 +660,6 @@ static YGSize YGJNIMeasureFunc(
 
     return YGSize{*measuredWidth, *measuredHeight};
   } else {
-    Log::log(
-        node,
-        YGLogLevelError,
-        nullptr,
-        "Java YGNode was GCed during layout calculation\n");
     return YGSize{
         widthMode == YGMeasureModeUndefined ? 0 : width,
         heightMode == YGMeasureModeUndefined ? 0 : height,
@@ -737,7 +715,7 @@ static void jni_YGNodePrintJNI(JNIEnv* env, jobject obj, jlong nativePointer) {
 static jlong jni_YGNodeCloneJNI(JNIEnv* env, jobject obj, jlong nativePointer) {
   auto node = _jlong2YGNodeRef(nativePointer);
   const YGNodeRef clonedYogaNode = YGNodeClone(node);
-  clonedYogaNode->setContext(node->getContext());
+  YGNodeSetContext(clonedYogaNode, YGNodeGetContext(node));
 
   return reinterpret_cast<jlong>(clonedYogaNode);
 }
@@ -801,7 +779,9 @@ static JNINativeMethod methods[] = {
     {"jni_YGNodeIsReferenceBaselineJNI",
      "(J)Z",
      (void*) jni_YGNodeIsReferenceBaselineJNI},
-    {"jni_YGNodeClearChildrenJNI", "(J)V", (void*) jni_YGNodeClearChildrenJNI},
+    {"jni_YGNodeRemoveAllChildrenJNI",
+     "(J)V",
+     (void*) jni_YGNodeRemoveAllChildrenJNI},
     {"jni_YGNodeRemoveChildJNI", "(JJ)V", (void*) jni_YGNodeRemoveChildJNI},
     {"jni_YGNodeCalculateLayoutJNI",
      "(JFF[J[Lcom/facebook/yoga/YogaNodeJNIBase;)V",

--- a/java/jni/YGJTypesVanilla.h
+++ b/java/jni/YGJTypesVanilla.h
@@ -5,11 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "jni.h"
-#include <yoga/YGValue.h>
-#include <yoga/Yoga.h>
 #include <map>
+#include <vector>
+
+#include <yoga/Yoga.h>
+
 #include "common.h"
+#include "jni.h"
 
 class PtrJNodeMapVanilla {
   std::map<YGNodeRef, size_t> ptrsToIdxs_;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/react-native/pull/37127

This prevents targets which include Yoga from using its private APIs.

Instances of this have been mostly cleaned up in the past diffs, with the major exception of RN Fabric. To stage this without blocking on that, I added a `yoga-private-api` target for now to keep using these headers while making it unlikely new usages will show up.

Reviewed By: javache

Differential Revision: D45339425

