### PR TITLE
Mark YogaKit Podspec as Deprecated

### DIFF
--- a/YogaKit.podspec
+++ b/YogaKit.podspec
@@ -9,6 +9,7 @@ podspec = Pod::Spec.new do |spec|
   spec.license =  { :type => 'MIT', :file => "LICENSE" }
   spec.homepage = 'https://facebook.github.io/yoga/'
   spec.documentation_url = 'https://facebook.github.io/yoga/docs/'
+  spec.deprecated = true
 
   spec.summary = 'Yoga is a cross-platform layout engine which implements Flexbox.'
   spec.description = 'Yoga is a cross-platform layout engine enabling maximum collaboration within your team by implementing an API many designers are familiar with, and opening it up to developers across different platforms.'


### PR DESCRIPTION
Summary:
We are deprecating YogaKit as part of Yoga 2.0, with that version planned as the last release. Mark the podspec as deprecated.

We are also deprecating the Android ViewGroup in a similar way but from the googling I did there is not an equivalent way to do that for Maven artifacts.

Differential Revision: D46663201

