### PR TITLE
Fixup Yoga UT compilation on non-clang compilers

### DIFF
--- a/tests/YGNodeCallbackTest.cpp
+++ b/tests/YGNodeCallbackTest.cpp
@@ -33,11 +33,7 @@ TEST(YGNode, measure_with_measure_fn) {
 
   n.setMeasureFunc(
       [](YGNode*, float w, YGMeasureMode wm, float h, YGMeasureMode hm) {
-// TODO: Correctly fix enum - float conversion warning: T158155910
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wenum-float-conversion"
-        return YGSize{w * wm, h / hm};
-#pragma clang diagnostic pop
+        return YGSize{w * static_cast<int>(wm), h / static_cast<int>(hm)};
       });
 
   ASSERT_EQ(
@@ -62,19 +58,11 @@ TEST(YGNode, switching_measure_fn_types) {
   auto n = YGNode{};
   n.setMeasureFunc(
       [](YGNode*, float, YGMeasureMode, float, YGMeasureMode, void*) {
-// TODO: Properly fix enum - float conversion warning: T158155910
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wenum-float-conversion"
         return YGSize{};
-#pragma clang diagnostic pop
       });
   n.setMeasureFunc(
       [](YGNode*, float w, YGMeasureMode wm, float h, YGMeasureMode hm) {
-// TODO: Properly fix enum - float conversion warning: T158155910
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wenum-float-conversion"
-        return YGSize{w * wm, h / hm};
-#pragma clang diagnostic pop
+        return YGSize{w * static_cast<int>(wm), h / static_cast<int>(hm)};
       });
 
   ASSERT_EQ(


### PR DESCRIPTION
Summary:
Yoga is compiled on more than clang, both internally, and in OSS. D47345669 added unguarded usage of `
#pragma clang diagnostic push` to Yoga UTs which will cause unrecognized pragma errors if building the tests on other platforms.

The code here is flagged for implicitly converting enum to float. This is test code which is using the enum as an arbitrary differentiating input, so I just changed this to an explicit cast.

Differential Revision: D47460301

