### PR TITLE
Removed pinned NDK/CMake versions from Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,7 @@ allprojects {
 
 ext {
     buildToolsVersion = "33.0.0"
-    ndkVersion = "23.1.7779620" // Corresponds to AGP 7.3
-    cmakeVersion = "3.18.1+"
+    ndkVersion = "23.1.7779620"
     minSdkVersion = 21
     compileSdkVersion = 33
     targetSdkVersion = 33

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -28,7 +28,6 @@ android {
 
     externalNativeBuild {
         cmake {
-            version rootProject.cmakeVersion
             path 'CMakeLists.txt'
         }
     }


### PR DESCRIPTION
Summary: AGP 8.0 will now bring in a new enough CMake version to avoid internal warnings without extra configuration.

Reviewed By: yungsters

Differential Revision: D45766980

