### PR TITLE
Cleanup YGValue.h header

### DIFF
--- a/tests/YGValueTest.cpp
+++ b/tests/YGValueTest.cpp
@@ -21,29 +21,3 @@ TEST(YGValue, supports_equality) {
       (YGValue{YGUndefined, YGUnitUndefined}));
   ASSERT_EQ((YGValue{0, YGUnitAuto}), (YGValue{-1, YGUnitAuto}));
 }
-
-using namespace facebook::yoga::literals;
-
-TEST(YGValue, supports_double_point_literals) {
-  ASSERT_EQ(12.5_pt, (YGValue{12.5, YGUnitPoint}));
-}
-
-TEST(YGValue, supports_double_percent_literals) {
-  ASSERT_EQ(12.5_percent, (YGValue{12.5, YGUnitPercent}));
-}
-
-TEST(YGValue, supports_integral_point_literals) {
-  ASSERT_EQ(34_pt, (YGValue{34, YGUnitPoint}));
-}
-
-TEST(YGValue, supports_integral_percent_literals) {
-  ASSERT_EQ(125_percent, (YGValue{125, YGUnitPercent}));
-}
-
-TEST(YGValue, supports_negative_point_literals) {
-  ASSERT_EQ(-34.5_pt, (YGValue{-34.5, YGUnitPoint}));
-}
-
-TEST(YGValue, supports_negative_percent_literals) {
-  ASSERT_EQ(-34.5_percent, (YGValue{-34.5, YGUnitPercent}));
-}

--- a/yoga/YGValue.h
+++ b/yoga/YGValue.h
@@ -7,27 +7,10 @@
 
 #pragma once
 
-#include <math.h>
 #include "YGEnums.h"
 #include "YGMacros.h"
 
-#if defined(_MSC_VER) && defined(__clang__)
-#define COMPILING_WITH_CLANG_ON_WINDOWS
-#endif
-#if defined(COMPILING_WITH_CLANG_ON_WINDOWS)
-#include <limits>
-constexpr float YGUndefined = std::numeric_limits<float>::quiet_NaN();
-#else
 YG_EXTERN_C_BEGIN
-
-// Not defined in MSVC++
-#ifndef NAN
-static const uint32_t __nan = 0x7fc00000;
-#define NAN (*(const float*) __nan)
-#endif
-
-#define YGUndefined NAN
-#endif
 
 typedef struct YGValue {
   float value;
@@ -38,13 +21,17 @@ YOGA_EXPORT extern const YGValue YGValueAuto;
 YOGA_EXPORT extern const YGValue YGValueUndefined;
 YOGA_EXPORT extern const YGValue YGValueZero;
 
-#if !defined(COMPILING_WITH_CLANG_ON_WINDOWS)
 YG_EXTERN_C_END
-#endif
-#undef COMPILING_WITH_CLANG_ON_WINDOWS
 
 #ifdef __cplusplus
+#include <limits>
+constexpr float YGUndefined = std::numeric_limits<float>::quiet_NaN();
+#else
+#include <math.h>
+#define YGUndefined NAN
+#endif
 
+#ifdef __cplusplus
 inline bool operator==(const YGValue& lhs, const YGValue& rhs) {
   if (lhs.unit != rhs.unit) {
     return false;
@@ -69,27 +56,4 @@ inline bool operator!=(const YGValue& lhs, const YGValue& rhs) {
 inline YGValue operator-(const YGValue& value) {
   return {-value.value, value.unit};
 }
-
-namespace facebook {
-namespace yoga {
-namespace literals {
-
-inline YGValue operator"" _pt(long double value) {
-  return YGValue{static_cast<float>(value), YGUnitPoint};
-}
-inline YGValue operator"" _pt(unsigned long long value) {
-  return operator"" _pt(static_cast<long double>(value));
-}
-
-inline YGValue operator"" _percent(long double value) {
-  return YGValue{static_cast<float>(value), YGUnitPercent};
-}
-inline YGValue operator"" _percent(unsigned long long value) {
-  return operator"" _percent(static_cast<long double>(value));
-}
-
-} // namespace literals
-} // namespace yoga
-} // namespace facebook
-
 #endif


### PR DESCRIPTION
Summary:
1. Simplify nan handling a bit
2. Remove string literal operators which seem dead enough to remove. These are public, so anyone could be using them, but it seems like almost nobody is.
    1. FB has no usages of `using namespace facebook::yoga::literals` (exposing the literal operators) outside of Yoga tests.
    1. There is only [a single usage](https://github.com/XITRIX/UIKit/blob/6dfba905ea83c89e255144f7ed90fde8c33ca81a/SDLTest/UIKit.hpp#L19) on GitHub.

Differential Revision: D45419970

