### PR TITLE
Add publish workflows for npmjs and CocoaPods

### DIFF
--- a/.github/workflows/publish-cocoapods-release.yml
+++ b/.github/workflows/publish-cocoapods-release.yml
@@ -1,0 +1,28 @@
+name: Publish CocoaPods Release
+
+on:
+  push:
+    tags:
+      - *
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish to CocoaPods trunk
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup
+        uses: ./.github/actions/setup-apple
+
+      - name: Publish Yoga
+        run: pod trunk push Yoga.podspec
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+
+      - name: Publish YogaKit
+        run: pod trunk push YogaKit.podspec
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/publish-npm-release.yml
+++ b/.github/workflows/publish-npm-release.yml
@@ -1,0 +1,24 @@
+name: Publish NPM Release
+
+on:
+  push:
+    tags:
+      - *
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish to npmjs registry
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup
+        uses: ./.github/actions/setup-js
+
+      - name: yarn publish
+        run: yarn publish
+        working-directory: javascript
+         env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This adds workflows which run on tag, or manually, to publish packages to npmjs and cocoapods. These secrets should be set, but this is untested. We can fix manually and re-run though.