### PR TITLE
Change how we set cmake policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...3.26)
 project(yoga-all)
 set(CMAKE_VERBOSE_MAKEFILE on)
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...3.26)
 project(benchmark)
 set(CMAKE_VERBOSE_MAKEFILE on)
 

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...3.26)
 project(yogajni)
 set(CMAKE_VERBOSE_MAKEFILE on)
 

--- a/javascript/CMakeLists.txt
+++ b/javascript/CMakeLists.txt
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...3.26)
 set(CMAKE_VERBOSE_MAKEFILE on)
 project(yoga)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...3.26)
 project(tests)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
@@ -15,7 +15,6 @@ set(YOGA_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
 include(${YOGA_ROOT}/cmake/project-defaults.cmake)
 
 # Fetch GTest
-cmake_policy(SET CMP0135 NEW)
 FetchContent_Declare(
   googletest
   URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip

--- a/yoga/CMakeLists.txt
+++ b/yoga/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...3.26)
 project(yogacore)
 set(CMAKE_VERBOSE_MAKEFILE on)
 


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/yoga/issues/1283

New versions of CMake add "policies" which control how the build system acts wrt breaking changes. By default, CMake will emulate the behavior of the version specified in `cmake_minimum_required`.

Setting a policy to true (to opt into new behavior where `cmake_minimum_required` is lower than the current version) seems actually just error out on the old versions.

Googling around, apparently the way I should be doing this is to specify `<policy_max>` as part of `cmake_minimum_required `. https://gitlab.kitware.com/cmake/cmake/-/issues/20392

This should I think use new policies introduced up to 3.26 (what we test on right now), while letting 3.13 be the minimum.

Differential Revision: D45724864

