### PR TITLE
Build WebAssembly with `SINGLE_FILE=1`

### DIFF
--- a/javascript/CMakeLists.txt
+++ b/javascript/CMakeLists.txt
@@ -64,9 +64,11 @@ target_link_options(asmjs-async PUBLIC
 add_executable(wasm-sync $<TARGET_OBJECTS:yogaObjLib>)
 target_link_options(wasm-sync PUBLIC
     "SHELL:-s WASM=1"
+    "SHELL:-s SINGLE_FILE=1"
     "SHELL:-s WASM_ASYNC_COMPILATION=0")
 
 add_executable(wasm-async $<TARGET_OBJECTS:yogaObjLib>)
 target_link_options(wasm-async PUBLIC
     "SHELL:-s WASM=1"
+    "SHELL:-s SINGLE_FILE=1"
     "SHELL:-s WASM_ASYNC_COMPILATION=1")


### PR DESCRIPTION
Summary:
Emscripten normally compiles a binary into a `.js` file and a `.wasm` file. The `.js` file contains a shim to load the WebAssembly file for the target platform, along with passing some environment information to the underlying assembly.

Under Node this would use APIs like `fs.readFile` and its WebAssembly APIs to load the binary. In a browser, APIs like `instantiateStreaming` are used to start downloading and compiling the binary at the same time.

This format creates many, many, headaches, and manual bundler configuration. E.g. we must tell Webpack to treat WASM files as auxilary files instead of WebAssembly, cannot use Emscripten's loader directly, and would need to add more variants of the binary, since (or Node polyfills in the browser) `-s ENVIRONMENT='web,node'` emits code that looks like `if (isNode) {require('fs')}`.

This change makes us instead pack the WebAssembly as base64 inline with the JS loader. This adds a size penalty, and means we cannot start async compilation until the entire file is present, but should work out of the box when using different bundlers and configurations, and the size is small enough where it likely makes sense to inline into the bundle anyway.

There is a [proposal for integration of WebAssembly and ES Modules](https://github.com/WebAssembly/esm-integration/tree/main/proposals/esm-integration) that Node has experimental support for, and bundlers are veering towards supporting. It is the eventual solution we should target, but does not seem mature enough yet. E.g. WebPack [does not support](https://github.com/webpack/webpack/issues/11893) WebAssembly import objects, and will instead try to import each of the named imports as modules.

Reviewed By: rozele

Differential Revision: D46884398

