### PR TITLE
Allow negative padding (I known CSS rule is not allowed)

### DIFF
--- a/yoga/YGConfig.cpp
+++ b/yoga/YGConfig.cpp
@@ -38,6 +38,14 @@ bool YGConfig::shouldPrintTree() const {
   return flags_.printTree;
 }
 
+void YGConfig::setAllowNegativePadding(bool allowNegativePadding) {
+  flags_.allowNegativePadding = allowNegativePadding;
+}
+
+bool YGConfig::allowNegativePadding() const {
+  return flags_.allowNegativePadding;
+}
+
 void YGConfig::setExperimentalFeatureEnabled(
     YGExperimentalFeature feature,
     bool enabled) {

--- a/yoga/YGConfig.h
+++ b/yoga/YGConfig.h
@@ -44,6 +44,7 @@ struct YGConfigFlags {
   bool printTree : 1;
   bool cloneNodeUsesContext : 1;
   bool loggerUsesContext : 1;
+  bool allowNegativePadding : 1;
 };
 #pragma pack(pop)
 
@@ -57,6 +58,9 @@ struct YOGA_EXPORT YGConfig {
 
   void setShouldPrintTree(bool printTree);
   bool shouldPrintTree() const;
+
+  void setAllowNegativePadding(bool allowNegativePadding);
+  bool allowNegativePadding() const;
 
   void setExperimentalFeatureEnabled(
       YGExperimentalFeature feature,

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -542,8 +542,10 @@ YGFloatOptional YGNode::getLeadingPadding(
             CompactValue::ofZero())
       : computeEdgeValueForColumn(
             style_.padding(), leading[axis], CompactValue::ofZero());
-  return YGFloatOptionalMax(
-      YGResolveValue(leadingPadding, widthSize), YGFloatOptional(0.0f));
+  auto leadingPaddingValue = YGResolveValue(leadingPadding, widthSize);
+  return !config_->allowNegativePadding()
+      ? YGFloatOptionalMax(leadingPaddingValue, YGFloatOptional(0.0f))
+      : leadingPaddingValue;
 }
 
 YGFloatOptional YGNode::getTrailingPadding(
@@ -554,8 +556,10 @@ YGFloatOptional YGNode::getTrailingPadding(
             style_.padding(), YGEdgeEnd, trailing[axis], CompactValue::ofZero())
       : computeEdgeValueForColumn(
             style_.padding(), trailing[axis], CompactValue::ofZero());
-  return YGFloatOptionalMax(
-      YGResolveValue(trailingPadding, widthSize), YGFloatOptional(0.0f));
+  auto trailingPaddingValue = YGResolveValue(trailingPadding, widthSize);
+  return !config_->allowNegativePadding()
+      ? YGFloatOptionalMax(trailingPaddingValue, YGFloatOptional(0.0f))
+      : trailingPaddingValue;
 }
 
 YGFloatOptional YGNode::getLeadingPaddingAndBorder(


### PR DESCRIPTION
Negative padding support is an useful feature.

The padding of the parent element can offset the margin of the child element:

```
+----------++-----------+     Grid
|          ||           | padding: -2pt
|          ||           |
|    A     ||     B     |
|          ||           |    Item
|          ||           | margin: 2pt
+----------++-----------+
+----------++-----------+
|          ||           |
|          ||           |
|    C     ||     D     |
|          ||           |
|          ||           |
+----------++-----------+
```