### PR TITLE
Fix segfault calling YGJNILogFunc

### DIFF
--- a/java/jni/YGJNIVanilla.cpp
+++ b/java/jni/YGJNIVanilla.cpp
@@ -139,7 +139,9 @@ static int YGJNILogFunc(
     void* /*layoutContext*/,
     const char* format,
     va_list args) {
-  int result = vsnprintf(NULL, 0, format, args);
+  va_list argsCopy;
+  va_copy(argsCopy, args);
+  int result = vsnprintf(nullptr, 0, format, argsCopy);
   std::vector<char> buffer(1 + result);
   vsnprintf(buffer.data(), buffer.size(), format, args);
 


### PR DESCRIPTION
Summary:
`YGJNILogFunc` has a bug where it uses a `va_list` to determine the length of a printf string, then reuses the same `va_list` later after it has already been iterated through. Even if no arguments are present, this may cause a crash looking something like:

```
C  [libsystem_platform.dylib+0xf12]  _platform_strlen+0x12
C  [libsystem_c.dylib+0x31bf]  __vfprintf+0x1339
C  [libsystem_c.dylib+0x307ce]  _vsnprintf+0x100
C  [libsystem_c.dylib+0x6965]  vsnprintf+0x44
C  [libyoga.dylib+0x5161]  YGJNILogFunc(YGConfig*, YGNode*, YGLogLevel, void*, char const*, __va_list_tag*)+0x59
```

Fixing this fixes crashing unit tests which are not explicitly disabled.

Reviewed By: yungsters

Differential Revision: D48388548

