### PR TITLE
Fixes for publish workflows

### DIFF
--- a/.github/workflows/publish-android-release.yml
+++ b/.github/workflows/publish-android-release.yml
@@ -3,7 +3,7 @@ name: Publish Android Release
 on:
   push:
     tags:
-      - *
+      - '*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-cocoapods-release.yml
+++ b/.github/workflows/publish-cocoapods-release.yml
@@ -3,7 +3,7 @@ name: Publish CocoaPods Release
 on:
   push:
     tags:
-      - *
+      - '*'
   workflow_dispatch:
 
 jobs:
@@ -23,6 +23,7 @@ jobs:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
       - name: Publish YogaKit
-        run: pod trunk push YogaKit.podspec
+        # Must run with --synchronous since YogaKit may depend on the just published version of Yoga
+        run: pod trunk push YogaKit.podspec --synchronous
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/publish-npm-release.yml
+++ b/.github/workflows/publish-npm-release.yml
@@ -3,7 +3,7 @@ name: Publish NPM Release
 on:
   push:
     tags:
-      - *
+      - '*'
   workflow_dispatch:
 
 jobs:
@@ -17,8 +17,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup-js
 
+      - name: Store auth token in config file
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
       - name: yarn publish
         run: yarn publish
         working-directory: javascript
-         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.buckd
 /gentest/test.html
 .buck-java11
+node_modules
 
 # Jekyll
 /.sass-cache/

--- a/javascript/.gitignore
+++ b/javascript/.gitignore
@@ -1,4 +1,3 @@
 /binaries
 /build
 /dist
-/node_modules

--- a/website-next/.gitignore
+++ b/website-next/.gitignore
@@ -1,6 +1,3 @@
-# Dependencies
-/node_modules
-
 # Production
 /build
 

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,6 +1,4 @@
 # Project dependencies
-# https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
-node_modules
 .cache/
 # Build directory
 public/


### PR DESCRIPTION
Summary:
This fixes a few issues encountered during publishing Yoga `2.0.0-beta.1`.

1. The tag trigger was missing quotes needed to be valid syntax
2. `pod trunk publish` must be run with `--synchronous` if we are publishing a package that relies on another just published package. There does not seem to be a way to just publish evertything at once.
3. `yarn publish` was not reading the NPM auth token from the environment, so we write it to a `.npmrc` before publishing.
4. The root `.gitignore` was not updated when moving to yarn workspaces to ignore `node_modules`, so the OSS Yoga repo (not internal) will, try to add its contents after `yarn install`.

Differential Revision: D47135994

