### PR TITLE
Dirty nodes when dynamically setting config

### DIFF
--- a/tests/YGDirtyMarkingTest.cpp
+++ b/tests/YGDirtyMarkingTest.cpp
@@ -68,6 +68,99 @@ TEST(YogaTest, dirty_propagation_only_if_prop_changed) {
   YGNodeFreeRecursive(root);
 }
 
+TEST(YogaTest, dirty_propagation_changing_layout_config) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetAlignItems(root, YGAlignFlexStart);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 20);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child0_child0 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child0_child0, 25);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root, root_child0_child0, 0);
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  EXPECT_FALSE(root->isDirty());
+  EXPECT_FALSE(root_child0->isDirty());
+  EXPECT_FALSE(root_child1->isDirty());
+  EXPECT_FALSE(root_child0_child0->isDirty());
+
+  YGConfigRef newConfig = YGConfigNew();
+  YGConfigSetErrata(newConfig, YGErrataStretchFlexBasis);
+  YGNodeSetConfig(root_child0, newConfig);
+
+  EXPECT_TRUE(root->isDirty());
+  EXPECT_TRUE(root_child0->isDirty());
+  EXPECT_FALSE(root_child1->isDirty());
+  EXPECT_FALSE(root_child0_child0->isDirty());
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  EXPECT_FALSE(root->isDirty());
+  EXPECT_FALSE(root_child0->isDirty());
+  EXPECT_FALSE(root_child1->isDirty());
+  EXPECT_FALSE(root_child0_child0->isDirty());
+
+  YGConfigFree(newConfig);
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, dirty_propagation_changing_benign_config) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetAlignItems(root, YGAlignFlexStart);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 20);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child0_child0 = YGNodeNew();
+  YGNodeStyleSetWidth(root_child0_child0, 25);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root, root_child0_child0, 0);
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  EXPECT_FALSE(root->isDirty());
+  EXPECT_FALSE(root_child0->isDirty());
+  EXPECT_FALSE(root_child1->isDirty());
+  EXPECT_FALSE(root_child0_child0->isDirty());
+
+  YGConfigRef newConfig = YGConfigNew();
+  YGConfigSetLogger(
+      newConfig,
+      [](const YGConfigRef, const YGNodeRef, YGLogLevel, const char*, va_list) {
+        return 0;
+      });
+  YGNodeSetConfig(root_child0, newConfig);
+
+  EXPECT_FALSE(root->isDirty());
+  EXPECT_FALSE(root_child0->isDirty());
+  EXPECT_FALSE(root_child1->isDirty());
+  EXPECT_FALSE(root_child0_child0->isDirty());
+
+  YGConfigFree(newConfig);
+  YGNodeFreeRecursive(root);
+}
+
 TEST(YogaTest, dirty_mark_all_children_as_dirty_when_display_changes) {
   const YGNodeRef root = YGNodeNew();
   YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);

--- a/yoga/YGConfig.cpp
+++ b/yoga/YGConfig.cpp
@@ -7,7 +7,18 @@
 
 #include "YGConfig.h"
 
-using namespace facebook::yoga::detail;
+using namespace facebook::yoga;
+
+namespace facebook {
+namespace yoga {
+bool configUpdateInvalidatesLayout(YGConfigRef a, YGConfigRef b) {
+  return a->getErrata() != b->getErrata() ||
+      a->getEnabledExperiments() != b->getEnabledExperiments() ||
+      a->getPointScaleFactor() != b->getPointScaleFactor() ||
+      a->useWebDefaults() != b->useWebDefaults();
+}
+} // namespace yoga
+} // namespace facebook
 
 YGConfig::YGConfig(YGLogger logger) : cloneNodeCallback_{nullptr} {
   setLogger(logger);
@@ -38,6 +49,10 @@ void YGConfig::setExperimentalFeatureEnabled(
 bool YGConfig::isExperimentalFeatureEnabled(
     YGExperimentalFeature feature) const {
   return experimentalFeatures_.test(feature);
+}
+
+ExperimentalFeatureSet YGConfig::getEnabledExperiments() const {
+  return experimentalFeatures_;
 }
 
 void YGConfig::setErrata(YGErrata errata) {

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -269,6 +269,11 @@ void YGNode::setConfig(YGConfigRef config) {
       config,
       config->useWebDefaults() == config_->useWebDefaults(),
       "UseWebDefaults may not be changed after constructing a YGNode");
+
+  if (yoga::configUpdateInvalidatesLayout(config_, config)) {
+    markDirtyAndPropagate();
+  }
+
   config_ = config;
 }
 


### PR DESCRIPTION
Summary:
Yoga exposes public APIs for dirtying Nodes, but will itself perform dirty marking when changing bits which invalidate layout. E.g. changing the style of a Node will invalidate it along with every parent Node.

Because config setting is newly public to the C ABI, this makes a similar change so that replacing a Node's config will dirty the tree above the node if there is a layout impacting config change (I don't think children need to be invalidated since child output shouldn't change given the same owner dimensions).

One quirk of this is that configs may be changed independently of the node. So someone could attach a config to a Node, then change the live config after the fact. The config does not currently have a back pointer to the Node, so we do not invalidate in that case of live config edits. The future work to rectify this would be to make configs immutable once created.

There are also currently some experimental features here which should maybe be compared, but these should be moved to YGErrata anyway.

Differential Revision: D45505089

