### PR TITLE
Target C++ 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Yoga is an embeddable and performant flexbox layout engine with bindings for mul
 
 
 ## Building
-Yoga's main implementation targets C++ 14 with accompanying build logic in CMake. A wrapper is provided to build the main library and run unit tests.
+Yoga's main implementation targets C++ 17 with accompanying build logic in CMake. A wrapper is provided to build the main library and run unit tests.
 
 ```sh
 ./unit_tests <Debug|Release>

--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |spec|
       '-Wall',
       '-Werror',
       '-Wextra',
-      '-std=c++14',
+      '-std=c++17',
       '-fPIC'
   ]
   spec.source_files = 'yoga/**/*.{h,cpp}'

--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/javascript/CMakeLists.txt
+++ b/javascript/CMakeLists.txt
@@ -14,7 +14,7 @@ file(GLOB SOURCES CONFIGURE_DEPENDS
 
 include_directories(..)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 add_compile_definitions(
     EMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0)


### PR DESCRIPTION
Summary:
This bumps Yoga to C++ 17 for a few reasons:
1. New versions of C++ may introduce behavior changes (e.g. evaluation order) and deprecations. Keeping the version closer to the version of large users helps avoid that.
2. C++ 17 unblocks some new bits I have wanted to use at times, like `std::optional`, `std::variant`, `if constexpr`, `[[nodiscard]]`.
3. There are already changes in C++ 20 that would be directly useful to Yoga, like `std::bit_cast` to avoid `memcpy` style type punning.

There has been some contention around C++ versions before, but by the time the next stable version of Yoga is out, it will have been more than 6 years (~2 C++ versions) since a stable version of Clang/LLVM with C++ 17 support. I would not like to go back further than n-2.

Reviewed By: christophpurrer

Differential Revision: D47383922

