### PR TITLE
Apply fixes from clag-tidy `misc-unused-parameters`

### DIFF
--- a/java/jni/YGJNIVanilla.cpp
+++ b/java/jni/YGJNIVanilla.cpp
@@ -35,11 +35,14 @@ static inline YGConfigRef _jlong2YGConfigRef(jlong addr) {
   return reinterpret_cast<YGConfigRef>(static_cast<intptr_t>(addr));
 }
 
-static jlong jni_YGConfigNewJNI(JNIEnv* env, jobject obj) {
+static jlong jni_YGConfigNewJNI(JNIEnv* /*env*/, jobject /*obj*/) {
   return reinterpret_cast<jlong>(YGConfigNew());
 }
 
-static void jni_YGConfigFreeJNI(JNIEnv* env, jobject obj, jlong nativePointer) {
+static void jni_YGConfigFreeJNI(
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
+    jlong nativePointer) {
   const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
   // unique_ptr will destruct the underlying global_ref, if present.
   auto context = std::unique_ptr<ScopedGlobalRef<jobject>>{
@@ -48,8 +51,8 @@ static void jni_YGConfigFreeJNI(JNIEnv* env, jobject obj, jlong nativePointer) {
 }
 
 static void jni_YGConfigSetExperimentalFeatureEnabledJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jint feature,
     jboolean enabled) {
@@ -59,8 +62,8 @@ static void jni_YGConfigSetExperimentalFeatureEnabledJNI(
 }
 
 static void jni_YGConfigSetUseWebDefaultsJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jboolean useWebDefaults) {
   const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
@@ -68,8 +71,8 @@ static void jni_YGConfigSetUseWebDefaultsJNI(
 }
 
 static void jni_YGConfigSetPrintTreeFlagJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jboolean enable) {
   const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
@@ -77,8 +80,8 @@ static void jni_YGConfigSetPrintTreeFlagJNI(
 }
 
 static void jni_YGConfigSetPointScaleFactorJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jfloat pixelsInPoint) {
   const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
@@ -86,8 +89,8 @@ static void jni_YGConfigSetPointScaleFactorJNI(
 }
 
 static void jni_YGConfigSetUseLegacyStretchBehaviourJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jboolean useLegacyStretchBehaviour) {
   const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
@@ -98,8 +101,8 @@ static void jni_YGConfigSetUseLegacyStretchBehaviourJNI(
 }
 
 static void jni_YGConfigSetErrataJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jint errata) {
   const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
@@ -107,22 +110,22 @@ static void jni_YGConfigSetErrataJNI(
 }
 
 static jint jni_YGConfigGetErrataJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer) {
   const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
   return static_cast<jint>(YGConfigGetErrata(config));
 }
 
-static jlong jni_YGNodeNewJNI(JNIEnv* env, jobject obj) {
+static jlong jni_YGNodeNewJNI(JNIEnv* /*env*/, jobject /*obj*/) {
   const YGNodeRef node = YGNodeNew();
   YGNodeSetContext(node, YGNodeContext{}.asVoidPtr);
   return reinterpret_cast<jlong>(node);
 }
 
 static jlong jni_YGNodeNewWithConfigJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong configPointer) {
   const YGNodeRef node = YGNodeNewWithConfig(_jlong2YGConfigRef(configPointer));
   YGNodeSetContext(node, YGNodeContext{}.asVoidPtr);
@@ -131,9 +134,9 @@ static jlong jni_YGNodeNewWithConfigJNI(
 
 static int YGJNILogFunc(
     const YGConfigRef config,
-    const YGNodeRef node,
+    const YGNodeRef /*node*/,
     YGLogLevel level,
-    void* layoutContext,
+    void* /*layoutContext*/,
     const char* format,
     va_list args) {
   int result = vsnprintf(NULL, 0, format, args);
@@ -175,7 +178,7 @@ static int YGJNILogFunc(
 
 static void jni_YGConfigSetLoggerJNI(
     JNIEnv* env,
-    jobject obj,
+    jobject /*obj*/,
     jlong nativePointer,
     jobject logger) {
   const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
@@ -200,8 +203,8 @@ static void jni_YGConfigSetLoggerJNI(
 }
 
 static void jni_YGNodeDeallocateJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer) {
   if (nativePointer == 0) {
     return;
@@ -210,7 +213,10 @@ static void jni_YGNodeDeallocateJNI(
   YGNodeFree(node);
 }
 
-static void jni_YGNodeResetJNI(JNIEnv* env, jobject obj, jlong nativePointer) {
+static void jni_YGNodeResetJNI(
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
+    jlong nativePointer) {
   const YGNodeRef node = _jlong2YGNodeRef(nativePointer);
   void* context = YGNodeGetContext(node);
   YGNodeReset(node);
@@ -218,8 +224,8 @@ static void jni_YGNodeResetJNI(JNIEnv* env, jobject obj, jlong nativePointer) {
 }
 
 static void jni_YGNodeInsertChildJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jlong childPointer,
     jint index) {
@@ -228,8 +234,8 @@ static void jni_YGNodeInsertChildJNI(
 }
 
 static void jni_YGNodeSwapChildJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jlong childPointer,
     jint index) {
@@ -238,8 +244,8 @@ static void jni_YGNodeSwapChildJNI(
 }
 
 static void jni_YGNodeSetIsReferenceBaselineJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jboolean isReferenceBaseline) {
   YGNodeSetIsReferenceBaseline(
@@ -247,23 +253,23 @@ static void jni_YGNodeSetIsReferenceBaselineJNI(
 }
 
 static jboolean jni_YGNodeIsReferenceBaselineJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer) {
   return YGNodeIsReferenceBaseline(_jlong2YGNodeRef(nativePointer));
 }
 
 static void jni_YGNodeRemoveAllChildrenJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer) {
   const YGNodeRef node = _jlong2YGNodeRef(nativePointer);
   YGNodeRemoveAllChildren(node);
 }
 
 static void jni_YGNodeRemoveChildJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jlong childPointer) {
   YGNodeRemoveChild(
@@ -389,29 +395,29 @@ static void jni_YGNodeCalculateLayoutJNI(
 }
 
 static void jni_YGNodeMarkDirtyJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer) {
   YGNodeMarkDirty(_jlong2YGNodeRef(nativePointer));
 }
 
 static void jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer) {
   YGNodeMarkDirtyAndPropagateToDescendants(_jlong2YGNodeRef(nativePointer));
 }
 
 static jboolean jni_YGNodeIsDirtyJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer) {
   return (jboolean) YGNodeIsDirty(_jlong2YGNodeRef(nativePointer));
 }
 
 static void jni_YGNodeCopyStyleJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong dstNativePointer,
     jlong srcNativePointer) {
   YGNodeCopyStyle(
@@ -512,8 +518,8 @@ YG_NODE_JNI_STYLE_UNIT_PROP(MaxHeight);
 YG_NODE_JNI_STYLE_EDGE_UNIT_PROP(Position);
 
 static jlong jni_YGNodeStyleGetMarginJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jint edge) {
   YGNodeRef yogaNodeRef = _jlong2YGNodeRef(nativePointer);
@@ -525,8 +531,8 @@ static jlong jni_YGNodeStyleGetMarginJNI(
 }
 
 static void jni_YGNodeStyleSetMarginJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jint edge,
     jfloat margin) {
@@ -537,8 +543,8 @@ static void jni_YGNodeStyleSetMarginJNI(
 }
 
 static void jni_YGNodeStyleSetMarginPercentJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jint edge,
     jfloat percent) {
@@ -549,8 +555,8 @@ static void jni_YGNodeStyleSetMarginPercentJNI(
 }
 
 static void jni_YGNodeStyleSetMarginAutoJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jint edge) {
   YGNodeRef yogaNodeRef = _jlong2YGNodeRef(nativePointer);
@@ -559,8 +565,8 @@ static void jni_YGNodeStyleSetMarginAutoJNI(
 }
 
 static jlong jni_YGNodeStyleGetPaddingJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jint edge) {
   YGNodeRef yogaNodeRef = _jlong2YGNodeRef(nativePointer);
@@ -572,8 +578,8 @@ static jlong jni_YGNodeStyleGetPaddingJNI(
 }
 
 static void jni_YGNodeStyleSetPaddingJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jint edge,
     jfloat padding) {
@@ -584,8 +590,8 @@ static void jni_YGNodeStyleSetPaddingJNI(
 }
 
 static void jni_YGNodeStyleSetPaddingPercentJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jint edge,
     jfloat percent) {
@@ -596,8 +602,8 @@ static void jni_YGNodeStyleSetPaddingPercentJNI(
 }
 
 static jfloat jni_YGNodeStyleGetBorderJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jint edge) {
   YGNodeRef yogaNodeRef = _jlong2YGNodeRef(nativePointer);
@@ -608,8 +614,8 @@ static jfloat jni_YGNodeStyleGetBorderJNI(
 }
 
 static void jni_YGNodeStyleSetBorderJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jint edge,
     jfloat border) {
@@ -671,8 +677,8 @@ static YGSize YGJNIMeasureFunc(
 }
 
 static void jni_YGNodeSetHasMeasureFuncJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jboolean hasMeasureFunc) {
   _jlong2YGNodeRef(nativePointer)
@@ -698,8 +704,8 @@ static float YGJNIBaselineFunc(
 }
 
 static void jni_YGNodeSetHasBaselineFuncJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jboolean hasBaselineFunc) {
   _jlong2YGNodeRef(nativePointer)
@@ -715,7 +721,10 @@ static void jni_YGNodePrintJNI(JNIEnv* env, jobject obj, jlong nativePointer) {
 #endif
 }
 
-static jlong jni_YGNodeCloneJNI(JNIEnv* env, jobject obj, jlong nativePointer) {
+static jlong jni_YGNodeCloneJNI(
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
+    jlong nativePointer) {
   auto node = _jlong2YGNodeRef(nativePointer);
   const YGNodeRef clonedYogaNode = YGNodeClone(node);
   YGNodeSetContext(clonedYogaNode, YGNodeGetContext(node));
@@ -724,8 +733,8 @@ static jlong jni_YGNodeCloneJNI(JNIEnv* env, jobject obj, jlong nativePointer) {
 }
 
 static jfloat jni_YGNodeStyleGetGapJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jint gutter) {
   return (jfloat) YGNodeStyleGetGap(
@@ -733,8 +742,8 @@ static jfloat jni_YGNodeStyleGetGapJNI(
 }
 
 static void jni_YGNodeStyleSetGapJNI(
-    JNIEnv* env,
-    jobject obj,
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
     jlong nativePointer,
     jint gutter,
     jfloat gapLength) {

--- a/tests/YGAlignBaselineTest.cpp
+++ b/tests/YGAlignBaselineTest.cpp
@@ -10,27 +10,27 @@
 #include <yoga/Yoga.h>
 
 static float _baselineFunc(
-    YGNodeRef node,
-    const float width,
+    YGNodeRef /*node*/,
+    const float /*width*/,
     const float height) {
   return height / 2;
 }
 
 static YGSize _measure1(
-    YGNodeRef node,
-    float width,
-    YGMeasureMode widthMode,
-    float height,
-    YGMeasureMode heightMode) {
+    YGNodeRef /*node*/,
+    float /*width*/,
+    YGMeasureMode /*widthMode*/,
+    float /*height*/,
+    YGMeasureMode /*heightMode*/) {
   return YGSize{42, 50};
 }
 
 static YGSize _measure2(
-    YGNodeRef node,
-    float width,
-    YGMeasureMode widthMode,
-    float height,
-    YGMeasureMode heightMode) {
+    YGNodeRef /*node*/,
+    float /*width*/,
+    YGMeasureMode /*widthMode*/,
+    float /*height*/,
+    YGMeasureMode /*heightMode*/) {
   return YGSize{279, 126};
 }
 

--- a/tests/YGAspectRatioTest.cpp
+++ b/tests/YGAspectRatioTest.cpp
@@ -10,7 +10,7 @@
 #include <yoga/Yoga.h>
 
 static YGSize _measure(
-    YGNodeRef node,
+    YGNodeRef /*node*/,
     float width,
     YGMeasureMode widthMode,
     float height,

--- a/tests/YGBaselineFuncTest.cpp
+++ b/tests/YGBaselineFuncTest.cpp
@@ -9,7 +9,10 @@
 #include <yoga/YGNode.h>
 #include <yoga/Yoga.h>
 
-static float _baseline(YGNodeRef node, const float width, const float height) {
+static float _baseline(
+    YGNodeRef node,
+    const float /*width*/,
+    const float /*height*/) {
   float* baseline = (float*) node->getContext();
   return *baseline;
 }

--- a/tests/YGLoggerTest.cpp
+++ b/tests/YGLoggerTest.cpp
@@ -14,9 +14,9 @@
 namespace {
 char writeBuffer[4096];
 int _unmanagedLogger(
-    const YGConfigRef config,
-    const YGNodeRef node,
-    YGLogLevel level,
+    const YGConfigRef /*config*/,
+    const YGNodeRef /*node*/,
+    YGLogLevel /*level*/,
     const char* format,
     va_list args) {
   return vsnprintf(

--- a/tests/YGMeasureCacheTest.cpp
+++ b/tests/YGMeasureCacheTest.cpp
@@ -46,10 +46,10 @@ static YGSize _measureMin(
 
 static YGSize _measure_84_49(
     YGNodeRef node,
-    float width,
-    YGMeasureMode widthMode,
-    float height,
-    YGMeasureMode heightMode) {
+    float /*width*/,
+    YGMeasureMode /*widthMode*/,
+    float /*height*/,
+    YGMeasureMode /*heightMode*/) {
   int* measureCount = (int*) node->getContext();
   if (measureCount) {
     (*measureCount)++;

--- a/tests/YGMeasureTest.cpp
+++ b/tests/YGMeasureTest.cpp
@@ -11,10 +11,10 @@
 
 static YGSize _measure(
     YGNodeRef node,
-    float width,
-    YGMeasureMode widthMode,
-    float height,
-    YGMeasureMode heightMode) {
+    float /*width*/,
+    YGMeasureMode /*widthMode*/,
+    float /*height*/,
+    YGMeasureMode /*heightMode*/) {
   int* measureCount = (int*) node->getContext();
   if (measureCount) {
     (*measureCount)++;
@@ -24,11 +24,11 @@ static YGSize _measure(
 }
 
 static YGSize _simulate_wrapping_text(
-    YGNodeRef node,
+    YGNodeRef /*node*/,
     float width,
     YGMeasureMode widthMode,
-    float height,
-    YGMeasureMode heightMode) {
+    float /*height*/,
+    YGMeasureMode /*heightMode*/) {
   if (widthMode == YGMeasureModeUndefined || width >= 68) {
     return YGSize{68, 16};
   }
@@ -37,11 +37,11 @@ static YGSize _simulate_wrapping_text(
 }
 
 static YGSize _measure_assert_negative(
-    YGNodeRef node,
+    YGNodeRef /*node*/,
     float width,
-    YGMeasureMode widthMode,
+    YGMeasureMode /*widthMode*/,
     float height,
-    YGMeasureMode heightMode) {
+    YGMeasureMode /*heightMode*/) {
   EXPECT_GE(width, 0);
   EXPECT_GE(height, 0);
 
@@ -641,21 +641,21 @@ TEST(YogaTest, cant_call_negative_measure_horizontal) {
 }
 
 static YGSize _measure_90_10(
-    YGNodeRef node,
-    float width,
-    YGMeasureMode widthMode,
-    float height,
-    YGMeasureMode heightMode) {
+    YGNodeRef /*node*/,
+    float /*width*/,
+    YGMeasureMode /*widthMode*/,
+    float /*height*/,
+    YGMeasureMode /*heightMode*/) {
 
   return YGSize{90, 10};
 }
 
 static YGSize _measure_100_100(
-    YGNodeRef node,
-    float width,
-    YGMeasureMode widthMode,
-    float height,
-    YGMeasureMode heightMode) {
+    YGNodeRef /*node*/,
+    float /*width*/,
+    YGMeasureMode /*widthMode*/,
+    float /*height*/,
+    YGMeasureMode /*heightMode*/) {
 
   return YGSize{100, 100};
 }

--- a/tests/YGRoundingFunctionTest.cpp
+++ b/tests/YGRoundingFunctionTest.cpp
@@ -43,11 +43,11 @@ TEST(YogaTest, rounding_value) {
 }
 
 static YGSize measureText(
-    YGNodeRef node,
-    float width,
-    YGMeasureMode widthMode,
-    float height,
-    YGMeasureMode heightMode) {
+    YGNodeRef /*node*/,
+    float /*width*/,
+    YGMeasureMode /*widthMode*/,
+    float /*height*/,
+    YGMeasureMode /*heightMode*/) {
   return YGSize{10, 10};
 }
 

--- a/tests/YGRoundingMeasureFuncTest.cpp
+++ b/tests/YGRoundingMeasureFuncTest.cpp
@@ -10,11 +10,11 @@
 #include <yoga/Yoga.h>
 
 static YGSize _measureFloor(
-    YGNodeRef node,
+    YGNodeRef /*node*/,
     float width,
-    YGMeasureMode widthMode,
+    YGMeasureMode /*widthMode*/,
     float height,
-    YGMeasureMode heightMode) {
+    YGMeasureMode /*heightMode*/) {
   return YGSize{
       width = 10.2f,
       height = 10.2f,
@@ -22,11 +22,11 @@ static YGSize _measureFloor(
 }
 
 static YGSize _measureCeil(
-    YGNodeRef node,
+    YGNodeRef /*node*/,
     float width,
-    YGMeasureMode widthMode,
+    YGMeasureMode /*widthMode*/,
     float height,
-    YGMeasureMode heightMode) {
+    YGMeasureMode /*heightMode*/) {
   return YGSize{
       width = 10.5f,
       height = 10.5f,
@@ -34,11 +34,11 @@ static YGSize _measureCeil(
 }
 
 static YGSize _measureFractial(
-    YGNodeRef node,
+    YGNodeRef /*node*/,
     float width,
-    YGMeasureMode widthMode,
+    YGMeasureMode /*widthMode*/,
     float height,
-    YGMeasureMode heightMode) {
+    YGMeasureMode /*heightMode*/) {
   return YGSize{
       width = 0.5f,
       height = 0.5f,


### PR DESCRIPTION
Summary: Gets the project mostly clean of `-Wunused-parameter`, part of `-Wextra`.

Differential Revision: D45772554

