### PR TITLE
Fix the issue that local reference overflows in Yoga 1

### DIFF
--- a/enums.py
+++ b/enums.py
@@ -54,6 +54,8 @@ ENUMS = {
         "AbsolutePercentageAgainstPaddingEdge",
         # Conformance fix: https://github.com/facebook/yoga/pull/1028
         "FixAbsoluteTrailingColumnMargin",
+        # fix JNI local ref overflows
+        "FixJNILocalRefOverflows",
     ],
     "PrintOptions": [
         ("Layout", 1 << 0),

--- a/java/com/facebook/yoga/YogaExperimentalFeature.java
+++ b/java/com/facebook/yoga/YogaExperimentalFeature.java
@@ -12,7 +12,8 @@ package com.facebook.yoga;
 public enum YogaExperimentalFeature {
   WEB_FLEX_BASIS(0),
   ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE(1),
-  FIX_ABSOLUTE_TRAILING_COLUMN_MARGIN(2);
+  FIX_ABSOLUTE_TRAILING_COLUMN_MARGIN(2),
+  FIX_JNILOCAL_REF_OVERFLOWS(3);
 
   private final int mIntValue;
 
@@ -29,6 +30,7 @@ public enum YogaExperimentalFeature {
       case 0: return WEB_FLEX_BASIS;
       case 1: return ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE;
       case 2: return FIX_ABSOLUTE_TRAILING_COLUMN_MARGIN;
+      case 3: return FIX_JNILOCAL_REF_OVERFLOWS;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);
     }
   }

--- a/javascript/src/generated/YGEnums.ts
+++ b/javascript/src/generated/YGEnums.ts
@@ -57,6 +57,7 @@ export enum ExperimentalFeature {
   WebFlexBasis = 0,
   AbsolutePercentageAgainstPaddingEdge = 1,
   FixAbsoluteTrailingColumnMargin = 2,
+  FixJNILocalRefOverflows = 3,
 }
 
 export enum FlexDirection {
@@ -164,6 +165,7 @@ const constants = {
   EXPERIMENTAL_FEATURE_WEB_FLEX_BASIS: ExperimentalFeature.WebFlexBasis,
   EXPERIMENTAL_FEATURE_ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE: ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge,
   EXPERIMENTAL_FEATURE_FIX_ABSOLUTE_TRAILING_COLUMN_MARGIN: ExperimentalFeature.FixAbsoluteTrailingColumnMargin,
+  EXPERIMENTAL_FEATURE_FIX_JNILOCAL_REF_OVERFLOWS: ExperimentalFeature.FixJNILocalRefOverflows,
   FLEX_DIRECTION_COLUMN: FlexDirection.Column,
   FLEX_DIRECTION_COLUMN_REVERSE: FlexDirection.ColumnReverse,
   FLEX_DIRECTION_ROW: FlexDirection.Row,

--- a/yoga/YGEnums.cpp
+++ b/yoga/YGEnums.cpp
@@ -109,6 +109,8 @@ const char* YGExperimentalFeatureToString(const YGExperimentalFeature value) {
       return "absolute-percentage-against-padding-edge";
     case YGExperimentalFeatureFixAbsoluteTrailingColumnMargin:
       return "fix-absolute-trailing-column-margin";
+    case YGExperimentalFeatureFixJNILocalRefOverflows:
+      return "fix-jnilocal-ref-overflows";
   }
   return "unknown";
 }

--- a/yoga/YGEnums.h
+++ b/yoga/YGEnums.h
@@ -66,7 +66,8 @@ YG_ENUM_SEQ_DECL(
     YGExperimentalFeature,
     YGExperimentalFeatureWebFlexBasis,
     YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge,
-    YGExperimentalFeatureFixAbsoluteTrailingColumnMargin)
+    YGExperimentalFeatureFixAbsoluteTrailingColumnMargin,
+    YGExperimentalFeatureFixJNILocalRefOverflows)
 
 YG_ENUM_SEQ_DECL(
     YGFlexDirection,


### PR DESCRIPTION
Summary: Long story in short, we're trying to fix an issue with Yoga that could potentially lead to an overflow in the JNI local reference table.

Reviewed By: NickGerleman

Differential Revision: D46653732

