### PR TITLE
Quick and dirty versioning script

### DIFF
--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -6,7 +6,7 @@
 
 Pod::Spec.new do |spec|
   spec.name = 'Yoga'
-  spec.version = '2.0.0-beta.1'
+  spec.version = '2.0.0'
   spec.license =  { :type => 'MIT', :file => "LICENSE" }
   spec.homepage = 'https://yogalayout.com/'
   spec.documentation_url = 'https://yogalayout.com/docs'

--- a/YogaKit.podspec
+++ b/YogaKit.podspec
@@ -5,7 +5,7 @@
 
 podspec = Pod::Spec.new do |spec|
   spec.name = 'YogaKit'
-  spec.version = '2.0.0-beta.1'
+  spec.version = '2.0.0'
   spec.license =  { :type => 'MIT', :file => "LICENSE" }
   spec.homepage = 'https://facebook.github.io/yoga/'
   spec.documentation_url = 'https://facebook.github.io/yoga/docs/'
@@ -31,4 +31,3 @@ end
 
 # See https://github.com/facebook/yoga/pull/366
 podspec.attributes_hash["readme"] = "YogaKit/README.md"
-podspec

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ android.useAndroidX=true
 
 org.gradle.jvmargs=-Xmx1536M
 
-VERSION_NAME=1.19.0
+VERSION_NAME=2.0.0

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoga-layout",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0",
   "description": "JavaScript bindings for the Yoga layout engine",
   "license": "MIT",
   "repository": {

--- a/set-version.py
+++ b/set-version.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import re
+import sys
+
+os.chdir(os.path.dirname(__file__))
+
+if len(sys.argv) != 2:
+    print("usage: ./set-version <version>", file=sys.stderr)
+    sys.exit(1)
+
+version = sys.argv[1]
+
+with open("gradle.properties", "r+") as f:
+    new_contents = re.sub(r"VERSION_NAME=.*", f"VERSION_NAME={version}", f.read())
+    f.seek(0)
+    f.write(new_contents)
+
+
+with open("javascript/package.json", "r+") as f:
+    new_contents = re.sub(r'"version": ".*",', f'"version": "{version}",', f.read())
+    print(new_contents)
+    f.seek(0)
+    f.write(new_contents)
+
+for podspec in ["Yoga.podspec", "YogaKit.podspec"]:
+    with open(podspec, "r+") as f:
+        new_contents = re.sub(
+            r"spec\.version = '.*'", f"spec.version = '{version}'", f.read()
+        )
+        f.seek(0)
+        f.write(new_contents)


### PR DESCRIPTION
Summary:
Made a quick script to set versions in manifests that currently exist. This should probably be stamped in more places, like the binary as well, but we don't do that right now. This does not update lockfiles for CocoaPods or JS, so those will need to be updated via an install after running this script.

A note on language: This repo already has too many toolchains, but I chose Python for this since it corresponds with the enum script, and we  can run it with no dependencies on macOS/Linux distros.

Reviewed By: cortinico

Differential Revision: D46662378

