### PR TITLE
C++ Cleanup 2/N: Reorganize YGConfig

### DIFF
--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -35,7 +35,14 @@ Pod::Spec.new do |spec|
       '-std=c++17',
       '-fPIC'
   ]
-  spec.source_files = 'yoga/**/*.{h,cpp}'
-  spec.public_header_files = 'yoga/{Yoga,YGEnums,YGMacros,YGValue}.h'
+
   spec.swift_version = '5.1'
+  spec.source_files = 'yoga/**/*.{h,cpp}'
+  spec.header_mappings_dir = 'yoga'
+
+  public_header_files = 'yoga/{Yoga,YGEnums,YGMacros,YGValue}.h'
+  spec.public_header_files = public_header_files
+
+  all_header_files = 'yoga/**/*.h'
+  spec.private_header_files = Dir.glob(all_header_files) - Dir.glob(public_header_files)
 end

--- a/java/jni/YGJNIVanilla.cpp
+++ b/java/jni/YGJNIVanilla.cpp
@@ -19,6 +19,8 @@
 // API and use that
 #include <yoga/YGNode.h>
 
+using namespace facebook;
+using namespace facebook::yoga;
 using namespace facebook::yoga::vanillajni;
 
 static inline ScopedLocalRef<jobject> YGNodeJobject(
@@ -194,7 +196,7 @@ static void jni_YGConfigSetLoggerJNI(
     }
 
     *context = newGlobalRef(env, logger);
-    config->setLogger(YGJNILogFunc);
+    static_cast<yoga::Config*>(config)->setLogger(YGJNILogFunc);
   } else {
     if (context != nullptr) {
       delete context;

--- a/tests/CompactValueTest.cpp
+++ b/tests/CompactValueTest.cpp
@@ -7,11 +7,11 @@
 
 #define YOGA_COMPACT_VALUE_TEST
 
-#include <yoga/CompactValue.h>
+#include <yoga/style/CompactValue.h>
 #include <gtest/gtest.h>
 #include <cmath>
 
-using facebook::yoga::detail::CompactValue;
+using facebook::yoga::CompactValue;
 
 const auto tooSmall = nextafterf(CompactValue::LOWER_BOUND, -INFINITY);
 const auto tooLargePoints =

--- a/tests/YGStyleAccessorsTest.cpp
+++ b/tests/YGStyleAccessorsTest.cpp
@@ -8,9 +8,8 @@
 #include <cstdint>
 #include <type_traits>
 #include <gtest/gtest.h>
-#include <yoga/YGEnums.h>
-#include <yoga/YGStyle.h>
-#include <yoga/YGValue.h>
+#include <yoga/Yoga.h>
+#include <yoga/style/Style.h>
 
 #define ACCESSOR_TESTS_1(NAME, X) \
   style.NAME() = X;               \
@@ -31,14 +30,14 @@
 #define ACCESSOR_TESTS_N(a, b, c, d, e, COUNT, ...) ACCESSOR_TESTS_##COUNT
 #define ACCESSOR_TESTS(...) ACCESSOR_TESTS_N(__VA_ARGS__, 5, 4, 3, 2, 1)
 
-#define INDEX_ACCESSOR_TESTS_1(NAME, IDX, X)                           \
-  {                                                                    \
-    auto style = YGStyle{};                                            \
-    style.NAME()[IDX] = X;                                             \
-    ASSERT_EQ(style.NAME()[IDX], X);                                   \
-    auto asArray = decltype(std::declval<const YGStyle&>().NAME()){X}; \
-    style.NAME() = asArray;                                            \
-    ASSERT_EQ(static_cast<decltype(asArray)>(style.NAME()), asArray);  \
+#define INDEX_ACCESSOR_TESTS_1(NAME, IDX, X)                          \
+  {                                                                   \
+    auto style = Style{};                                             \
+    style.NAME()[IDX] = X;                                            \
+    ASSERT_EQ(style.NAME()[IDX], X);                                  \
+    auto asArray = decltype(std::declval<const Style&>().NAME()){X};  \
+    style.NAME() = asArray;                                           \
+    ASSERT_EQ(static_cast<decltype(asArray)>(style.NAME()), asArray); \
   }
 
 #define INDEX_ACCESSOR_TESTS_2(NAME, IDX, X, Y) \
@@ -64,21 +63,19 @@
 
 // test macro for up to 5 values. If more are needed, extend the macros above.
 #define ACCESSOR_TEST(NAME, DEFAULT_VAL, ...)      \
-  TEST(YGStyle, style_##NAME##_access) {           \
-    auto style = YGStyle{};                        \
+  TEST(Style, style_##NAME##_access) {             \
+    auto style = Style{};                          \
     ASSERT_EQ(style.NAME(), DEFAULT_VAL);          \
     ACCESSOR_TESTS(__VA_ARGS__)(NAME, __VA_ARGS__) \
   }
 
 #define INDEX_ACCESSOR_TEST(NAME, DEFAULT_VAL, IDX, ...)      \
-  TEST(YGStyle, style_##NAME##_access) {                      \
-    ASSERT_EQ(YGStyle{}.NAME()[IDX], DEFAULT_VAL);            \
+  TEST(Style, style_##NAME##_access) {                        \
+    ASSERT_EQ(Style{}.NAME()[IDX], DEFAULT_VAL);              \
     INDEX_ACCESSOR_TESTS(__VA_ARGS__)(NAME, IDX, __VA_ARGS__) \
   }
 
 namespace facebook::yoga {
-
-using CompactValue = detail::CompactValue;
 
 // TODO: MSVC doesn't like the macros
 #ifndef _MSC_VER

--- a/tests/generated/YGConfigTest.cpp
+++ b/tests/generated/YGConfigTest.cpp
@@ -9,14 +9,16 @@
 
 #include <gtest/gtest.h>
 #include <yoga/Yoga.h>
-#include <yoga/YGConfig.h>
+#include <yoga/config/Config.h>
 #include <yoga/YGNode.h>
 
 #include <functional>
 #include <memory>
 
+using namespace facebook;
+
 struct ConfigCloningTest : public ::testing::Test {
-  std::unique_ptr<YGConfig, std::function<void(YGConfig*)>> config;
+  std::unique_ptr<yoga::Config, std::function<void(yoga::Config*)>> config;
   void SetUp() override;
   void TearDown() override;
 
@@ -56,7 +58,7 @@ TEST_F(ConfigCloningTest, can_clone_with_context) {
 }
 
 void ConfigCloningTest::SetUp() {
-  config = {YGConfigNew(), YGConfigFree};
+  config = {static_cast<yoga::Config*>(YGConfigNew()), YGConfigFree};
 }
 
 void ConfigCloningTest::TearDown() {

--- a/yoga/Utils.h
+++ b/yoga/Utils.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include "YGNode.h"
-#include "Yoga-internal.h"
-#include "CompactValue.h"
+#include <yoga/Yoga-internal.h>
+#include <yoga/style/CompactValue.h>
 
 // This struct is an helper model to hold the data for step 4 of flexbox algo,
 // which is collecting the flex items in a line.
@@ -56,8 +56,8 @@ struct YGCollectFlexItemsRowValues {
 
 bool YGValueEqual(const YGValue& a, const YGValue& b);
 inline bool YGValueEqual(
-    facebook::yoga::detail::CompactValue a,
-    facebook::yoga::detail::CompactValue b) {
+    facebook::yoga::CompactValue a,
+    facebook::yoga::CompactValue b) {
   return YGValueEqual((YGValue) a, (YGValue) b);
 }
 
@@ -115,7 +115,7 @@ inline YGFloatOptional YGResolveValue(
 }
 
 inline YGFloatOptional YGResolveValue(
-    facebook::yoga::detail::CompactValue value,
+    facebook::yoga::CompactValue value,
     float ownerSize) {
   return YGResolveValue((YGValue) value, ownerSize);
 }
@@ -140,7 +140,7 @@ inline YGFlexDirection YGResolveFlexDirection(
 }
 
 inline YGFloatOptional YGResolveValueMargin(
-    facebook::yoga::detail::CompactValue value,
+    facebook::yoga::CompactValue value,
     const float ownerSize) {
   return value.isAuto() ? YGFloatOptional{0} : YGResolveValue(value, ownerSize);
 }

--- a/yoga/YGConfig.h
+++ b/yoga/YGConfig.h
@@ -9,8 +9,8 @@
 
 #include <yoga/Yoga.h>
 
-#include "BitUtils.h"
-#include "Yoga-internal.h"
+#include <yoga/BitUtils.h>
+#include <yoga/Yoga-internal.h>
 
 namespace facebook::yoga {
 

--- a/yoga/YGFloatOptional.h
+++ b/yoga/YGFloatOptional.h
@@ -9,7 +9,7 @@
 
 #include <cmath>
 #include <limits>
-#include "Yoga-internal.h"
+#include <yoga/Yoga-internal.h>
 
 struct YGFloatOptional {
 private:

--- a/yoga/YGLayout.h
+++ b/yoga/YGLayout.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include "BitUtils.h"
-#include "YGFloatOptional.h"
-#include "Yoga-internal.h"
+#include <yoga/BitUtils.h>
+#include <yoga/YGFloatOptional.h>
+#include <yoga/Yoga-internal.h>
 
 struct YGLayout {
   std::array<float, 4> position = {};

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -14,7 +14,7 @@ using namespace facebook;
 using namespace facebook::yoga;
 using facebook::yoga::CompactValue;
 
-YGNode::YGNode(const YGConfigRef config) : config_{config} {
+YGNode::YGNode(yoga::Config* config) : config_{config} {
   YGAssert(
       config != nullptr, "Attempting to construct YGNode with null config");
 
@@ -264,7 +264,7 @@ void YGNode::insertChild(YGNodeRef child, uint32_t index) {
   children_.insert(children_.begin() + index, child);
 }
 
-void YGNode::setConfig(YGConfigRef config) {
+void YGNode::setConfig(yoga::Config* config) {
   YGAssert(config != nullptr, "Attempting to set a null config on a YGNode");
   YGAssertWithConfig(
       config,

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -11,7 +11,8 @@
 #include "Utils.h"
 
 using namespace facebook;
-using facebook::yoga::detail::CompactValue;
+using namespace facebook::yoga;
+using facebook::yoga::CompactValue;
 
 YGNode::YGNode(const YGConfigRef config) : config_{config} {
   YGAssert(
@@ -53,7 +54,7 @@ void YGNode::print(void* printContext) {
 }
 
 CompactValue YGNode::computeEdgeValueForRow(
-    const YGStyle::Edges& edges,
+    const Style::Edges& edges,
     YGEdge rowEdge,
     YGEdge edge,
     CompactValue defaultValue) {
@@ -71,7 +72,7 @@ CompactValue YGNode::computeEdgeValueForRow(
 }
 
 CompactValue YGNode::computeEdgeValueForColumn(
-    const YGStyle::Edges& edges,
+    const Style::Edges& edges,
     YGEdge edge,
     CompactValue defaultValue) {
   if (!edges[edge].isUndefined()) {
@@ -86,7 +87,7 @@ CompactValue YGNode::computeEdgeValueForColumn(
 }
 
 CompactValue YGNode::computeRowGap(
-    const YGStyle::Gutters& gutters,
+    const Style::Gutters& gutters,
     CompactValue defaultValue) {
   if (!gutters[YGGutterRow].isUndefined()) {
     return gutters[YGGutterRow];
@@ -98,7 +99,7 @@ CompactValue YGNode::computeRowGap(
 }
 
 CompactValue YGNode::computeColumnGap(
-    const YGStyle::Gutters& gutters,
+    const Style::Gutters& gutters,
     CompactValue defaultValue) {
   if (!gutters[YGGutterColumn].isUndefined()) {
     return gutters[YGGutterColumn];
@@ -431,7 +432,7 @@ YGValue YGNode::resolveFlexBasisPtr() const {
 
 void YGNode::resolveDimension() {
   using namespace yoga;
-  const YGStyle& style = getStyle();
+  const Style& style = getStyle();
   for (auto dim : {YGDimensionWidth, YGDimensionHeight}) {
     if (!style.maxDimensions()[dim].isUndefined() &&
         YGValueEqual(style.maxDimensions()[dim], style.minDimensions()[dim])) {

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -9,11 +9,12 @@
 
 #include <cstdint>
 #include <stdio.h>
-#include "CompactValue.h"
 #include "YGConfig.h"
 #include "YGLayout.h"
-#include "YGStyle.h"
-#include "Yoga-internal.h"
+#include <yoga/Yoga-internal.h>
+
+#include <yoga/style/CompactValue.h>
+#include <yoga/style/Style.h>
 
 YGConfigRef YGConfigGetDefault();
 
@@ -52,7 +53,7 @@ private:
     PrintWithContextFn withContext;
   } print_ = {nullptr};
   YGDirtiedFunc dirtied_ = nullptr;
-  YGStyle style_ = {};
+  facebook::yoga::Style style_ = {};
   YGLayout layout_ = {};
   uint32_t lineIndex_ = 0;
   YGNodeRef owner_ = nullptr;
@@ -80,7 +81,7 @@ private:
   // DO NOT CHANGE THE VISIBILITY OF THIS METHOD!
   YGNode& operator=(YGNode&&) = default;
 
-  using CompactValue = facebook::yoga::detail::CompactValue;
+  using CompactValue = facebook::yoga::CompactValue;
 
 public:
   YGNode() : YGNode{YGConfigGetDefault()} { flags_.hasNewLayout = true; }
@@ -123,9 +124,9 @@ public:
   YGDirtiedFunc getDirtied() const { return dirtied_; }
 
   // For Performance reasons passing as reference.
-  YGStyle& getStyle() { return style_; }
+  facebook::yoga::Style& getStyle() { return style_; }
 
-  const YGStyle& getStyle() const { return style_; }
+  const facebook::yoga::Style& getStyle() const { return style_; }
 
   // For Performance reasons passing as reference.
   YGLayout& getLayout() { return layout_; }
@@ -178,22 +179,22 @@ public:
   }
 
   static CompactValue computeEdgeValueForColumn(
-      const YGStyle::Edges& edges,
+      const facebook::yoga::Style::Edges& edges,
       YGEdge edge,
       CompactValue defaultValue);
 
   static CompactValue computeEdgeValueForRow(
-      const YGStyle::Edges& edges,
+      const facebook::yoga::Style::Edges& edges,
       YGEdge rowEdge,
       YGEdge edge,
       CompactValue defaultValue);
 
   static CompactValue computeRowGap(
-      const YGStyle::Gutters& gutters,
+      const facebook::yoga::Style::Gutters& gutters,
       CompactValue defaultValue);
 
   static CompactValue computeColumnGap(
-      const YGStyle::Gutters& gutters,
+      const facebook::yoga::Style::Gutters& gutters,
       CompactValue defaultValue);
 
   // Methods related to positions, margin, padding and border
@@ -273,7 +274,7 @@ public:
 
   void setDirtiedFunc(YGDirtiedFunc dirtiedFunc) { dirtied_ = dirtiedFunc; }
 
-  void setStyle(const YGStyle& style) { style_ = style; }
+  void setStyle(const facebook::yoga::Style& style) { style_ = style; }
 
   void setLayout(const YGLayout& layout) { layout_ = layout; }
 

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -9,14 +9,12 @@
 
 #include <cstdint>
 #include <stdio.h>
-#include "YGConfig.h"
+#include <yoga/config/Config.h>
 #include "YGLayout.h"
 #include <yoga/Yoga-internal.h>
 
 #include <yoga/style/CompactValue.h>
 #include <yoga/style/Style.h>
-
-YGConfigRef YGConfigGetDefault();
 
 #pragma pack(push)
 #pragma pack(1)
@@ -58,7 +56,7 @@ private:
   uint32_t lineIndex_ = 0;
   YGNodeRef owner_ = nullptr;
   YGVector children_ = {};
-  YGConfigRef config_;
+  facebook::yoga::Config* config_;
   std::array<YGValue, 2> resolvedDimensions_ = {
       {YGValueUndefined, YGValueUndefined}};
 
@@ -84,8 +82,11 @@ private:
   using CompactValue = facebook::yoga::CompactValue;
 
 public:
-  YGNode() : YGNode{YGConfigGetDefault()} { flags_.hasNewLayout = true; }
-  explicit YGNode(const YGConfigRef config);
+  YGNode()
+      : YGNode{static_cast<facebook::yoga::Config*>(YGConfigGetDefault())} {
+    flags_.hasNewLayout = true;
+  }
+  explicit YGNode(facebook::yoga::Config* config);
   ~YGNode() = default; // cleanup of owner/children relationships in YGNodeFree
 
   YGNode(YGNode&&);
@@ -166,7 +167,7 @@ public:
 
   YGNodeRef getChild(uint32_t index) const { return children_.at(index); }
 
-  YGConfigRef getConfig() const { return config_; }
+  facebook::yoga::Config* getConfig() const { return config_; }
 
   bool isDirty() const { return flags_.isDirty; }
 
@@ -290,7 +291,7 @@ public:
 
   // TODO: rvalue override for setChildren
 
-  void setConfig(YGConfigRef config);
+  void setConfig(facebook::yoga::Config* config);
 
   void setDirty(bool isDirty);
   void setLayoutLastOwnerDirection(YGDirection direction);

--- a/yoga/YGNodePrint.cpp
+++ b/yoga/YGNodePrint.cpp
@@ -13,7 +13,7 @@
 
 #include "YGNodePrint.h"
 #include "YGNode.h"
-#include "Yoga-internal.h"
+#include <yoga/Yoga-internal.h>
 #include "Utils.h"
 
 namespace facebook::yoga {
@@ -25,7 +25,7 @@ static void indent(string& base, uint32_t level) {
   }
 }
 
-static bool areFourValuesEqual(const YGStyle::Edges& four) {
+static bool areFourValuesEqual(const Style::Edges& four) {
   return YGValueEqual(four[0], four[1]) && YGValueEqual(four[0], four[2]) &&
       YGValueEqual(four[0], four[3]);
 }
@@ -90,10 +90,10 @@ static void appendNumberIfNotZero(
 static void appendEdges(
     string& base,
     const string& key,
-    const YGStyle::Edges& edges) {
+    const Style::Edges& edges) {
   if (areFourValuesEqual(edges)) {
     auto edgeValue = YGNode::computeEdgeValueForColumn(
-        edges, YGEdgeLeft, detail::CompactValue::ofZero());
+        edges, YGEdgeLeft, CompactValue::ofZero());
     appendNumberIfNotZero(base, key, edgeValue);
   } else {
     for (int edge = YGEdgeLeft; edge != YGEdgeAll; ++edge) {
@@ -106,14 +106,14 @@ static void appendEdges(
 static void appendEdgeIfNotUndefined(
     string& base,
     const string& str,
-    const YGStyle::Edges& edges,
+    const Style::Edges& edges,
     const YGEdge edge) {
   // TODO: this doesn't take RTL / YGEdgeStart / YGEdgeEnd into account
   auto value = (edge == YGEdgeLeft || edge == YGEdgeRight)
       ? YGNode::computeEdgeValueForRow(
-            edges, edge, edge, detail::CompactValue::ofUndefined())
+            edges, edge, edge, CompactValue::ofUndefined())
       : YGNode::computeEdgeValueForColumn(
-            edges, edge, detail::CompactValue::ofUndefined());
+            edges, edge, CompactValue::ofUndefined());
   appendNumberIfNotUndefined(base, str, value);
 }
 
@@ -188,17 +188,15 @@ void YGNodeToString(
     appendEdges(str, "padding", style.padding());
     appendEdges(str, "border", style.border());
 
-    if (YGNode::computeColumnGap(
-            style.gap(), detail::CompactValue::ofUndefined()) !=
+    if (YGNode::computeColumnGap(style.gap(), CompactValue::ofUndefined()) !=
         YGNode::computeColumnGap(
-            YGNode().getStyle().gap(), detail::CompactValue::ofUndefined())) {
+            YGNode().getStyle().gap(), CompactValue::ofUndefined())) {
       appendNumberIfNotUndefined(
           str, "column-gap", style.gap()[YGGutterColumn]);
     }
-    if (YGNode::computeRowGap(
-            style.gap(), detail::CompactValue::ofUndefined()) !=
+    if (YGNode::computeRowGap(style.gap(), CompactValue::ofUndefined()) !=
         YGNode::computeRowGap(
-            YGNode().getStyle().gap(), detail::CompactValue::ofUndefined())) {
+            YGNode().getStyle().gap(), CompactValue::ofUndefined())) {
       appendNumberIfNotUndefined(str, "row-gap", style.gap()[YGGutterRow]);
     }
 

--- a/yoga/Yoga-internal.h
+++ b/yoga/Yoga-internal.h
@@ -14,7 +14,7 @@
 
 #include <yoga/Yoga.h>
 
-#include "CompactValue.h"
+#include <yoga/style/CompactValue.h>
 
 using YGVector = std::vector<YGNodeRef>;
 

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -17,7 +17,7 @@
 #include "Utils.h"
 #include "YGNode.h"
 #include "YGNodePrint.h"
-#include "Yoga-internal.h"
+#include <yoga/Yoga-internal.h>
 #include "event/event.h"
 
 using namespace facebook::yoga;
@@ -480,26 +480,25 @@ void updateStyle(
 }
 
 template <typename Ref, typename T>
-void updateStyle(YGNode* node, Ref (YGStyle::*prop)(), T value) {
+void updateStyle(YGNode* node, Ref (Style::*prop)(), T value) {
   updateStyle(
       node,
       value,
-      [prop](YGStyle& s, T x) { return (s.*prop)() != x; },
-      [prop](YGStyle& s, T x) { (s.*prop)() = x; });
+      [prop](Style& s, T x) { return (s.*prop)() != x; },
+      [prop](Style& s, T x) { (s.*prop)() = x; });
 }
 
 template <typename Ref, typename Idx>
 void updateIndexedStyleProp(
     YGNode* node,
-    Ref (YGStyle::*prop)(),
+    Ref (Style::*prop)(),
     Idx idx,
-    detail::CompactValue value) {
-  using detail::CompactValue;
+    CompactValue value) {
   updateStyle(
       node,
       value,
-      [idx, prop](YGStyle& s, CompactValue x) { return (s.*prop)()[idx] != x; },
-      [idx, prop](YGStyle& s, CompactValue x) { (s.*prop)()[idx] = x; });
+      [idx, prop](Style& s, CompactValue x) { return (s.*prop)()[idx] != x; },
+      [idx, prop](Style& s, CompactValue x) { (s.*prop)()[idx] = x; });
 }
 
 } // namespace
@@ -509,12 +508,12 @@ void updateIndexedStyleProp(
 // overload like clang and GCC. For the purposes of updateStyle(), we can help
 // MSVC by specifying that return type explicitly. In combination with
 // decltype, MSVC will prefer the non-const version.
-#define MSVC_HINT(PROP) decltype(YGStyle{}.PROP())
+#define MSVC_HINT(PROP) decltype(Style{}.PROP())
 
 YOGA_EXPORT void YGNodeStyleSetDirection(
     const YGNodeRef node,
     const YGDirection value) {
-  updateStyle<MSVC_HINT(direction)>(node, &YGStyle::direction, value);
+  updateStyle<MSVC_HINT(direction)>(node, &Style::direction, value);
 }
 YOGA_EXPORT YGDirection YGNodeStyleGetDirection(const YGNodeConstRef node) {
   return node->getStyle().direction();
@@ -524,7 +523,7 @@ YOGA_EXPORT void YGNodeStyleSetFlexDirection(
     const YGNodeRef node,
     const YGFlexDirection flexDirection) {
   updateStyle<MSVC_HINT(flexDirection)>(
-      node, &YGStyle::flexDirection, flexDirection);
+      node, &Style::flexDirection, flexDirection);
 }
 YOGA_EXPORT YGFlexDirection
 YGNodeStyleGetFlexDirection(const YGNodeConstRef node) {
@@ -535,7 +534,7 @@ YOGA_EXPORT void YGNodeStyleSetJustifyContent(
     const YGNodeRef node,
     const YGJustify justifyContent) {
   updateStyle<MSVC_HINT(justifyContent)>(
-      node, &YGStyle::justifyContent, justifyContent);
+      node, &Style::justifyContent, justifyContent);
 }
 YOGA_EXPORT YGJustify YGNodeStyleGetJustifyContent(const YGNodeConstRef node) {
   return node->getStyle().justifyContent();
@@ -545,7 +544,7 @@ YOGA_EXPORT void YGNodeStyleSetAlignContent(
     const YGNodeRef node,
     const YGAlign alignContent) {
   updateStyle<MSVC_HINT(alignContent)>(
-      node, &YGStyle::alignContent, alignContent);
+      node, &Style::alignContent, alignContent);
 }
 YOGA_EXPORT YGAlign YGNodeStyleGetAlignContent(const YGNodeConstRef node) {
   return node->getStyle().alignContent();
@@ -554,7 +553,7 @@ YOGA_EXPORT YGAlign YGNodeStyleGetAlignContent(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetAlignItems(
     const YGNodeRef node,
     const YGAlign alignItems) {
-  updateStyle<MSVC_HINT(alignItems)>(node, &YGStyle::alignItems, alignItems);
+  updateStyle<MSVC_HINT(alignItems)>(node, &Style::alignItems, alignItems);
 }
 YOGA_EXPORT YGAlign YGNodeStyleGetAlignItems(const YGNodeConstRef node) {
   return node->getStyle().alignItems();
@@ -563,7 +562,7 @@ YOGA_EXPORT YGAlign YGNodeStyleGetAlignItems(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetAlignSelf(
     const YGNodeRef node,
     const YGAlign alignSelf) {
-  updateStyle<MSVC_HINT(alignSelf)>(node, &YGStyle::alignSelf, alignSelf);
+  updateStyle<MSVC_HINT(alignSelf)>(node, &Style::alignSelf, alignSelf);
 }
 YOGA_EXPORT YGAlign YGNodeStyleGetAlignSelf(const YGNodeConstRef node) {
   return node->getStyle().alignSelf();
@@ -573,7 +572,7 @@ YOGA_EXPORT void YGNodeStyleSetPositionType(
     const YGNodeRef node,
     const YGPositionType positionType) {
   updateStyle<MSVC_HINT(positionType)>(
-      node, &YGStyle::positionType, positionType);
+      node, &Style::positionType, positionType);
 }
 YOGA_EXPORT YGPositionType
 YGNodeStyleGetPositionType(const YGNodeConstRef node) {
@@ -583,7 +582,7 @@ YGNodeStyleGetPositionType(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetFlexWrap(
     const YGNodeRef node,
     const YGWrap flexWrap) {
-  updateStyle<MSVC_HINT(flexWrap)>(node, &YGStyle::flexWrap, flexWrap);
+  updateStyle<MSVC_HINT(flexWrap)>(node, &Style::flexWrap, flexWrap);
 }
 YOGA_EXPORT YGWrap YGNodeStyleGetFlexWrap(const YGNodeConstRef node) {
   return node->getStyle().flexWrap();
@@ -592,7 +591,7 @@ YOGA_EXPORT YGWrap YGNodeStyleGetFlexWrap(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetOverflow(
     const YGNodeRef node,
     const YGOverflow overflow) {
-  updateStyle<MSVC_HINT(overflow)>(node, &YGStyle::overflow, overflow);
+  updateStyle<MSVC_HINT(overflow)>(node, &Style::overflow, overflow);
 }
 YOGA_EXPORT YGOverflow YGNodeStyleGetOverflow(const YGNodeConstRef node) {
   return node->getStyle().overflow();
@@ -601,7 +600,7 @@ YOGA_EXPORT YGOverflow YGNodeStyleGetOverflow(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetDisplay(
     const YGNodeRef node,
     const YGDisplay display) {
-  updateStyle<MSVC_HINT(display)>(node, &YGStyle::display, display);
+  updateStyle<MSVC_HINT(display)>(node, &Style::display, display);
 }
 YOGA_EXPORT YGDisplay YGNodeStyleGetDisplay(const YGNodeConstRef node) {
   return node->getStyle().display();
@@ -609,7 +608,7 @@ YOGA_EXPORT YGDisplay YGNodeStyleGetDisplay(const YGNodeConstRef node) {
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
 YOGA_EXPORT void YGNodeStyleSetFlex(const YGNodeRef node, const float flex) {
-  updateStyle<MSVC_HINT(flex)>(node, &YGStyle::flex, YGFloatOptional{flex});
+  updateStyle<MSVC_HINT(flex)>(node, &Style::flex, YGFloatOptional{flex});
 }
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
@@ -624,7 +623,7 @@ YOGA_EXPORT void YGNodeStyleSetFlexGrow(
     const YGNodeRef node,
     const float flexGrow) {
   updateStyle<MSVC_HINT(flexGrow)>(
-      node, &YGStyle::flexGrow, YGFloatOptional{flexGrow});
+      node, &Style::flexGrow, YGFloatOptional{flexGrow});
 }
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
@@ -632,7 +631,7 @@ YOGA_EXPORT void YGNodeStyleSetFlexShrink(
     const YGNodeRef node,
     const float flexShrink) {
   updateStyle<MSVC_HINT(flexShrink)>(
-      node, &YGStyle::flexShrink, YGFloatOptional{flexShrink});
+      node, &Style::flexShrink, YGFloatOptional{flexShrink});
 }
 
 YOGA_EXPORT YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
@@ -647,37 +646,37 @@ YOGA_EXPORT YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetFlexBasis(
     const YGNodeRef node,
     const float flexBasis) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(flexBasis);
-  updateStyle<MSVC_HINT(flexBasis)>(node, &YGStyle::flexBasis, value);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(flexBasis);
+  updateStyle<MSVC_HINT(flexBasis)>(node, &Style::flexBasis, value);
 }
 
 YOGA_EXPORT void YGNodeStyleSetFlexBasisPercent(
     const YGNodeRef node,
     const float flexBasisPercent) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(flexBasisPercent);
-  updateStyle<MSVC_HINT(flexBasis)>(node, &YGStyle::flexBasis, value);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(flexBasisPercent);
+  updateStyle<MSVC_HINT(flexBasis)>(node, &Style::flexBasis, value);
 }
 
 YOGA_EXPORT void YGNodeStyleSetFlexBasisAuto(const YGNodeRef node) {
   updateStyle<MSVC_HINT(flexBasis)>(
-      node, &YGStyle::flexBasis, detail::CompactValue::ofAuto());
+      node, &Style::flexBasis, CompactValue::ofAuto());
 }
 
 YOGA_EXPORT void YGNodeStyleSetPosition(
     YGNodeRef node,
     YGEdge edge,
     float points) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(points);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<MSVC_HINT(position)>(
-      node, &YGStyle::position, edge, value);
+      node, &Style::position, edge, value);
 }
 YOGA_EXPORT void YGNodeStyleSetPositionPercent(
     YGNodeRef node,
     YGEdge edge,
     float percent) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(percent);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<MSVC_HINT(position)>(
-      node, &YGStyle::position, edge, value);
+      node, &Style::position, edge, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge) {
   return node->getStyle().position()[edge];
@@ -687,21 +686,19 @@ YOGA_EXPORT void YGNodeStyleSetMargin(
     YGNodeRef node,
     YGEdge edge,
     float points) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(points);
-  updateIndexedStyleProp<MSVC_HINT(margin)>(
-      node, &YGStyle::margin, edge, value);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
+  updateIndexedStyleProp<MSVC_HINT(margin)>(node, &Style::margin, edge, value);
 }
 YOGA_EXPORT void YGNodeStyleSetMarginPercent(
     YGNodeRef node,
     YGEdge edge,
     float percent) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(percent);
-  updateIndexedStyleProp<MSVC_HINT(margin)>(
-      node, &YGStyle::margin, edge, value);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
+  updateIndexedStyleProp<MSVC_HINT(margin)>(node, &Style::margin, edge, value);
 }
 YOGA_EXPORT void YGNodeStyleSetMarginAuto(YGNodeRef node, YGEdge edge) {
   updateIndexedStyleProp<MSVC_HINT(margin)>(
-      node, &YGStyle::margin, edge, detail::CompactValue::ofAuto());
+      node, &Style::margin, edge, CompactValue::ofAuto());
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge) {
   return node->getStyle().margin()[edge];
@@ -711,17 +708,17 @@ YOGA_EXPORT void YGNodeStyleSetPadding(
     YGNodeRef node,
     YGEdge edge,
     float points) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(points);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<MSVC_HINT(padding)>(
-      node, &YGStyle::padding, edge, value);
+      node, &Style::padding, edge, value);
 }
 YOGA_EXPORT void YGNodeStyleSetPaddingPercent(
     YGNodeRef node,
     YGEdge edge,
     float percent) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(percent);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<MSVC_HINT(padding)>(
-      node, &YGStyle::padding, edge, value);
+      node, &Style::padding, edge, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetPadding(YGNodeConstRef node, YGEdge edge) {
   return node->getStyle().padding()[edge];
@@ -732,9 +729,8 @@ YOGA_EXPORT void YGNodeStyleSetBorder(
     const YGNodeRef node,
     const YGEdge edge,
     const float border) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(border);
-  updateIndexedStyleProp<MSVC_HINT(border)>(
-      node, &YGStyle::border, edge, value);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(border);
+  updateIndexedStyleProp<MSVC_HINT(border)>(node, &Style::border, edge, value);
 }
 
 YOGA_EXPORT float YGNodeStyleGetBorder(
@@ -754,8 +750,8 @@ YOGA_EXPORT void YGNodeStyleSetGap(
     const YGNodeRef node,
     const YGGutter gutter,
     const float gapLength) {
-  auto length = detail::CompactValue::ofMaybe<YGUnitPoint>(gapLength);
-  updateIndexedStyleProp<MSVC_HINT(gap)>(node, &YGStyle::gap, gutter, length);
+  auto length = CompactValue::ofMaybe<YGUnitPoint>(gapLength);
+  updateIndexedStyleProp<MSVC_HINT(gap)>(node, &Style::gap, gutter, length);
 }
 
 YOGA_EXPORT float YGNodeStyleGetGap(
@@ -784,46 +780,40 @@ YOGA_EXPORT void YGNodeStyleSetAspectRatio(
     const YGNodeRef node,
     const float aspectRatio) {
   updateStyle<MSVC_HINT(aspectRatio)>(
-      node, &YGStyle::aspectRatio, YGFloatOptional{aspectRatio});
+      node, &Style::aspectRatio, YGFloatOptional{aspectRatio});
 }
 
 YOGA_EXPORT void YGNodeStyleSetWidth(YGNodeRef node, float points) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(points);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
-      node, &YGStyle::dimensions, YGDimensionWidth, value);
+      node, &Style::dimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT void YGNodeStyleSetWidthPercent(YGNodeRef node, float percent) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(percent);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
-      node, &YGStyle::dimensions, YGDimensionWidth, value);
+      node, &Style::dimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT void YGNodeStyleSetWidthAuto(YGNodeRef node) {
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
-      node,
-      &YGStyle::dimensions,
-      YGDimensionWidth,
-      detail::CompactValue::ofAuto());
+      node, &Style::dimensions, YGDimensionWidth, CompactValue::ofAuto());
 }
 YOGA_EXPORT YGValue YGNodeStyleGetWidth(YGNodeConstRef node) {
   return node->getStyle().dimensions()[YGDimensionWidth];
 }
 
 YOGA_EXPORT void YGNodeStyleSetHeight(YGNodeRef node, float points) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(points);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
-      node, &YGStyle::dimensions, YGDimensionHeight, value);
+      node, &Style::dimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT void YGNodeStyleSetHeightPercent(YGNodeRef node, float percent) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(percent);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
-      node, &YGStyle::dimensions, YGDimensionHeight, value);
+      node, &Style::dimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT void YGNodeStyleSetHeightAuto(YGNodeRef node) {
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
-      node,
-      &YGStyle::dimensions,
-      YGDimensionHeight,
-      detail::CompactValue::ofAuto());
+      node, &Style::dimensions, YGDimensionHeight, CompactValue::ofAuto());
 }
 YOGA_EXPORT YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
   return node->getStyle().dimensions()[YGDimensionHeight];
@@ -832,16 +822,16 @@ YOGA_EXPORT YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetMinWidth(
     const YGNodeRef node,
     const float minWidth) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(minWidth);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(minWidth);
   updateIndexedStyleProp<MSVC_HINT(minDimensions)>(
-      node, &YGStyle::minDimensions, YGDimensionWidth, value);
+      node, &Style::minDimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT void YGNodeStyleSetMinWidthPercent(
     const YGNodeRef node,
     const float minWidth) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(minWidth);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(minWidth);
   updateIndexedStyleProp<MSVC_HINT(minDimensions)>(
-      node, &YGStyle::minDimensions, YGDimensionWidth, value);
+      node, &Style::minDimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
   return node->getStyle().minDimensions()[YGDimensionWidth];
@@ -850,16 +840,16 @@ YOGA_EXPORT YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetMinHeight(
     const YGNodeRef node,
     const float minHeight) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(minHeight);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(minHeight);
   updateIndexedStyleProp<MSVC_HINT(minDimensions)>(
-      node, &YGStyle::minDimensions, YGDimensionHeight, value);
+      node, &Style::minDimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT void YGNodeStyleSetMinHeightPercent(
     const YGNodeRef node,
     const float minHeight) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(minHeight);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(minHeight);
   updateIndexedStyleProp<MSVC_HINT(minDimensions)>(
-      node, &YGStyle::minDimensions, YGDimensionHeight, value);
+      node, &Style::minDimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
   return node->getStyle().minDimensions()[YGDimensionHeight];
@@ -868,16 +858,16 @@ YOGA_EXPORT YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetMaxWidth(
     const YGNodeRef node,
     const float maxWidth) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(maxWidth);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(maxWidth);
   updateIndexedStyleProp<MSVC_HINT(maxDimensions)>(
-      node, &YGStyle::maxDimensions, YGDimensionWidth, value);
+      node, &Style::maxDimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT void YGNodeStyleSetMaxWidthPercent(
     const YGNodeRef node,
     const float maxWidth) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(maxWidth);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(maxWidth);
   updateIndexedStyleProp<MSVC_HINT(maxDimensions)>(
-      node, &YGStyle::maxDimensions, YGDimensionWidth, value);
+      node, &Style::maxDimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
   return node->getStyle().maxDimensions()[YGDimensionWidth];
@@ -886,16 +876,16 @@ YOGA_EXPORT YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetMaxHeight(
     const YGNodeRef node,
     const float maxHeight) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(maxHeight);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(maxHeight);
   updateIndexedStyleProp<MSVC_HINT(maxDimensions)>(
-      node, &YGStyle::maxDimensions, YGDimensionHeight, value);
+      node, &Style::maxDimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT void YGNodeStyleSetMaxHeightPercent(
     const YGNodeRef node,
     const float maxHeight) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(maxHeight);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(maxHeight);
   updateIndexedStyleProp<MSVC_HINT(maxDimensions)>(
-      node, &YGStyle::maxDimensions, YGDimensionHeight, value);
+      node, &Style::maxDimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMaxHeight(const YGNodeConstRef node) {
   return node->getStyle().maxDimensions()[YGDimensionHeight];
@@ -2519,7 +2509,7 @@ static void YGJustifyMainAxis(
        i < collectedFlexItemsValues.endOfLineIndex;
        i++) {
     const YGNodeRef child = node->getChild(i);
-    const YGStyle& childStyle = child->getStyle();
+    const Style& childStyle = child->getStyle();
     const YGLayout childLayout = child->getLayout();
     const bool isLastChild = i == collectedFlexItemsValues.endOfLineIndex - 1;
     // remove the gap if it is the last element of the line

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -343,7 +343,6 @@ void YGConfigSetUseLegacyStretchBehaviour(
 // YGConfig
 WIN_EXPORT YGConfigRef YGConfigNew(void);
 WIN_EXPORT void YGConfigFree(YGConfigRef config);
-WIN_EXPORT void YGConfigCopy(YGConfigRef dest, YGConfigRef src);
 WIN_EXPORT int32_t YGConfigGetInstanceCount(void);
 
 WIN_EXPORT void YGConfigSetExperimentalFeatureEnabled(

--- a/yoga/config/Config.cpp
+++ b/yoga/config/Config.cpp
@@ -5,133 +5,129 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "YGConfig.h"
-
-using namespace facebook::yoga;
+#include <yoga/config/Config.h>
 
 namespace facebook::yoga {
-bool configUpdateInvalidatesLayout(YGConfigRef a, YGConfigRef b) {
+
+bool configUpdateInvalidatesLayout(Config* a, Config* b) {
   return a->getErrata() != b->getErrata() ||
       a->getEnabledExperiments() != b->getEnabledExperiments() ||
       a->getPointScaleFactor() != b->getPointScaleFactor() ||
       a->useWebDefaults() != b->useWebDefaults();
 }
-} // namespace facebook::yoga
 
-YGConfig::YGConfig(YGLogger logger) : cloneNodeCallback_{nullptr} {
+Config::Config(YGLogger logger) : cloneNodeCallback_{nullptr} {
   setLogger(logger);
 }
 
-void YGConfig::setUseWebDefaults(bool useWebDefaults) {
+void Config::setUseWebDefaults(bool useWebDefaults) {
   flags_.useWebDefaults = useWebDefaults;
 }
 
-bool YGConfig::useWebDefaults() const {
+bool Config::useWebDefaults() const {
   return flags_.useWebDefaults;
 }
 
-void YGConfig::setShouldPrintTree(bool printTree) {
+void Config::setShouldPrintTree(bool printTree) {
   flags_.printTree = printTree;
 }
 
-bool YGConfig::shouldPrintTree() const {
+bool Config::shouldPrintTree() const {
   return flags_.printTree;
 }
 
-void YGConfig::setExperimentalFeatureEnabled(
+void Config::setExperimentalFeatureEnabled(
     YGExperimentalFeature feature,
     bool enabled) {
   experimentalFeatures_.set(feature, enabled);
 }
 
-bool YGConfig::isExperimentalFeatureEnabled(
-    YGExperimentalFeature feature) const {
+bool Config::isExperimentalFeatureEnabled(YGExperimentalFeature feature) const {
   return experimentalFeatures_.test(feature);
 }
 
-ExperimentalFeatureSet YGConfig::getEnabledExperiments() const {
+ExperimentalFeatureSet Config::getEnabledExperiments() const {
   return experimentalFeatures_;
 }
 
-void YGConfig::setErrata(YGErrata errata) {
+void Config::setErrata(YGErrata errata) {
   errata_ = errata;
 }
 
-void YGConfig::addErrata(YGErrata errata) {
+void Config::addErrata(YGErrata errata) {
   errata_ |= errata;
 }
 
-void YGConfig::removeErrata(YGErrata errata) {
+void Config::removeErrata(YGErrata errata) {
   errata_ &= (~errata);
 }
 
-YGErrata YGConfig::getErrata() const {
+YGErrata Config::getErrata() const {
   return errata_;
 }
 
-bool YGConfig::hasErrata(YGErrata errata) const {
+bool Config::hasErrata(YGErrata errata) const {
   return (errata_ & errata) != YGErrataNone;
 }
 
-void YGConfig::setPointScaleFactor(float pointScaleFactor) {
+void Config::setPointScaleFactor(float pointScaleFactor) {
   pointScaleFactor_ = pointScaleFactor;
 }
 
-float YGConfig::getPointScaleFactor() const {
+float Config::getPointScaleFactor() const {
   return pointScaleFactor_;
 }
 
-void YGConfig::setContext(void* context) {
+void Config::setContext(void* context) {
   context_ = context;
 }
 
-void* YGConfig::getContext() const {
+void* Config::getContext() const {
   return context_;
 }
 
-void YGConfig::setLogger(YGLogger logger) {
+void Config::setLogger(YGLogger logger) {
   logger_.noContext = logger;
   flags_.loggerUsesContext = false;
 }
 
-void YGConfig::setLogger(LogWithContextFn logger) {
+void Config::setLogger(LogWithContextFn logger) {
   logger_.withContext = logger;
   flags_.loggerUsesContext = true;
 }
 
-void YGConfig::setLogger(std::nullptr_t) {
+void Config::setLogger(std::nullptr_t) {
   setLogger(YGLogger{nullptr});
 }
 
-void YGConfig::log(
-    YGConfig* config,
-    YGNode* node,
+void Config::log(
+    YGNodeRef node,
     YGLogLevel logLevel,
     void* logContext,
     const char* format,
-    va_list args) const {
+    va_list args) {
   if (flags_.loggerUsesContext) {
-    logger_.withContext(config, node, logLevel, logContext, format, args);
+    logger_.withContext(this, node, logLevel, logContext, format, args);
   } else {
-    logger_.noContext(config, node, logLevel, format, args);
+    logger_.noContext(this, node, logLevel, format, args);
   }
 }
 
-void YGConfig::setCloneNodeCallback(YGCloneNodeFunc cloneNode) {
+void Config::setCloneNodeCallback(YGCloneNodeFunc cloneNode) {
   cloneNodeCallback_.noContext = cloneNode;
   flags_.cloneNodeUsesContext = false;
 }
 
-void YGConfig::setCloneNodeCallback(CloneWithContextFn cloneNode) {
+void Config::setCloneNodeCallback(CloneWithContextFn cloneNode) {
   cloneNodeCallback_.withContext = cloneNode;
   flags_.cloneNodeUsesContext = true;
 }
 
-void YGConfig::setCloneNodeCallback(std::nullptr_t) {
+void Config::setCloneNodeCallback(std::nullptr_t) {
   setCloneNodeCallback(YGCloneNodeFunc{nullptr});
 }
 
-YGNodeRef YGConfig::cloneNode(
+YGNodeRef Config::cloneNode(
     YGNodeRef node,
     YGNodeRef owner,
     int childIndex,
@@ -147,3 +143,5 @@ YGNodeRef YGConfig::cloneNode(
   }
   return clone;
 }
+
+} // namespace facebook::yoga

--- a/yoga/config/Config.h
+++ b/yoga/config/Config.h
@@ -12,11 +12,16 @@
 #include <yoga/BitUtils.h>
 #include <yoga/Yoga-internal.h>
 
+// Tag struct used to form the opaque YGConfigRef for the public C API
+struct YGConfig {};
+
 namespace facebook::yoga {
+
+class Config;
 
 // Whether moving a node from config "a" to config "b" should dirty previously
 // calculated layout results.
-bool configUpdateInvalidatesLayout(YGConfigRef a, YGConfigRef b);
+bool configUpdateInvalidatesLayout(Config* a, Config* b);
 
 // Internal variants of log functions, currently used only by JNI bindings.
 // TODO: Reconcile this with the public API
@@ -33,13 +38,12 @@ using CloneWithContextFn = YGNodeRef (*)(
     int childIndex,
     void* cloneContext);
 
-using ExperimentalFeatureSet =
-    facebook::yoga::detail::EnumBitset<YGExperimentalFeature>;
+using ExperimentalFeatureSet = detail::EnumBitset<YGExperimentalFeature>;
 
 #pragma pack(push)
 #pragma pack(1)
 // Packed structure of <32-bit options to miminize size per node.
-struct YGConfigFlags {
+struct ConfigFlags {
   bool useWebDefaults : 1;
   bool printTree : 1;
   bool cloneNodeUsesContext : 1;
@@ -47,10 +51,9 @@ struct YGConfigFlags {
 };
 #pragma pack(pop)
 
-} // namespace facebook::yoga
-
-struct YOGA_EXPORT YGConfig {
-  YGConfig(YGLogger logger);
+class YOGA_EXPORT Config : public ::YGConfig {
+public:
+  Config(YGLogger logger);
 
   void setUseWebDefaults(bool useWebDefaults);
   bool useWebDefaults() const;
@@ -62,7 +65,7 @@ struct YOGA_EXPORT YGConfig {
       YGExperimentalFeature feature,
       bool enabled);
   bool isExperimentalFeatureEnabled(YGExperimentalFeature feature) const;
-  facebook::yoga::ExperimentalFeatureSet getEnabledExperiments() const;
+  ExperimentalFeatureSet getEnabledExperiments() const;
 
   void setErrata(YGErrata errata);
   void addErrata(YGErrata errata);
@@ -77,12 +80,12 @@ struct YOGA_EXPORT YGConfig {
   void* getContext() const;
 
   void setLogger(YGLogger logger);
-  void setLogger(facebook::yoga::LogWithContextFn logger);
+  void setLogger(LogWithContextFn logger);
   void setLogger(std::nullptr_t);
-  void log(YGConfig*, YGNode*, YGLogLevel, void*, const char*, va_list) const;
+  void log(YGNodeRef, YGLogLevel, void*, const char*, va_list);
 
   void setCloneNodeCallback(YGCloneNodeFunc cloneNode);
-  void setCloneNodeCallback(facebook::yoga::CloneWithContextFn cloneNode);
+  void setCloneNodeCallback(CloneWithContextFn cloneNode);
   void setCloneNodeCallback(std::nullptr_t);
   YGNodeRef cloneNode(
       YGNodeRef node,
@@ -92,17 +95,19 @@ struct YOGA_EXPORT YGConfig {
 
 private:
   union {
-    facebook::yoga::CloneWithContextFn withContext;
+    CloneWithContextFn withContext;
     YGCloneNodeFunc noContext;
   } cloneNodeCallback_;
   union {
-    facebook::yoga::LogWithContextFn withContext;
+    LogWithContextFn withContext;
     YGLogger noContext;
   } logger_;
 
-  facebook::yoga::YGConfigFlags flags_{};
-  facebook::yoga::ExperimentalFeatureSet experimentalFeatures_{};
+  ConfigFlags flags_{};
+  ExperimentalFeatureSet experimentalFeatures_{};
   YGErrata errata_ = YGErrataNone;
   float pointScaleFactor_ = 1.0f;
   void* context_ = nullptr;
 };
+
+} // namespace facebook::yoga

--- a/yoga/log.cpp
+++ b/yoga/log.cpp
@@ -8,7 +8,7 @@
 #include <yoga/Yoga.h>
 
 #include "log.h"
-#include "YGConfig.h"
+#include <yoga/config/Config.h>
 #include "YGNode.h"
 
 namespace facebook::yoga::detail {
@@ -16,14 +16,16 @@ namespace facebook::yoga::detail {
 namespace {
 
 void vlog(
-    YGConfig* config,
+    yoga::Config* config,
     YGNode* node,
     YGLogLevel level,
     void* context,
     const char* format,
     va_list args) {
-  YGConfig* logConfig = config != nullptr ? config : YGConfigGetDefault();
-  logConfig->log(logConfig, node, level, context, format, args);
+  yoga::Config* logConfig = config != nullptr
+      ? config
+      : static_cast<yoga::Config*>(YGConfigGetDefault());
+  logConfig->log(node, level, context, format, args);
 }
 } // namespace
 
@@ -46,7 +48,7 @@ YOGA_EXPORT void Log::log(
 }
 
 void Log::log(
-    YGConfig* config,
+    yoga::Config* config,
     YGLogLevel level,
     void* context,
     const char* format,

--- a/yoga/log.h
+++ b/yoga/log.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <yoga/YGEnums.h>
+#include <yoga/config/Config.h>
 
 struct YGNode;
 struct YGConfig;
@@ -23,7 +24,7 @@ struct Log {
       ...) noexcept;
 
   static void log(
-      YGConfig* config,
+      yoga::Config* config,
       YGLogLevel level,
       void*,
       const char* format,

--- a/yoga/style/CompactValue.h
+++ b/yoga/style/CompactValue.h
@@ -38,7 +38,7 @@ static_assert(
 #define VISIBLE_FOR_TESTING private:
 #endif
 
-namespace facebook::yoga::detail {
+namespace facebook::yoga {
 
 // This class stores YGValue in 32 bits.
 // - The value does not matter for Undefined and Auto. NaNs are used for their
@@ -207,4 +207,4 @@ constexpr bool operator!=(CompactValue a, CompactValue b) noexcept {
   return !(a == b);
 }
 
-} // namespace facebook::yoga::detail
+} // namespace facebook::yoga

--- a/yoga/style/Style.cpp
+++ b/yoga/style/Style.cpp
@@ -5,11 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "YGStyle.h"
-#include "Utils.h"
+#include <yoga/style/Style.h>
+#include <yoga/Utils.h>
+
+namespace facebook::yoga {
 
 // Yoga specific properties, not compatible with flexbox specification
-bool operator==(const YGStyle& lhs, const YGStyle& rhs) {
+bool operator==(const Style& lhs, const Style& rhs) {
   bool areNonFloatValuesEqual = lhs.direction() == rhs.direction() &&
       lhs.flexDirection() == rhs.flexDirection() &&
       lhs.justifyContent() == rhs.justifyContent() &&
@@ -54,3 +56,5 @@ bool operator==(const YGStyle& lhs, const YGStyle& rhs) {
 
   return areNonFloatValuesEqual;
 }
+
+} // namespace facebook::yoga

--- a/yoga/style/Style.h
+++ b/yoga/style/Style.h
@@ -13,17 +13,17 @@
 #include <type_traits>
 
 #include <yoga/Yoga.h>
+#include <yoga/YGFloatOptional.h>
+#include <yoga/Yoga-internal.h>
+#include <yoga/BitUtils.h>
 
-#include "CompactValue.h"
-#include "YGFloatOptional.h"
-#include "Yoga-internal.h"
-#include "BitUtils.h"
+#include <yoga/style/CompactValue.h>
 
-class YOGA_EXPORT YGStyle {
+namespace facebook::yoga {
+
+class YOGA_EXPORT Style {
   template <typename Enum>
-  using Values =
-      facebook::yoga::detail::Values<facebook::yoga::enums::count<Enum>()>;
-  using CompactValue = facebook::yoga::detail::CompactValue;
+  using Values = detail::Values<enums::count<Enum>()>;
 
 public:
   using Dimensions = Values<YGDimension>;
@@ -32,7 +32,7 @@ public:
 
   template <typename T>
   struct BitfieldRef {
-    YGStyle& style;
+    Style& style;
     size_t offset;
     operator T() const {
       return facebook::yoga::detail::getEnumData<T>(style.flags, offset);
@@ -43,9 +43,9 @@ public:
     }
   };
 
-  template <typename T, T YGStyle::*Prop>
+  template <typename T, T Style::*Prop>
   struct Ref {
-    YGStyle& style;
+    Style& style;
     operator T() const { return style.*Prop; }
     Ref<T, Prop>& operator=(T value) {
       style.*Prop = value;
@@ -53,10 +53,10 @@ public:
     }
   };
 
-  template <typename Idx, Values<Idx> YGStyle::*Prop>
+  template <typename Idx, Values<Idx> Style::*Prop>
   struct IdxRef {
     struct Ref {
-      YGStyle& style;
+      Style& style;
       Idx idx;
       operator CompactValue() const { return (style.*Prop)[idx]; }
       operator YGValue() const { return (style.*Prop)[idx]; }
@@ -66,7 +66,7 @@ public:
       }
     };
 
-    YGStyle& style;
+    Style& style;
     IdxRef<Idx, Prop>& operator=(const Values<Idx>& values) {
       style.*Prop = values;
       return *this;
@@ -76,11 +76,11 @@ public:
     CompactValue operator[](Idx idx) const { return (style.*Prop)[idx]; }
   };
 
-  YGStyle() {
+  Style() {
     alignContent() = YGAlignFlexStart;
     alignItems() = YGAlignStretch;
   }
-  ~YGStyle() = default;
+  ~Style() = default;
 
 private:
   static constexpr size_t directionOffset = 0;
@@ -188,51 +188,52 @@ public:
   BitfieldRef<YGDisplay> display() { return {*this, displayOffset}; }
 
   YGFloatOptional flex() const { return flex_; }
-  Ref<YGFloatOptional, &YGStyle::flex_> flex() { return {*this}; }
+  Ref<YGFloatOptional, &Style::flex_> flex() { return {*this}; }
 
   YGFloatOptional flexGrow() const { return flexGrow_; }
-  Ref<YGFloatOptional, &YGStyle::flexGrow_> flexGrow() { return {*this}; }
+  Ref<YGFloatOptional, &Style::flexGrow_> flexGrow() { return {*this}; }
 
   YGFloatOptional flexShrink() const { return flexShrink_; }
-  Ref<YGFloatOptional, &YGStyle::flexShrink_> flexShrink() { return {*this}; }
+  Ref<YGFloatOptional, &Style::flexShrink_> flexShrink() { return {*this}; }
 
   CompactValue flexBasis() const { return flexBasis_; }
-  Ref<CompactValue, &YGStyle::flexBasis_> flexBasis() { return {*this}; }
+  Ref<CompactValue, &Style::flexBasis_> flexBasis() { return {*this}; }
 
   const Edges& margin() const { return margin_; }
-  IdxRef<YGEdge, &YGStyle::margin_> margin() { return {*this}; }
+  IdxRef<YGEdge, &Style::margin_> margin() { return {*this}; }
 
   const Edges& position() const { return position_; }
-  IdxRef<YGEdge, &YGStyle::position_> position() { return {*this}; }
+  IdxRef<YGEdge, &Style::position_> position() { return {*this}; }
 
   const Edges& padding() const { return padding_; }
-  IdxRef<YGEdge, &YGStyle::padding_> padding() { return {*this}; }
+  IdxRef<YGEdge, &Style::padding_> padding() { return {*this}; }
 
   const Edges& border() const { return border_; }
-  IdxRef<YGEdge, &YGStyle::border_> border() { return {*this}; }
+  IdxRef<YGEdge, &Style::border_> border() { return {*this}; }
 
   const Gutters& gap() const { return gap_; }
-  IdxRef<YGGutter, &YGStyle::gap_> gap() { return {*this}; }
+  IdxRef<YGGutter, &Style::gap_> gap() { return {*this}; }
 
   const Dimensions& dimensions() const { return dimensions_; }
-  IdxRef<YGDimension, &YGStyle::dimensions_> dimensions() { return {*this}; }
+  IdxRef<YGDimension, &Style::dimensions_> dimensions() { return {*this}; }
 
   const Dimensions& minDimensions() const { return minDimensions_; }
-  IdxRef<YGDimension, &YGStyle::minDimensions_> minDimensions() {
+  IdxRef<YGDimension, &Style::minDimensions_> minDimensions() {
     return {*this};
   }
 
   const Dimensions& maxDimensions() const { return maxDimensions_; }
-  IdxRef<YGDimension, &YGStyle::maxDimensions_> maxDimensions() {
+  IdxRef<YGDimension, &Style::maxDimensions_> maxDimensions() {
     return {*this};
   }
 
   // Yoga specific properties, not compatible with flexbox specification
   YGFloatOptional aspectRatio() const { return aspectRatio_; }
-  Ref<YGFloatOptional, &YGStyle::aspectRatio_> aspectRatio() { return {*this}; }
+  Ref<YGFloatOptional, &Style::aspectRatio_> aspectRatio() { return {*this}; }
 };
 
-YOGA_EXPORT bool operator==(const YGStyle& lhs, const YGStyle& rhs);
-YOGA_EXPORT inline bool operator!=(const YGStyle& lhs, const YGStyle& rhs) {
+YOGA_EXPORT bool operator==(const Style& lhs, const Style& rhs);
+YOGA_EXPORT inline bool operator!=(const Style& lhs, const Style& rhs) {
   return !(lhs == rhs);
 }
+} // namespace facebook::yoga


### PR DESCRIPTION
Summary:
## This diff

This diff adds a top level `config` directory for code related to configuring Yoga and Yoga Nodes.

The public API for config handles is `YGConfigRef`, which is forward declared to be a pointer to a struct named `YGConfig`. The existing `YGConfig` is split into `yoga::Config`, as the private C++ implementation, inheriting from `YGConfig`, a marker type represented as an empty struct. The public API continues to accept `YGConfigRef`, which continues to be `YGConfig *`, but it must be cast to its concrete internal representation at the API boundary before doing work on it.

## This stack

The organization of the C++ internals of Yoga are in need of attention.
1. Some of the C++ internals are namespaced, but others not.
2. Some of the namespaces include `detail`, but are meant to be used outside of the translation unit (FB Clang Tidy rules warn on any usage of these)
2. Most of the files are in a flat hierarchy, except for event tracing in its own folder
3. Some files and functions begin with YG, others don’t
4. Some functions are uppercase, others are not
5. Almost all of the interesting logic is in Yoga.cpp, and the file is too large to reason about
6. There are multiple grab bag files where folks put random functions they need in (Utils, BitUtils, Yoga-Internal.h)
7. There is no clear indication from file structure or type naming what is private vs not
8. Handles like `YGNodeRef` and `YGConfigRef` can be used to access internals just by importing headers

This stack does some much needed spring cleaning:
1. All non-public headers and C++ implementation details are in separate folders from the root level `yoga`. This will give us room to split up logic and add more files without too large a flat hierarchy
3. All private C++ internals are under the `facebook::yoga` namespace. Details namespaces are only ever used within the same header, as they are intended
4. Utils files are split
5. Most C++ internals drop the YG prefix
6. Most C++ internal function names are all lower camel case
7. We start to split up Yoga.cpp
8. Every header beginning with YG or at the top-level directory is public and C only, with the exception of Yoga-Internal.h which has non-public functions for bindings
9. It is not possible to use private APIs without static casting handles to internal classes

This will give us more leeway to continue splitting monolithic files, and consistent guidelines for style in new files as well.

These changes should not be breaking to any project using only public Yoga headers. This includes every usage of Yoga in fbsource except for RN Fabric which is currently tied to internals. This refactor should make that boundary clearer.

Changelog: [Internal]

Differential Revision: D48710796

