### PR TITLE
Update version in Yoga.podspec

### DIFF
--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -6,7 +6,7 @@
 
 Pod::Spec.new do |spec|
   spec.name = 'Yoga'
-  spec.version = '1.14.0'
+  spec.version = '1.19.0'
   spec.license =  { :type => 'MIT', :file => "LICENSE" }
   spec.homepage = 'https://yogalayout.com/'
   spec.documentation_url = 'https://yogalayout.com/docs'


### PR DESCRIPTION
In `v1.19.0`, the Xcode compilation error was fixed. 
https://github.com/facebook/yoga/commit/f174de70afdde2492e8677bd0e716eb41bf64469

So `spec.version` should be updated.