### PR TITLE
C++ Cleanup 3/N: Reorganize YGNode

### DIFF
--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -35,7 +35,14 @@ Pod::Spec.new do |spec|
       '-std=c++17',
       '-fPIC'
   ]
-  spec.source_files = 'yoga/**/*.{h,cpp}'
-  spec.public_header_files = 'yoga/{Yoga,YGEnums,YGMacros,YGValue}.h'
+
   spec.swift_version = '5.1'
+  spec.source_files = 'yoga/**/*.{h,cpp}'
+  spec.header_mappings_dir = 'yoga'
+
+  public_header_files = 'yoga/{Yoga,YGEnums,YGMacros,YGValue}.h'
+  spec.public_header_files = public_header_files
+
+  all_header_files = 'yoga/**/*.h'
+  spec.private_header_files = Dir.glob(all_header_files) - Dir.glob(public_header_files)
 end

--- a/java/jni/YGJNIVanilla.cpp
+++ b/java/jni/YGJNIVanilla.cpp
@@ -19,6 +19,8 @@
 // API and use that
 #include <yoga/YGNode.h>
 
+using namespace facebook;
+using namespace facebook::yoga;
 using namespace facebook::yoga::vanillajni;
 
 static inline ScopedLocalRef<jobject> YGNodeJobject(
@@ -194,7 +196,7 @@ static void jni_YGConfigSetLoggerJNI(
     }
 
     *context = newGlobalRef(env, logger);
-    config->setLogger(YGJNILogFunc);
+    static_cast<yoga::Config*>(config)->setLogger(YGJNILogFunc);
   } else {
     if (context != nullptr) {
       delete context;

--- a/java/jni/YGJNIVanilla.cpp
+++ b/java/jni/YGJNIVanilla.cpp
@@ -17,7 +17,7 @@
 
 // TODO: Reconcile missing layoutContext functionality from callbacks in the C
 // API and use that
-#include <yoga/YGNode.h>
+#include <yoga/node/Node.h>
 
 using namespace facebook;
 using namespace facebook::yoga;
@@ -688,7 +688,7 @@ static void jni_YGNodeSetHasMeasureFuncJNI(
     jobject /*obj*/,
     jlong nativePointer,
     jboolean hasMeasureFunc) {
-  _jlong2YGNodeRef(nativePointer)
+  static_cast<yoga::Node*>(_jlong2YGNodeRef(nativePointer))
       ->setMeasureFunc(hasMeasureFunc ? YGJNIMeasureFunc : nullptr);
 }
 
@@ -715,7 +715,7 @@ static void jni_YGNodeSetHasBaselineFuncJNI(
     jobject /*obj*/,
     jlong nativePointer,
     jboolean hasBaselineFunc) {
-  _jlong2YGNodeRef(nativePointer)
+  static_cast<yoga::Node*>(_jlong2YGNodeRef(nativePointer))
       ->setBaselineFunc(hasBaselineFunc ? YGJNIBaselineFunc : nullptr);
 }
 

--- a/java/jni/YGJTypesVanilla.h
+++ b/java/jni/YGJTypesVanilla.h
@@ -14,11 +14,12 @@
 #include "jni.h"
 
 class PtrJNodeMapVanilla {
-  std::map<YGNodeRef, size_t> ptrsToIdxs_;
-  jobjectArray javaNodes_;
+  std::map<YGNodeConstRef, size_t> ptrsToIdxs_{};
+  jobjectArray javaNodes_{};
 
 public:
-  PtrJNodeMapVanilla() : ptrsToIdxs_{}, javaNodes_{} {}
+  PtrJNodeMapVanilla() = default;
+
   PtrJNodeMapVanilla(jlongArray javaNativePointers, jobjectArray javaNodes)
       : javaNodes_{javaNodes} {
     using namespace facebook::yoga::vanillajni;
@@ -30,11 +31,11 @@ public:
         javaNativePointers, 0, nativePointersSize, nativePointers.data());
 
     for (size_t i = 0; i < nativePointersSize; ++i) {
-      ptrsToIdxs_[(YGNodeRef) nativePointers[i]] = i;
+      ptrsToIdxs_[(YGNodeConstRef) nativePointers[i]] = i;
     }
   }
 
-  facebook::yoga::vanillajni::ScopedLocalRef<jobject> ref(YGNodeRef node) {
+  facebook::yoga::vanillajni::ScopedLocalRef<jobject> ref(YGNodeConstRef node) {
     using namespace facebook::yoga::vanillajni;
 
     JNIEnv* env = getCurrentEnv();

--- a/tests/CompactValueTest.cpp
+++ b/tests/CompactValueTest.cpp
@@ -7,11 +7,11 @@
 
 #define YOGA_COMPACT_VALUE_TEST
 
-#include <yoga/CompactValue.h>
+#include <yoga/style/CompactValue.h>
 #include <gtest/gtest.h>
 #include <cmath>
 
-using facebook::yoga::detail::CompactValue;
+using facebook::yoga::CompactValue;
 
 const auto tooSmall = nextafterf(CompactValue::LOWER_BOUND, -INFINITY);
 const auto tooLargePoints =

--- a/tests/EventsTest.cpp
+++ b/tests/EventsTest.cpp
@@ -9,7 +9,6 @@
 #include <yoga/event/event.h>
 #include <yoga/Yoga.h>
 #include <yoga/YGEnums.h>
-#include <yoga/YGNode.h>
 
 #include <algorithm>
 #include <functional>
@@ -30,7 +29,7 @@ struct TypedEventTestData<Event::LayoutPassEnd> {
 };
 
 struct EventArgs {
-  const YGNode* node;
+  const YGNodeConstRef node;
   Event::Type type;
   std::unique_ptr<void, std::function<void(void*)>> dataPtr;
   std::unique_ptr<void, std::function<void(void*)>> eventTestDataPtr;
@@ -48,7 +47,7 @@ struct EventArgs {
 
 class EventTest : public ::testing::Test {
   ScopedEventSubscription subscription = {&EventTest::listen};
-  static void listen(const YGNode&, Event::Type, Event::Data);
+  static void listen(YGNodeConstRef, Event::Type, Event::Data);
 
 public:
   static std::vector<EventArgs> events;
@@ -284,16 +283,16 @@ TEST_F(EventTest, baseline_functions_get_wrapped) {
 namespace {
 
 template <Event::Type E>
-EventArgs createArgs(const YGNode& node, const Event::Data data) {
+EventArgs createArgs(YGNodeConstRef node, const Event::Data data) {
   using Data = Event::TypedData<E>;
   auto deleteData = [](void* x) { delete static_cast<Data*>(x); };
 
-  return {&node, E, {new Data{(data.get<E>())}, deleteData}, nullptr};
+  return {node, E, {new Data{(data.get<E>())}, deleteData}, nullptr};
 }
 
 template <Event::Type E>
 EventArgs createArgs(
-    const YGNode& node,
+    YGNodeConstRef node,
     const Event::Data data,
     TypedEventTestData<E> eventTestData) {
   using EventTestData = TypedEventTestData<E>;
@@ -309,7 +308,10 @@ EventArgs createArgs(
 
 } // namespace
 
-void EventTest::listen(const YGNode& node, Event::Type type, Event::Data data) {
+void EventTest::listen(
+    YGNodeConstRef node,
+    Event::Type type,
+    Event::Data data) {
   switch (type) {
     case Event::NodeAllocation:
       events.push_back(createArgs<Event::NodeAllocation>(node, data));

--- a/tests/YGAlignBaselineTest.cpp
+++ b/tests/YGAlignBaselineTest.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <yoga/YGNode.h>
 #include <yoga/Yoga.h>
 
 static float _baselineFunc(
@@ -197,7 +196,7 @@ TEST(YogaTest, align_baseline_parent_using_child_in_column_as_reference) {
 
   const YGNodeRef root_child1_child1 =
       createYGNode(config, YGFlexDirectionColumn, 500, 400, false);
-  root_child1_child1->setBaselineFunc(_baselineFunc);
+  YGNodeSetBaselineFunc(root_child1_child1, _baselineFunc);
   YGNodeSetIsReferenceBaseline(root_child1_child1, true);
   YGNodeInsertChild(root_child1, root_child1_child1, 1);
 
@@ -242,7 +241,7 @@ TEST(
 
   const YGNodeRef root_child1_child1 =
       createYGNode(config, YGFlexDirectionColumn, 500, 400, false);
-  root_child1_child1->setBaselineFunc(_baselineFunc);
+  YGNodeSetBaselineFunc(root_child1_child1, _baselineFunc);
   YGNodeSetIsReferenceBaseline(root_child1_child1, true);
   YGNodeStyleSetPadding(root_child1_child1, YGEdgeLeft, 100);
   YGNodeStyleSetPadding(root_child1_child1, YGEdgeRight, 100);
@@ -295,7 +294,7 @@ TEST(
 
   const YGNodeRef root_child1_child1 =
       createYGNode(config, YGFlexDirectionColumn, 500, 400, false);
-  root_child1_child1->setBaselineFunc(_baselineFunc);
+  YGNodeSetBaselineFunc(root_child1_child1, _baselineFunc);
   YGNodeSetIsReferenceBaseline(root_child1_child1, true);
   YGNodeInsertChild(root_child1, root_child1_child1, 1);
 
@@ -344,7 +343,7 @@ TEST(
 
   const YGNodeRef root_child1_child1 =
       createYGNode(config, YGFlexDirectionColumn, 500, 400, false);
-  root_child1_child1->setBaselineFunc(_baselineFunc);
+  YGNodeSetBaselineFunc(root_child1_child1, _baselineFunc);
   YGNodeSetIsReferenceBaseline(root_child1_child1, true);
   YGNodeInsertChild(root_child1, root_child1_child1, 1);
 
@@ -389,7 +388,7 @@ TEST(
 
   const YGNodeRef root_child1_child1 =
       createYGNode(config, YGFlexDirectionColumn, 500, 400, false);
-  root_child1_child1->setBaselineFunc(_baselineFunc);
+  YGNodeSetBaselineFunc(root_child1_child1, _baselineFunc);
   YGNodeSetIsReferenceBaseline(root_child1_child1, true);
   YGNodeStyleSetMargin(root_child1_child1, YGEdgeLeft, 100);
   YGNodeStyleSetMargin(root_child1_child1, YGEdgeRight, 100);
@@ -436,7 +435,7 @@ TEST(YogaTest, align_baseline_parent_using_child_in_row_as_reference) {
 
   const YGNodeRef root_child1_child1 =
       createYGNode(config, YGFlexDirectionColumn, 500, 400, false);
-  root_child1_child1->setBaselineFunc(_baselineFunc);
+  YGNodeSetBaselineFunc(root_child1_child1, _baselineFunc);
   YGNodeSetIsReferenceBaseline(root_child1_child1, true);
   YGNodeInsertChild(root_child1, root_child1_child1, 1);
 
@@ -481,7 +480,7 @@ TEST(
 
   const YGNodeRef root_child1_child1 =
       createYGNode(config, YGFlexDirectionColumn, 500, 400, false);
-  root_child1_child1->setBaselineFunc(_baselineFunc);
+  YGNodeSetBaselineFunc(root_child1_child1, _baselineFunc);
   YGNodeSetIsReferenceBaseline(root_child1_child1, true);
   YGNodeStyleSetPadding(root_child1_child1, YGEdgeLeft, 100);
   YGNodeStyleSetPadding(root_child1_child1, YGEdgeRight, 100);
@@ -530,7 +529,7 @@ TEST(
 
   const YGNodeRef root_child1_child1 =
       createYGNode(config, YGFlexDirectionColumn, 500, 400, false);
-  root_child1_child1->setBaselineFunc(_baselineFunc);
+  YGNodeSetBaselineFunc(root_child1_child1, _baselineFunc);
   YGNodeSetIsReferenceBaseline(root_child1_child1, true);
   YGNodeStyleSetMargin(root_child1_child1, YGEdgeLeft, 100);
   YGNodeStyleSetMargin(root_child1_child1, YGEdgeRight, 100);
@@ -670,7 +669,7 @@ TEST(
 
   const YGNodeRef root_child1_child1 =
       createYGNode(config, YGFlexDirectionColumn, 500, 400, false);
-  root_child1_child1->setBaselineFunc(_baselineFunc);
+  YGNodeSetBaselineFunc(root_child1_child1, _baselineFunc);
   YGNodeSetIsReferenceBaseline(root_child1_child1, true);
   YGNodeInsertChild(root_child1, root_child1_child1, 1);
 
@@ -721,7 +720,7 @@ TEST(
 
   const YGNodeRef root_child1_child1 =
       createYGNode(config, YGFlexDirectionColumn, 500, 400, false);
-  root_child1_child1->setBaselineFunc(_baselineFunc);
+  YGNodeSetBaselineFunc(root_child1_child1, _baselineFunc);
   YGNodeSetIsReferenceBaseline(root_child1_child1, true);
   YGNodeInsertChild(root_child1, root_child1_child1, 1);
 

--- a/tests/YGAspectRatioTest.cpp
+++ b/tests/YGAspectRatioTest.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <yoga/YGNode.h>
 #include <yoga/Yoga.h>
 
 static YGSize _measure(
@@ -449,7 +448,7 @@ TEST(YogaTest, aspect_ratio_with_measure_func) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNew();
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeStyleSetAspectRatio(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 

--- a/tests/YGBaselineFuncTest.cpp
+++ b/tests/YGBaselineFuncTest.cpp
@@ -6,14 +6,13 @@
  */
 
 #include <gtest/gtest.h>
-#include <yoga/YGNode.h>
 #include <yoga/Yoga.h>
 
 static float _baseline(
     YGNodeRef node,
     const float /*width*/,
     const float /*height*/) {
-  float* baseline = (float*) node->getContext();
+  float* baseline = (float*) YGNodeGetContext(node);
   return *baseline;
 }
 
@@ -36,9 +35,9 @@ TEST(YogaTest, align_baseline_customer_func) {
 
   float baselineValue = 10;
   const YGNodeRef root_child1_child0 = YGNodeNew();
-  root_child1_child0->setContext(&baselineValue);
+  YGNodeSetContext(root_child1_child0, &baselineValue);
   YGNodeStyleSetWidth(root_child1_child0, 50);
-  root_child1_child0->setBaselineFunc(_baseline);
+  YGNodeSetBaselineFunc(root_child1_child0, _baseline);
   YGNodeStyleSetHeight(root_child1_child0, 20);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);

--- a/tests/YGDirtiedTest.cpp
+++ b/tests/YGDirtiedTest.cpp
@@ -6,10 +6,13 @@
  */
 
 #include <gtest/gtest.h>
-#include <yoga/YGNode.h>
+#include <yoga/Yoga.h>
+#include <yoga/node/Node.h>
+
+using namespace facebook;
 
 static void _dirtied(YGNodeRef node) {
-  int* dirtiedCount = (int*) node->getContext();
+  int* dirtiedCount = (int*) YGNodeGetContext(node);
   (*dirtiedCount)++;
 }
 
@@ -22,17 +25,17 @@ TEST(YogaTest, dirtied) {
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
   int dirtiedCount = 0;
-  root->setContext(&dirtiedCount);
-  root->setDirtiedFunc(_dirtied);
+  YGNodeSetContext(root, &dirtiedCount);
+  YGNodeSetDirtiedFunc(root, _dirtied);
 
   ASSERT_EQ(0, dirtiedCount);
 
   // `_dirtied` MUST be called in case of explicit dirtying.
-  root->setDirty(true);
+  static_cast<yoga::Node*>(root)->setDirty(true);
   ASSERT_EQ(1, dirtiedCount);
 
   // `_dirtied` MUST be called ONCE.
-  root->setDirty(true);
+  static_cast<yoga::Node*>(root)->setDirty(true);
   ASSERT_EQ(1, dirtiedCount);
 }
 
@@ -55,17 +58,17 @@ TEST(YogaTest, dirtied_propagation) {
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
   int dirtiedCount = 0;
-  root->setContext(&dirtiedCount);
-  root->setDirtiedFunc(_dirtied);
+  YGNodeSetContext(root, &dirtiedCount);
+  YGNodeSetDirtiedFunc(root, _dirtied);
 
   ASSERT_EQ(0, dirtiedCount);
 
   // `_dirtied` MUST be called for the first time.
-  root_child0->markDirtyAndPropagate();
+  static_cast<yoga::Node*>(root_child0)->markDirtyAndPropagate();
   ASSERT_EQ(1, dirtiedCount);
 
   // `_dirtied` must NOT be called for the second time.
-  root_child0->markDirtyAndPropagate();
+  static_cast<yoga::Node*>(root_child0)->markDirtyAndPropagate();
   ASSERT_EQ(1, dirtiedCount);
 }
 
@@ -88,20 +91,20 @@ TEST(YogaTest, dirtied_hierarchy) {
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
   int dirtiedCount = 0;
-  root_child0->setContext(&dirtiedCount);
-  root_child0->setDirtiedFunc(_dirtied);
+  YGNodeSetContext(root_child0, &dirtiedCount);
+  YGNodeSetDirtiedFunc(root_child0, _dirtied);
 
   ASSERT_EQ(0, dirtiedCount);
 
   // `_dirtied` must NOT be called for descendants.
-  root->markDirtyAndPropagate();
+  static_cast<yoga::Node*>(root)->markDirtyAndPropagate();
   ASSERT_EQ(0, dirtiedCount);
 
   // `_dirtied` must NOT be called for the sibling node.
-  root_child1->markDirtyAndPropagate();
+  static_cast<yoga::Node*>(root_child1)->markDirtyAndPropagate();
   ASSERT_EQ(0, dirtiedCount);
 
   // `_dirtied` MUST be called in case of explicit dirtying.
-  root_child0->markDirtyAndPropagate();
+  static_cast<yoga::Node*>(root_child0)->markDirtyAndPropagate();
   ASSERT_EQ(1, dirtiedCount);
 }

--- a/tests/YGDirtyMarkingTest.cpp
+++ b/tests/YGDirtyMarkingTest.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <yoga/YGNode.h>
+#include <yoga/Yoga.h>
 
 TEST(YogaTest, dirty_propagation) {
   const YGNodeRef root = YGNodeNew();
@@ -28,15 +28,15 @@ TEST(YogaTest, dirty_propagation) {
 
   YGNodeStyleSetWidth(root_child0, 20);
 
-  EXPECT_TRUE(root_child0->isDirty());
-  EXPECT_FALSE(root_child1->isDirty());
-  EXPECT_TRUE(root->isDirty());
+  EXPECT_TRUE(YGNodeIsDirty(root_child0));
+  EXPECT_FALSE(YGNodeIsDirty(root_child1));
+  EXPECT_TRUE(YGNodeIsDirty(root));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
-  EXPECT_FALSE(root_child0->isDirty());
-  EXPECT_FALSE(root_child1->isDirty());
-  EXPECT_FALSE(root->isDirty());
+  EXPECT_FALSE(YGNodeIsDirty(root_child0));
+  EXPECT_FALSE(YGNodeIsDirty(root_child1));
+  EXPECT_FALSE(YGNodeIsDirty(root));
 
   YGNodeFreeRecursive(root);
 }
@@ -61,9 +61,9 @@ TEST(YogaTest, dirty_propagation_only_if_prop_changed) {
 
   YGNodeStyleSetWidth(root_child0, 50);
 
-  EXPECT_FALSE(root_child0->isDirty());
-  EXPECT_FALSE(root_child1->isDirty());
-  EXPECT_FALSE(root->isDirty());
+  EXPECT_FALSE(YGNodeIsDirty(root_child0));
+  EXPECT_FALSE(YGNodeIsDirty(root_child1));
+  EXPECT_FALSE(YGNodeIsDirty(root));
 
   YGNodeFreeRecursive(root);
 }
@@ -91,26 +91,26 @@ TEST(YogaTest, dirty_propagation_changing_layout_config) {
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
-  EXPECT_FALSE(root->isDirty());
-  EXPECT_FALSE(root_child0->isDirty());
-  EXPECT_FALSE(root_child1->isDirty());
-  EXPECT_FALSE(root_child0_child0->isDirty());
+  EXPECT_FALSE(YGNodeIsDirty(root));
+  EXPECT_FALSE(YGNodeIsDirty(root_child0));
+  EXPECT_FALSE(YGNodeIsDirty(root_child1));
+  EXPECT_FALSE(YGNodeIsDirty(root_child0_child0));
 
   YGConfigRef newConfig = YGConfigNew();
   YGConfigSetErrata(newConfig, YGErrataStretchFlexBasis);
   YGNodeSetConfig(root_child0, newConfig);
 
-  EXPECT_TRUE(root->isDirty());
-  EXPECT_TRUE(root_child0->isDirty());
-  EXPECT_FALSE(root_child1->isDirty());
-  EXPECT_FALSE(root_child0_child0->isDirty());
+  EXPECT_TRUE(YGNodeIsDirty(root));
+  EXPECT_TRUE(YGNodeIsDirty(root_child0));
+  EXPECT_FALSE(YGNodeIsDirty(root_child1));
+  EXPECT_FALSE(YGNodeIsDirty(root_child0_child0));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
-  EXPECT_FALSE(root->isDirty());
-  EXPECT_FALSE(root_child0->isDirty());
-  EXPECT_FALSE(root_child1->isDirty());
-  EXPECT_FALSE(root_child0_child0->isDirty());
+  EXPECT_FALSE(YGNodeIsDirty(root));
+  EXPECT_FALSE(YGNodeIsDirty(root_child0));
+  EXPECT_FALSE(YGNodeIsDirty(root_child1));
+  EXPECT_FALSE(YGNodeIsDirty(root_child0_child0));
 
   YGConfigFree(newConfig);
   YGNodeFreeRecursive(root);
@@ -139,10 +139,10 @@ TEST(YogaTest, dirty_propagation_changing_benign_config) {
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
-  EXPECT_FALSE(root->isDirty());
-  EXPECT_FALSE(root_child0->isDirty());
-  EXPECT_FALSE(root_child1->isDirty());
-  EXPECT_FALSE(root_child0_child0->isDirty());
+  EXPECT_FALSE(YGNodeIsDirty(root));
+  EXPECT_FALSE(YGNodeIsDirty(root_child0));
+  EXPECT_FALSE(YGNodeIsDirty(root_child1));
+  EXPECT_FALSE(YGNodeIsDirty(root_child0_child0));
 
   YGConfigRef newConfig = YGConfigNew();
   YGConfigSetLogger(
@@ -152,10 +152,10 @@ TEST(YogaTest, dirty_propagation_changing_benign_config) {
       });
   YGNodeSetConfig(root_child0, newConfig);
 
-  EXPECT_FALSE(root->isDirty());
-  EXPECT_FALSE(root_child0->isDirty());
-  EXPECT_FALSE(root_child1->isDirty());
-  EXPECT_FALSE(root_child0_child0->isDirty());
+  EXPECT_FALSE(YGNodeIsDirty(root));
+  EXPECT_FALSE(YGNodeIsDirty(root_child0));
+  EXPECT_FALSE(YGNodeIsDirty(root_child1));
+  EXPECT_FALSE(YGNodeIsDirty(root_child0_child0));
 
   YGConfigFree(newConfig);
   YGNodeFreeRecursive(root);
@@ -224,11 +224,11 @@ TEST(YogaTest, dirty_node_only_if_children_are_actually_removed) {
 
   const YGNodeRef child1 = YGNodeNew();
   YGNodeRemoveChild(root, child1);
-  EXPECT_FALSE(root->isDirty());
+  EXPECT_FALSE(YGNodeIsDirty(root));
   YGNodeFree(child1);
 
   YGNodeRemoveChild(root, child0);
-  EXPECT_TRUE(root->isDirty());
+  EXPECT_TRUE(YGNodeIsDirty(root));
   YGNodeFree(child0);
 
   YGNodeFreeRecursive(root);
@@ -241,12 +241,11 @@ TEST(YogaTest, dirty_node_only_if_undefined_values_gets_set_to_undefined) {
   YGNodeStyleSetMinWidth(root, YGUndefined);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
-
-  EXPECT_FALSE(root->isDirty());
+  EXPECT_FALSE(YGNodeIsDirty(root));
 
   YGNodeStyleSetMinWidth(root, YGUndefined);
 
-  EXPECT_FALSE(root->isDirty());
+  EXPECT_FALSE(YGNodeIsDirty(root));
 
   YGNodeFreeRecursive(root);
 }

--- a/tests/YGMeasureCacheTest.cpp
+++ b/tests/YGMeasureCacheTest.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <yoga/YGNode.h>
 #include <yoga/Yoga.h>
 
 static YGSize _measureMax(
@@ -15,7 +14,7 @@ static YGSize _measureMax(
     YGMeasureMode widthMode,
     float height,
     YGMeasureMode heightMode) {
-  int* measureCount = (int*) node->getContext();
+  int* measureCount = (int*) YGNodeGetContext(node);
   (*measureCount)++;
 
   return YGSize{
@@ -30,7 +29,7 @@ static YGSize _measureMin(
     YGMeasureMode widthMode,
     float height,
     YGMeasureMode heightMode) {
-  int* measureCount = (int*) node->getContext();
+  int* measureCount = (int*) YGNodeGetContext(node);
   *measureCount = *measureCount + 1;
   return YGSize{
       widthMode == YGMeasureModeUndefined ||
@@ -50,7 +49,7 @@ static YGSize _measure_84_49(
     YGMeasureMode /*widthMode*/,
     float /*height*/,
     YGMeasureMode /*heightMode*/) {
-  int* measureCount = (int*) node->getContext();
+  int* measureCount = (int*) YGNodeGetContext(node);
   if (measureCount) {
     (*measureCount)++;
   }
@@ -67,8 +66,8 @@ TEST(YogaTest, measure_once_single_flexible_child) {
 
   const YGNodeRef root_child0 = YGNodeNew();
   int measureCount = 0;
-  root_child0->setContext(&measureCount);
-  root_child0->setMeasureFunc(_measureMax);
+  YGNodeSetContext(root_child0, &measureCount);
+  YGNodeSetMeasureFunc(root_child0, _measureMax);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
@@ -84,8 +83,8 @@ TEST(YogaTest, remeasure_with_same_exact_width_larger_than_needed_height) {
 
   const YGNodeRef root_child0 = YGNodeNew();
   int measureCount = 0;
-  root_child0->setContext(&measureCount);
-  root_child0->setMeasureFunc(_measureMin);
+  YGNodeSetContext(root_child0, &measureCount);
+  YGNodeSetMeasureFunc(root_child0, _measureMin);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, 100, 100, YGDirectionLTR);
@@ -102,8 +101,8 @@ TEST(YogaTest, remeasure_with_same_atmost_width_larger_than_needed_height) {
 
   const YGNodeRef root_child0 = YGNodeNew();
   int measureCount = 0;
-  root_child0->setContext(&measureCount);
-  root_child0->setMeasureFunc(_measureMin);
+  YGNodeSetContext(root_child0, &measureCount);
+  YGNodeSetMeasureFunc(root_child0, _measureMin);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, 100, 100, YGDirectionLTR);
@@ -120,8 +119,8 @@ TEST(YogaTest, remeasure_with_computed_width_larger_than_needed_height) {
 
   const YGNodeRef root_child0 = YGNodeNew();
   int measureCount = 0;
-  root_child0->setContext(&measureCount);
-  root_child0->setMeasureFunc(_measureMin);
+  YGNodeSetContext(root_child0, &measureCount);
+  YGNodeSetMeasureFunc(root_child0, _measureMin);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, 100, 100, YGDirectionLTR);
@@ -139,8 +138,8 @@ TEST(YogaTest, remeasure_with_atmost_computed_width_undefined_height) {
 
   const YGNodeRef root_child0 = YGNodeNew();
   int measureCount = 0;
-  root_child0->setContext(&measureCount);
-  root_child0->setMeasureFunc(_measureMin);
+  YGNodeSetContext(root_child0, &measureCount);
+  YGNodeSetMeasureFunc(root_child0, _measureMin);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, 100, YGUndefined, YGDirectionLTR);
@@ -167,8 +166,8 @@ TEST(
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNew();
-  root_child0_child0->setContext(&measureCount);
-  root_child0_child0->setMeasureFunc(_measure_84_49);
+  YGNodeSetContext(root_child0_child0, &measureCount);
+  YGNodeSetMeasureFunc(root_child0_child0, _measure_84_49);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);

--- a/tests/YGMeasureModeTest.cpp
+++ b/tests/YGMeasureModeTest.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <yoga/YGNode.h>
 #include <yoga/Yoga.h>
 
 struct _MeasureConstraint {
@@ -28,7 +27,7 @@ static YGSize _measure(
     float height,
     YGMeasureMode heightMode) {
   struct _MeasureConstraintList* constraintList =
-      (struct _MeasureConstraintList*) node->getContext();
+      (struct _MeasureConstraintList*) YGNodeGetContext(node);
   struct _MeasureConstraint* constraints = constraintList->constraints;
   uint32_t currentIndex = constraintList->length;
   (&constraints[currentIndex])->width = width;
@@ -55,10 +54,8 @@ TEST(YogaTest, exactly_measure_stretched_child_column) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNew();
-  //  root_child0->setContext(&constraintList);
-  root_child0->setContext(&constraintList);
-  root_child0->setMeasureFunc(_measure);
-  //  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &constraintList);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -85,9 +82,8 @@ TEST(YogaTest, exactly_measure_stretched_child_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNew();
-  //  root_child0->setContext(&constraintList);
-  root_child0->setContext(&constraintList);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &constraintList);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -113,8 +109,8 @@ TEST(YogaTest, at_most_main_axis_column) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNew();
-  root_child0->setContext(&constraintList);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &constraintList);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -141,8 +137,8 @@ TEST(YogaTest, at_most_cross_axis_column) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNew();
-  root_child0->setContext(&constraintList);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &constraintList);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -169,8 +165,8 @@ TEST(YogaTest, at_most_main_axis_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNew();
-  root_child0->setContext(&constraintList);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &constraintList);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -198,8 +194,8 @@ TEST(YogaTest, at_most_cross_axis_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNew();
-  root_child0->setContext(&constraintList);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &constraintList);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -225,8 +221,8 @@ TEST(YogaTest, flex_child) {
 
   const YGNodeRef root_child0 = YGNodeNew();
   YGNodeStyleSetFlexGrow(root_child0, 1);
-  root_child0->setContext(&constraintList);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &constraintList);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -256,8 +252,8 @@ TEST(YogaTest, flex_child_with_flex_basis) {
   const YGNodeRef root_child0 = YGNodeNew();
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 0);
-  root_child0->setContext(&constraintList);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &constraintList);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -285,8 +281,8 @@ TEST(YogaTest, overflow_scroll_column) {
   YGNodeStyleSetWidth(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNew();
-  root_child0->setContext(&constraintList);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &constraintList);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -318,8 +314,8 @@ TEST(YogaTest, overflow_scroll_row) {
   YGNodeStyleSetWidth(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNew();
-  root_child0->setContext(&constraintList);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &constraintList);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);

--- a/tests/YGMeasureTest.cpp
+++ b/tests/YGMeasureTest.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <yoga/YGNode.h>
 #include <yoga/Yoga.h>
 
 static YGSize _measure(
@@ -15,7 +14,7 @@ static YGSize _measure(
     YGMeasureMode /*widthMode*/,
     float /*height*/,
     YGMeasureMode /*heightMode*/) {
-  int* measureCount = (int*) node->getContext();
+  int* measureCount = (int*) YGNodeGetContext(node);
   if (measureCount) {
     (*measureCount)++;
   }
@@ -56,8 +55,8 @@ TEST(YogaTest, dont_measure_single_grow_shrink_child) {
   int measureCount = 0;
 
   const YGNodeRef root_child0 = YGNodeNew();
-  root_child0->setContext(&measureCount);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &measureCount);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
@@ -79,8 +78,8 @@ TEST(YogaTest, measure_absolute_child_with_no_constraints) {
 
   const YGNodeRef root_child0_child0 = YGNodeNew();
   YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
-  root_child0_child0->setContext(&measureCount);
-  root_child0_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0_child0, &measureCount);
+  YGNodeSetMeasureFunc(root_child0_child0, _measure);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -99,8 +98,8 @@ TEST(YogaTest, dont_measure_when_min_equals_max) {
   int measureCount = 0;
 
   const YGNodeRef root_child0 = YGNodeNew();
-  root_child0->setContext(&measureCount);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &measureCount);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeStyleSetMinWidth(root_child0, 10);
   YGNodeStyleSetMaxWidth(root_child0, 10);
   YGNodeStyleSetMinHeight(root_child0, 10);
@@ -127,8 +126,8 @@ TEST(YogaTest, dont_measure_when_min_equals_max_percentages) {
   int measureCount = 0;
 
   const YGNodeRef root_child0 = YGNodeNew();
-  root_child0->setContext(&measureCount);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &measureCount);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeStyleSetMinWidthPercent(root_child0, 10);
   YGNodeStyleSetMaxWidthPercent(root_child0, 10);
   YGNodeStyleSetMinHeightPercent(root_child0, 10);
@@ -152,7 +151,7 @@ TEST(YogaTest, measure_nodes_with_margin_auto_and_stretch) {
   YGNodeStyleSetHeight(root, 500);
 
   const YGNodeRef root_child0 = YGNodeNew();
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeLeft);
   YGNodeInsertChild(root, root_child0, 0);
 
@@ -175,8 +174,8 @@ TEST(YogaTest, dont_measure_when_min_equals_max_mixed_width_percent) {
   int measureCount = 0;
 
   const YGNodeRef root_child0 = YGNodeNew();
-  root_child0->setContext(&measureCount);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &measureCount);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeStyleSetMinWidthPercent(root_child0, 10);
   YGNodeStyleSetMaxWidthPercent(root_child0, 10);
   YGNodeStyleSetMinHeight(root_child0, 10);
@@ -203,8 +202,8 @@ TEST(YogaTest, dont_measure_when_min_equals_max_mixed_height_percent) {
   int measureCount = 0;
 
   const YGNodeRef root_child0 = YGNodeNew();
-  root_child0->setContext(&measureCount);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &measureCount);
+  YGNodeSetMeasureFunc(root_child0, _measure);
   YGNodeStyleSetMinWidth(root_child0, 10);
   YGNodeStyleSetMaxWidth(root_child0, 10);
   YGNodeStyleSetMinHeightPercent(root_child0, 10);
@@ -228,7 +227,7 @@ TEST(YogaTest, measure_enough_size_should_be_in_single_line) {
 
   const YGNodeRef root_child0 = YGNodeNew();
   YGNodeStyleSetAlignSelf(root_child0, YGAlignFlexStart);
-  root_child0->setMeasureFunc(_simulate_wrapping_text);
+  YGNodeSetMeasureFunc(root_child0, _simulate_wrapping_text);
 
   YGNodeInsertChild(root, root_child0, 0);
 
@@ -247,7 +246,7 @@ TEST(YogaTest, measure_not_enough_size_should_wrap) {
   const YGNodeRef root_child0 = YGNodeNew();
   YGNodeStyleSetAlignSelf(root_child0, YGAlignFlexStart);
   //  YGNodeSetMeasureFunc(root_child0, _simulate_wrapping_text);
-  root_child0->setMeasureFunc(_simulate_wrapping_text);
+  YGNodeSetMeasureFunc(root_child0, _simulate_wrapping_text);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -269,8 +268,8 @@ TEST(YogaTest, measure_zero_space_should_grow) {
   const YGNodeRef root_child0 = YGNodeNew();
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumn);
   YGNodeStyleSetPadding(root_child0, YGEdgeAll, 100);
-  root_child0->setContext(&measureCount);
-  root_child0->setMeasureFunc(_measure);
+  YGNodeSetContext(root_child0, &measureCount);
+  YGNodeSetMeasureFunc(root_child0, _measure);
 
   YGNodeInsertChild(root, root_child0, 0);
 
@@ -295,8 +294,7 @@ TEST(YogaTest, measure_flex_direction_row_and_padding) {
   YGNodeStyleSetHeight(root, 50);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  root_child0->setMeasureFunc(_simulate_wrapping_text);
-  //  YGNodeSetMeasureFunc(root_child0, _simulate_wrapping_text);
+  YGNodeSetMeasureFunc(root_child0, _simulate_wrapping_text);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
@@ -335,7 +333,7 @@ TEST(YogaTest, measure_flex_direction_column_and_padding) {
   YGNodeStyleSetHeight(root, 50);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  root_child0->setMeasureFunc(_simulate_wrapping_text);
+  YGNodeSetMeasureFunc(root_child0, _simulate_wrapping_text);
   //  YGNodeSetMeasureFunc(root_child0, _simulate_wrapping_text);
   YGNodeInsertChild(root, root_child0, 0);
 
@@ -376,7 +374,7 @@ TEST(YogaTest, measure_flex_direction_row_no_padding) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   //  YGNodeSetMeasureFunc(root_child0, _simulate_wrapping_text);
-  root_child0->setMeasureFunc(_simulate_wrapping_text);
+  YGNodeSetMeasureFunc(root_child0, _simulate_wrapping_text);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
@@ -416,7 +414,7 @@ TEST(YogaTest, measure_flex_direction_row_no_padding_align_items_flexstart) {
   YGNodeStyleSetAlignItems(root, YGAlignFlexStart);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  root_child0->setMeasureFunc(_simulate_wrapping_text);
+  YGNodeSetMeasureFunc(root_child0, _simulate_wrapping_text);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
@@ -455,7 +453,7 @@ TEST(YogaTest, measure_with_fixed_size) {
   YGNodeStyleSetHeight(root, 50);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  root_child0->setMeasureFunc(_simulate_wrapping_text);
+  YGNodeSetMeasureFunc(root_child0, _simulate_wrapping_text);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -496,7 +494,7 @@ TEST(YogaTest, measure_with_flex_shrink) {
   YGNodeStyleSetHeight(root, 50);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  root_child0->setMeasureFunc(_simulate_wrapping_text);
+  YGNodeSetMeasureFunc(root_child0, _simulate_wrapping_text);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
@@ -535,7 +533,7 @@ TEST(YogaTest, measure_no_padding) {
   YGNodeStyleSetHeight(root, 50);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  root_child0->setMeasureFunc(_simulate_wrapping_text);
+  YGNodeSetMeasureFunc(root_child0, _simulate_wrapping_text);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
@@ -568,7 +566,7 @@ TEST(YogaTest, measure_no_padding) {
 #if GTEST_HAS_DEATH_TEST
 TEST(YogaDeathTest, cannot_add_child_to_node_with_measure_func) {
   const YGNodeRef root = YGNodeNew();
-  root->setMeasureFunc(_measure);
+  YGNodeSetMeasureFunc(root, _measure);
 
   const YGNodeRef root_child0 = YGNodeNew();
 #if defined(__cpp_exceptions)
@@ -585,9 +583,10 @@ TEST(YogaDeathTest, cannot_add_nonnull_measure_func_to_non_leaf_node) {
   const YGNodeRef root_child0 = YGNodeNew();
   YGNodeInsertChild(root, root_child0, 0);
 #if defined(__cpp_exceptions)
-  ASSERT_THROW(root->setMeasureFunc(_measure), std::logic_error);
+  ASSERT_THROW(YGNodeSetMeasureFunc(root, _measure), std::logic_error);
 #else // !defined(__cpp_exceptions)
-  ASSERT_DEATH(root->setMeasureFunc(_measure), "Cannot set measure function.*");
+  ASSERT_DEATH(
+      YGNodeSetMeasureFunc(root, _measure), "Cannot set measure function.*");
 #endif // defined(__cpp_exceptions)
   YGNodeFreeRecursive(root);
 }
@@ -597,8 +596,8 @@ TEST(YogaDeathTest, cannot_add_nonnull_measure_func_to_non_leaf_node) {
 TEST(YogaTest, can_nullify_measure_func_on_any_node) {
   const YGNodeRef root = YGNodeNew();
   YGNodeInsertChild(root, YGNodeNew(), 0);
-  root->setMeasureFunc(nullptr);
-  ASSERT_TRUE(!root->hasMeasureFunc());
+  YGNodeSetMeasureFunc(root, nullptr);
+  ASSERT_TRUE(!YGNodeHasMeasureFunc(root));
   YGNodeFreeRecursive(root);
 }
 
@@ -611,7 +610,7 @@ TEST(YogaTest, cant_call_negative_measure) {
   YGNodeStyleSetHeight(root, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  root_child0->setMeasureFunc(_measure_assert_negative);
+  YGNodeSetMeasureFunc(root_child0, _measure_assert_negative);
   YGNodeStyleSetMargin(root_child0, YGEdgeTop, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
@@ -630,7 +629,7 @@ TEST(YogaTest, cant_call_negative_measure_horizontal) {
   YGNodeStyleSetHeight(root, 20);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  root_child0->setMeasureFunc(_measure_assert_negative);
+  YGNodeSetMeasureFunc(root_child0, _measure_assert_negative);
   YGNodeStyleSetMargin(root_child0, YGEdgeStart, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
@@ -674,7 +673,7 @@ TEST(YogaTest, percent_with_text_node) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  root_child1->setMeasureFunc(_measure_90_10);
+  YGNodeSetMeasureFunc(root_child1, _measure_90_10);
   YGNodeStyleSetMaxWidthPercent(root_child1, 50);
   YGNodeStyleSetPaddingPercent(root_child1, YGEdgeTop, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -713,28 +712,28 @@ TEST(YogaTest, percent_margin_with_measure_func) {
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeStyleSetMargin(root_child0, YGEdgeTop, 0);
-  root_child0->setMeasureFunc(_measure_100_100);
+  YGNodeSetMeasureFunc(root_child0, _measure_100_100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetWidth(root_child1, 100);
   YGNodeStyleSetHeight(root_child1, 100);
   YGNodeStyleSetMargin(root_child1, YGEdgeTop, 100);
-  root_child1->setMeasureFunc(_measure_100_100);
+  YGNodeSetMeasureFunc(root_child1, _measure_100_100);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
   YGNodeStyleSetWidth(root_child2, 100);
   YGNodeStyleSetHeight(root_child2, 100);
   YGNodeStyleSetMarginPercent(root_child2, YGEdgeTop, 10);
-  root_child2->setMeasureFunc(_measure_100_100);
+  YGNodeSetMeasureFunc(root_child2, _measure_100_100);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
   YGNodeStyleSetWidth(root_child3, 100);
   YGNodeStyleSetHeight(root_child3, 100);
   YGNodeStyleSetMarginPercent(root_child3, YGEdgeTop, 20);
-  root_child3->setMeasureFunc(_measure_100_100);
+  YGNodeSetMeasureFunc(root_child3, _measure_100_100);
   YGNodeInsertChild(root, root_child3, 3);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -783,24 +782,24 @@ TEST(YogaTest, percent_padding_with_measure_func) {
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeTop, 0);
-  root_child0->setMeasureFunc(_measure_100_100);
+  YGNodeSetMeasureFunc(root_child0, _measure_100_100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetWidth(root_child1, 100);
   YGNodeStyleSetHeight(root_child1, 100);
   YGNodeStyleSetPadding(root_child1, YGEdgeTop, 100);
-  root_child1->setMeasureFunc(_measure_100_100);
+  YGNodeSetMeasureFunc(root_child1, _measure_100_100);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
   YGNodeStyleSetPaddingPercent(root_child2, YGEdgeTop, 10);
-  root_child2->setMeasureFunc(_measure_100_100);
+  YGNodeSetMeasureFunc(root_child2, _measure_100_100);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
   YGNodeStyleSetPaddingPercent(root_child3, YGEdgeTop, 20);
-  root_child3->setMeasureFunc(_measure_100_100);
+  YGNodeSetMeasureFunc(root_child3, _measure_100_100);
   YGNodeInsertChild(root, root_child3, 3);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -849,26 +848,26 @@ TEST(YogaTest, percent_padding_and_percent_margin_with_measure_func) {
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeTop, 0);
-  root_child0->setMeasureFunc(_measure_100_100);
+  YGNodeSetMeasureFunc(root_child0, _measure_100_100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetWidth(root_child1, 100);
   YGNodeStyleSetHeight(root_child1, 100);
   YGNodeStyleSetPadding(root_child1, YGEdgeTop, 100);
-  root_child1->setMeasureFunc(_measure_100_100);
+  YGNodeSetMeasureFunc(root_child1, _measure_100_100);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
   YGNodeStyleSetPaddingPercent(root_child2, YGEdgeTop, 10);
   YGNodeStyleSetMarginPercent(root_child2, YGEdgeTop, 10);
-  root_child2->setMeasureFunc(_measure_100_100);
+  YGNodeSetMeasureFunc(root_child2, _measure_100_100);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
   YGNodeStyleSetPaddingPercent(root_child3, YGEdgeTop, 20);
   YGNodeStyleSetMarginPercent(root_child3, YGEdgeTop, 20);
-  root_child3->setMeasureFunc(_measure_100_100);
+  YGNodeSetMeasureFunc(root_child3, _measure_100_100);
   YGNodeInsertChild(root, root_child3, 3);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);

--- a/tests/YGNodeCallbackTest.cpp
+++ b/tests/YGNodeCallbackTest.cpp
@@ -6,33 +6,33 @@
  */
 
 #include <gtest/gtest.h>
-#include <yoga/YGNode.h>
+#include <yoga/node/Node.h>
 #include <ostream>
+
+using namespace facebook::yoga;
 
 inline bool operator==(const YGSize& lhs, const YGSize& rhs) {
   return lhs.width == rhs.width && lhs.height == rhs.height;
 }
 
-void PrintTo(const YGSize&, std::ostream*);
-
-TEST(YGNode, hasMeasureFunc_initial) {
-  auto n = YGNode{};
+TEST(Node, hasMeasureFunc_initial) {
+  auto n = Node{};
   ASSERT_FALSE(n.hasMeasureFunc());
 }
 
-TEST(YGNode, hasMeasureFunc_with_measure_fn) {
-  auto n = YGNode{};
-  n.setMeasureFunc([](YGNode*, float, YGMeasureMode, float, YGMeasureMode) {
+TEST(Node, hasMeasureFunc_with_measure_fn) {
+  auto n = Node{};
+  n.setMeasureFunc([](YGNodeRef, float, YGMeasureMode, float, YGMeasureMode) {
     return YGSize{};
   });
   ASSERT_TRUE(n.hasMeasureFunc());
 }
 
-TEST(YGNode, measure_with_measure_fn) {
-  auto n = YGNode{};
+TEST(Node, measure_with_measure_fn) {
+  auto n = Node{};
 
   n.setMeasureFunc(
-      [](YGNode*, float w, YGMeasureMode wm, float h, YGMeasureMode hm) {
+      [](YGNodeRef, float w, YGMeasureMode wm, float h, YGMeasureMode hm) {
         return YGSize{w * static_cast<int>(wm), h / static_cast<int>(hm)};
       });
 
@@ -41,10 +41,10 @@ TEST(YGNode, measure_with_measure_fn) {
       (YGSize{23, 12}));
 }
 
-TEST(YGNode, measure_with_context_measure_fn) {
-  auto n = YGNode{};
+TEST(Node, measure_with_context_measure_fn) {
+  auto n = Node{};
   n.setMeasureFunc(
-      [](YGNode*, float, YGMeasureMode, float, YGMeasureMode, void* ctx) {
+      [](YGNodeRef, float, YGMeasureMode, float, YGMeasureMode, void* ctx) {
         return *(YGSize*) ctx;
       });
 
@@ -54,14 +54,14 @@ TEST(YGNode, measure_with_context_measure_fn) {
       result);
 }
 
-TEST(YGNode, switching_measure_fn_types) {
-  auto n = YGNode{};
+TEST(Node, switching_measure_fn_types) {
+  auto n = Node{};
   n.setMeasureFunc(
-      [](YGNode*, float, YGMeasureMode, float, YGMeasureMode, void*) {
+      [](YGNodeRef, float, YGMeasureMode, float, YGMeasureMode, void*) {
         return YGSize{};
       });
   n.setMeasureFunc(
-      [](YGNode*, float w, YGMeasureMode wm, float h, YGMeasureMode hm) {
+      [](YGNodeRef, float w, YGMeasureMode wm, float h, YGMeasureMode hm) {
         return YGSize{w * static_cast<int>(wm), h / static_cast<int>(hm)};
       });
 
@@ -70,9 +70,9 @@ TEST(YGNode, switching_measure_fn_types) {
       (YGSize{23, 12}));
 }
 
-TEST(YGNode, hasMeasureFunc_after_unset) {
-  auto n = YGNode{};
-  n.setMeasureFunc([](YGNode*, float, YGMeasureMode, float, YGMeasureMode) {
+TEST(Node, hasMeasureFunc_after_unset) {
+  auto n = Node{};
+  n.setMeasureFunc([](YGNodeRef, float, YGMeasureMode, float, YGMeasureMode) {
     return YGSize{};
   });
 
@@ -80,10 +80,10 @@ TEST(YGNode, hasMeasureFunc_after_unset) {
   ASSERT_FALSE(n.hasMeasureFunc());
 }
 
-TEST(YGNode, hasMeasureFunc_after_unset_context) {
-  auto n = YGNode{};
+TEST(Node, hasMeasureFunc_after_unset_context) {
+  auto n = Node{};
   n.setMeasureFunc(
-      [](YGNode*, float, YGMeasureMode, float, YGMeasureMode, void*) {
+      [](YGNodeRef, float, YGMeasureMode, float, YGMeasureMode, void*) {
         return YGSize{};
       });
 
@@ -91,27 +91,27 @@ TEST(YGNode, hasMeasureFunc_after_unset_context) {
   ASSERT_FALSE(n.hasMeasureFunc());
 }
 
-TEST(YGNode, hasBaselineFunc_initial) {
-  auto n = YGNode{};
+TEST(Node, hasBaselineFunc_initial) {
+  auto n = Node{};
   ASSERT_FALSE(n.hasBaselineFunc());
 }
 
-TEST(YGNode, hasBaselineFunc_with_baseline_fn) {
-  auto n = YGNode{};
-  n.setBaselineFunc([](YGNode*, float, float) { return 0.0f; });
+TEST(Node, hasBaselineFunc_with_baseline_fn) {
+  auto n = Node{};
+  n.setBaselineFunc([](YGNodeRef, float, float) { return 0.0f; });
   ASSERT_TRUE(n.hasBaselineFunc());
 }
 
-TEST(YGNode, baseline_with_baseline_fn) {
-  auto n = YGNode{};
-  n.setBaselineFunc([](YGNode*, float w, float h) { return w + h; });
+TEST(Node, baseline_with_baseline_fn) {
+  auto n = Node{};
+  n.setBaselineFunc([](YGNodeRef, float w, float h) { return w + h; });
 
   ASSERT_EQ(n.baseline(1.25f, 2.5f, nullptr), 3.75f);
 }
 
-TEST(YGNode, baseline_with_context_baseline_fn) {
-  auto n = YGNode{};
-  n.setBaselineFunc([](YGNode*, float w, float h, void* ctx) {
+TEST(Node, baseline_with_context_baseline_fn) {
+  auto n = Node{};
+  n.setBaselineFunc([](YGNodeRef, float w, float h, void* ctx) {
     return w + h + *(float*) ctx;
   });
 
@@ -119,29 +119,25 @@ TEST(YGNode, baseline_with_context_baseline_fn) {
   ASSERT_EQ(n.baseline(1.25f, 2.5f, &ctx), -6.25f);
 }
 
-TEST(YGNode, hasBaselineFunc_after_unset) {
-  auto n = YGNode{};
-  n.setBaselineFunc([](YGNode*, float, float) { return 0.0f; });
+TEST(Node, hasBaselineFunc_after_unset) {
+  auto n = Node{};
+  n.setBaselineFunc([](YGNodeRef, float, float) { return 0.0f; });
 
   n.setBaselineFunc(nullptr);
   ASSERT_FALSE(n.hasBaselineFunc());
 }
 
-TEST(YGNode, hasBaselineFunc_after_unset_context) {
-  auto n = YGNode{};
-  n.setBaselineFunc([](YGNode*, float, float, void*) { return 0.0f; });
+TEST(Node, hasBaselineFunc_after_unset_context) {
+  auto n = Node{};
+  n.setBaselineFunc([](YGNodeRef, float, float, void*) { return 0.0f; });
 
   n.setMeasureFunc(nullptr);
   ASSERT_FALSE(n.hasMeasureFunc());
 }
 
-TEST(YGNode, switching_baseline_fn_types) {
-  auto n = YGNode{};
-  n.setBaselineFunc([](YGNode*, float, float, void*) { return 0.0f; });
-  n.setBaselineFunc([](YGNode*, float, float) { return 1.0f; });
+TEST(Node, switching_baseline_fn_types) {
+  auto n = Node{};
+  n.setBaselineFunc([](YGNodeRef, float, float, void*) { return 0.0f; });
+  n.setBaselineFunc([](YGNodeRef, float, float) { return 1.0f; });
   ASSERT_EQ(n.baseline(1, 2, nullptr), 1.0f);
-}
-
-void PrintTo(const YGSize& size, std::ostream* os) {
-  *os << "YGSize{" << size.width << ", " << size.height << "}";
 }

--- a/tests/YGPersistenceTest.cpp
+++ b/tests/YGPersistenceTest.cpp
@@ -7,10 +7,11 @@
 
 #include <gtest/gtest.h>
 #include <yoga/Yoga.h>
-#include <yoga/YGNode.h>
+#include <yoga/node/Node.h>
 
 #include "util/TestUtil.h"
 
+using namespace facebook;
 using facebook::yoga::test::TestUtil;
 
 TEST(YogaTest, cloning_shared_root) {
@@ -273,9 +274,10 @@ TEST(YogaTest, mixed_shared_and_owned_children) {
   YGNodeInsertChild(root1, root1_child0, 0);
   YGNodeInsertChild(root1, root1_child2, 1);
 
-  auto children = root1->getChildren();
-  children.insert(children.begin() + 1, root0_child0);
-  root1->setChildren(children);
+  auto children = static_cast<yoga::Node*>(root1)->getChildren();
+  children.insert(children.begin() + 1, static_cast<yoga::Node*>(root0_child0));
+  static_cast<yoga::Node*>(root1)->setChildren(children);
+
   auto secondChild = YGNodeGetChild(root1, 1);
   ASSERT_EQ(secondChild, YGNodeGetChild(root0, 0));
   ASSERT_EQ(YGNodeGetChild(secondChild, 0), YGNodeGetChild(root0_child0, 0));

--- a/tests/YGRoundingMeasureFuncTest.cpp
+++ b/tests/YGRoundingMeasureFuncTest.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <yoga/YGNode.h>
 #include <yoga/Yoga.h>
 
 static YGSize _measureFloor(
@@ -50,7 +49,7 @@ TEST(YogaTest, rounding_feature_with_custom_measure_func_floor) {
   const YGNodeRef root = YGNodeNewWithConfig(config);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  root_child0->setMeasureFunc(_measureFloor);
+  YGNodeSetMeasureFunc(root_child0, _measureFloor);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGConfigSetPointScaleFactor(config, 0.0f);
@@ -98,7 +97,7 @@ TEST(YogaTest, rounding_feature_with_custom_measure_func_ceil) {
   const YGNodeRef root = YGNodeNewWithConfig(config);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  root_child0->setMeasureFunc(_measureCeil);
+  YGNodeSetMeasureFunc(root_child0, _measureCeil);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGConfigSetPointScaleFactor(config, 1.0f);
@@ -121,7 +120,7 @@ TEST(
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetPosition(root_child0, YGEdgeLeft, 73.625);
-  root_child0->setMeasureFunc(_measureFractial);
+  YGNodeSetMeasureFunc(root_child0, _measureFractial);
   YGNodeInsertChild(root, root_child0, 0);
 
   YGConfigSetPointScaleFactor(config, 2.0f);

--- a/tests/YGStyleAccessorsTest.cpp
+++ b/tests/YGStyleAccessorsTest.cpp
@@ -8,9 +8,8 @@
 #include <cstdint>
 #include <type_traits>
 #include <gtest/gtest.h>
-#include <yoga/YGEnums.h>
-#include <yoga/YGStyle.h>
-#include <yoga/YGValue.h>
+#include <yoga/Yoga.h>
+#include <yoga/style/Style.h>
 
 #define ACCESSOR_TESTS_1(NAME, X) \
   style.NAME() = X;               \
@@ -31,14 +30,14 @@
 #define ACCESSOR_TESTS_N(a, b, c, d, e, COUNT, ...) ACCESSOR_TESTS_##COUNT
 #define ACCESSOR_TESTS(...) ACCESSOR_TESTS_N(__VA_ARGS__, 5, 4, 3, 2, 1)
 
-#define INDEX_ACCESSOR_TESTS_1(NAME, IDX, X)                           \
-  {                                                                    \
-    auto style = YGStyle{};                                            \
-    style.NAME()[IDX] = X;                                             \
-    ASSERT_EQ(style.NAME()[IDX], X);                                   \
-    auto asArray = decltype(std::declval<const YGStyle&>().NAME()){X}; \
-    style.NAME() = asArray;                                            \
-    ASSERT_EQ(static_cast<decltype(asArray)>(style.NAME()), asArray);  \
+#define INDEX_ACCESSOR_TESTS_1(NAME, IDX, X)                          \
+  {                                                                   \
+    auto style = Style{};                                             \
+    style.NAME()[IDX] = X;                                            \
+    ASSERT_EQ(style.NAME()[IDX], X);                                  \
+    auto asArray = decltype(std::declval<const Style&>().NAME()){X};  \
+    style.NAME() = asArray;                                           \
+    ASSERT_EQ(static_cast<decltype(asArray)>(style.NAME()), asArray); \
   }
 
 #define INDEX_ACCESSOR_TESTS_2(NAME, IDX, X, Y) \
@@ -64,21 +63,19 @@
 
 // test macro for up to 5 values. If more are needed, extend the macros above.
 #define ACCESSOR_TEST(NAME, DEFAULT_VAL, ...)      \
-  TEST(YGStyle, style_##NAME##_access) {           \
-    auto style = YGStyle{};                        \
+  TEST(Style, style_##NAME##_access) {             \
+    auto style = Style{};                          \
     ASSERT_EQ(style.NAME(), DEFAULT_VAL);          \
     ACCESSOR_TESTS(__VA_ARGS__)(NAME, __VA_ARGS__) \
   }
 
 #define INDEX_ACCESSOR_TEST(NAME, DEFAULT_VAL, IDX, ...)      \
-  TEST(YGStyle, style_##NAME##_access) {                      \
-    ASSERT_EQ(YGStyle{}.NAME()[IDX], DEFAULT_VAL);            \
+  TEST(Style, style_##NAME##_access) {                        \
+    ASSERT_EQ(Style{}.NAME()[IDX], DEFAULT_VAL);              \
     INDEX_ACCESSOR_TESTS(__VA_ARGS__)(NAME, IDX, __VA_ARGS__) \
   }
 
 namespace facebook::yoga {
-
-using CompactValue = detail::CompactValue;
 
 // TODO: MSVC doesn't like the macros
 #ifndef _MSC_VER

--- a/tests/YGStyleTest.cpp
+++ b/tests/YGStyleTest.cpp
@@ -6,16 +6,15 @@
  */
 
 #include <gtest/gtest.h>
-#include <yoga/YGNode.h>
-#include <iostream>
+#include <yoga/Yoga.h>
 
 TEST(YogaTest, copy_style_same) {
   const YGNodeRef node0 = YGNodeNew();
   const YGNodeRef node1 = YGNodeNew();
-  ASSERT_FALSE(node0->isDirty());
+  ASSERT_FALSE(YGNodeIsDirty(node0));
 
   YGNodeCopyStyle(node0, node1);
-  ASSERT_FALSE(node0->isDirty());
+  ASSERT_FALSE(YGNodeIsDirty(node0));
 
   YGNodeFree(node0);
   YGNodeFree(node1);
@@ -23,7 +22,7 @@ TEST(YogaTest, copy_style_same) {
 
 TEST(YogaTest, copy_style_modified) {
   const YGNodeRef node0 = YGNodeNew();
-  ASSERT_FALSE(node0->isDirty());
+  ASSERT_FALSE(YGNodeIsDirty(node0));
   ASSERT_EQ(YGFlexDirectionColumn, YGNodeStyleGetFlexDirection(node0));
   ASSERT_FALSE(YGNodeStyleGetMaxHeight(node0).unit != YGUnitUndefined);
 
@@ -32,7 +31,7 @@ TEST(YogaTest, copy_style_modified) {
   YGNodeStyleSetMaxHeight(node1, 10);
 
   YGNodeCopyStyle(node0, node1);
-  ASSERT_TRUE(node0->isDirty());
+  ASSERT_TRUE(YGNodeIsDirty(node0));
   ASSERT_EQ(YGFlexDirectionRow, YGNodeStyleGetFlexDirection(node0));
   ASSERT_FLOAT_EQ(10, YGNodeStyleGetMaxHeight(node0).value);
 
@@ -45,14 +44,14 @@ TEST(YogaTest, copy_style_modified_same) {
   YGNodeStyleSetFlexDirection(node0, YGFlexDirectionRow);
   YGNodeStyleSetMaxHeight(node0, 10);
   YGNodeCalculateLayout(node0, YGUndefined, YGUndefined, YGDirectionLTR);
-  ASSERT_FALSE(node0->isDirty());
+  ASSERT_FALSE(YGNodeIsDirty(node0));
 
   const YGNodeRef node1 = YGNodeNew();
   YGNodeStyleSetFlexDirection(node1, YGFlexDirectionRow);
   YGNodeStyleSetMaxHeight(node1, 10);
 
   YGNodeCopyStyle(node0, node1);
-  ASSERT_FALSE(node0->isDirty());
+  ASSERT_FALSE(YGNodeIsDirty(node0));
 
   YGNodeFree(node0);
   YGNodeFree(node1);

--- a/tests/generated/YGConfigTest.cpp
+++ b/tests/generated/YGConfigTest.cpp
@@ -10,7 +10,7 @@
 #include <gtest/gtest.h>
 #include <yoga/Yoga.h>
 #include <yoga/config/Config.h>
-#include <yoga/YGNode.h>
+#include <yoga/node/Node.h>
 
 #include <functional>
 #include <memory>
@@ -22,7 +22,7 @@ struct ConfigCloningTest : public ::testing::Test {
   void SetUp() override;
   void TearDown() override;
 
-  static YGNode clonedNode;
+  static yoga::Node clonedNode;
   static YGNodeRef cloneNode(YGNodeRef, YGNodeRef, int) { return &clonedNode; }
   static YGNodeRef doNotClone(YGNodeRef, YGNodeRef, int) { return nullptr; }
 };
@@ -30,7 +30,7 @@ struct ConfigCloningTest : public ::testing::Test {
 TEST_F(ConfigCloningTest, uses_values_provided_by_cloning_callback) {
   config->setCloneNodeCallback(cloneNode);
 
-  YGNode node{}, owner{};
+  yoga::Node node{}, owner{};
   auto clone = config->cloneNode(&node, &owner, 0, nullptr);
 
   ASSERT_EQ(clone, &clonedNode);
@@ -41,7 +41,7 @@ TEST_F(
     falls_back_to_regular_cloning_if_callback_returns_null) {
   config->setCloneNodeCallback(doNotClone);
 
-  YGNode node{}, owner{};
+  yoga::Node node{}, owner{};
   auto clone = config->cloneNode(&node, &owner, 0, nullptr);
 
   ASSERT_NE(clone, nullptr);
@@ -53,7 +53,7 @@ TEST_F(ConfigCloningTest, can_clone_with_context) {
     return (YGNodeRef) context;
   });
 
-  YGNode node{}, owner{}, clone{};
+  yoga::Node node{}, owner{}, clone{};
   ASSERT_EQ(config->cloneNode(&node, &owner, 0, &clone), &clone);
 }
 
@@ -65,4 +65,4 @@ void ConfigCloningTest::TearDown() {
   config.reset();
 }
 
-YGNode ConfigCloningTest::clonedNode = {};
+yoga::Node ConfigCloningTest::clonedNode = {};

--- a/tests/generated/YGConfigTest.cpp
+++ b/tests/generated/YGConfigTest.cpp
@@ -9,14 +9,16 @@
 
 #include <gtest/gtest.h>
 #include <yoga/Yoga.h>
-#include <yoga/YGConfig.h>
+#include <yoga/config/Config.h>
 #include <yoga/YGNode.h>
 
 #include <functional>
 #include <memory>
 
+using namespace facebook;
+
 struct ConfigCloningTest : public ::testing::Test {
-  std::unique_ptr<YGConfig, std::function<void(YGConfig*)>> config;
+  std::unique_ptr<yoga::Config, std::function<void(yoga::Config*)>> config;
   void SetUp() override;
   void TearDown() override;
 
@@ -56,7 +58,7 @@ TEST_F(ConfigCloningTest, can_clone_with_context) {
 }
 
 void ConfigCloningTest::SetUp() {
-  config = {YGConfigNew(), YGConfigFree};
+  config = {static_cast<yoga::Config*>(YGConfigNew()), YGConfigFree};
 }
 
 void ConfigCloningTest::TearDown() {

--- a/tests/util/TestUtil.cpp
+++ b/tests/util/TestUtil.cpp
@@ -7,7 +7,7 @@
 
 #include "TestUtil.h"
 
-#include <yoga/YGNode.h>
+#include <yoga/node/Node.h>
 #include <yoga/event/event.h>
 
 namespace facebook::yoga::test {
@@ -17,7 +17,7 @@ int nodeInstanceCount = 0;
 namespace {
 
 void yogaEventSubscriber(
-    const YGNode& /*node*/,
+    YGNodeConstRef /*node*/,
     Event::Type eventType,
     const Event::Data& /*eventData*/) {
 

--- a/yoga/Utils.h
+++ b/yoga/Utils.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include "YGNode.h"
-#include "Yoga-internal.h"
-#include "CompactValue.h"
+#include <yoga/Yoga-internal.h>
+#include <yoga/style/CompactValue.h>
 
 // This struct is an helper model to hold the data for step 4 of flexbox algo,
 // which is collecting the flex items in a line.
@@ -56,8 +56,8 @@ struct YGCollectFlexItemsRowValues {
 
 bool YGValueEqual(const YGValue& a, const YGValue& b);
 inline bool YGValueEqual(
-    facebook::yoga::detail::CompactValue a,
-    facebook::yoga::detail::CompactValue b) {
+    facebook::yoga::CompactValue a,
+    facebook::yoga::CompactValue b) {
   return YGValueEqual((YGValue) a, (YGValue) b);
 }
 
@@ -115,7 +115,7 @@ inline YGFloatOptional YGResolveValue(
 }
 
 inline YGFloatOptional YGResolveValue(
-    facebook::yoga::detail::CompactValue value,
+    facebook::yoga::CompactValue value,
     float ownerSize) {
   return YGResolveValue((YGValue) value, ownerSize);
 }
@@ -140,7 +140,7 @@ inline YGFlexDirection YGResolveFlexDirection(
 }
 
 inline YGFloatOptional YGResolveValueMargin(
-    facebook::yoga::detail::CompactValue value,
+    facebook::yoga::CompactValue value,
     const float ownerSize) {
   return value.isAuto() ? YGFloatOptional{0} : YGResolveValue(value, ownerSize);
 }

--- a/yoga/Utils.h
+++ b/yoga/Utils.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "YGNode.h"
+#include <yoga/node/Node.h>
 #include <yoga/Yoga-internal.h>
 #include <yoga/style/CompactValue.h>
 
@@ -43,7 +43,7 @@ struct YGCollectFlexItemsRowValues {
   float totalFlexGrowFactors;
   float totalFlexShrinkScaledFactors;
   uint32_t endOfLineIndex;
-  std::vector<YGNodeRef> relativeChildren;
+  std::vector<facebook::yoga::Node*> relativeChildren;
   float remainingFreeSpace;
   // The size of the mainDim for the row after considering size, padding, margin
   // and border of flex items. This is used to calculate maxLineDim after going

--- a/yoga/YGConfig.h
+++ b/yoga/YGConfig.h
@@ -9,8 +9,8 @@
 
 #include <yoga/Yoga.h>
 
-#include "BitUtils.h"
-#include "Yoga-internal.h"
+#include <yoga/BitUtils.h>
+#include <yoga/Yoga-internal.h>
 
 namespace facebook::yoga {
 

--- a/yoga/YGFloatOptional.h
+++ b/yoga/YGFloatOptional.h
@@ -9,7 +9,7 @@
 
 #include <cmath>
 #include <limits>
-#include "Yoga-internal.h"
+#include <yoga/Yoga-internal.h>
 
 struct YGFloatOptional {
 private:

--- a/yoga/YGLayout.h
+++ b/yoga/YGLayout.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include "BitUtils.h"
-#include "YGFloatOptional.h"
-#include "Yoga-internal.h"
+#include <yoga/BitUtils.h>
+#include <yoga/YGFloatOptional.h>
+#include <yoga/Yoga-internal.h>
 
 struct YGLayout {
   std::array<float, 4> position = {};

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -14,7 +14,7 @@ using namespace facebook;
 using namespace facebook::yoga;
 using facebook::yoga::CompactValue;
 
-YGNode::YGNode(const YGConfigRef config) : config_{config} {
+YGNode::YGNode(yoga::Config* config) : config_{config} {
   YGAssert(
       config != nullptr, "Attempting to construct YGNode with null config");
 
@@ -264,7 +264,7 @@ void YGNode::insertChild(YGNodeRef child, uint32_t index) {
   children_.insert(children_.begin() + index, child);
 }
 
-void YGNode::setConfig(YGConfigRef config) {
+void YGNode::setConfig(yoga::Config* config) {
   YGAssert(config != nullptr, "Attempting to set a null config on a YGNode");
   YGAssertWithConfig(
       config,

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -11,7 +11,8 @@
 #include "Utils.h"
 
 using namespace facebook;
-using facebook::yoga::detail::CompactValue;
+using namespace facebook::yoga;
+using facebook::yoga::CompactValue;
 
 YGNode::YGNode(const YGConfigRef config) : config_{config} {
   YGAssert(
@@ -53,7 +54,7 @@ void YGNode::print(void* printContext) {
 }
 
 CompactValue YGNode::computeEdgeValueForRow(
-    const YGStyle::Edges& edges,
+    const Style::Edges& edges,
     YGEdge rowEdge,
     YGEdge edge,
     CompactValue defaultValue) {
@@ -71,7 +72,7 @@ CompactValue YGNode::computeEdgeValueForRow(
 }
 
 CompactValue YGNode::computeEdgeValueForColumn(
-    const YGStyle::Edges& edges,
+    const Style::Edges& edges,
     YGEdge edge,
     CompactValue defaultValue) {
   if (!edges[edge].isUndefined()) {
@@ -86,7 +87,7 @@ CompactValue YGNode::computeEdgeValueForColumn(
 }
 
 CompactValue YGNode::computeRowGap(
-    const YGStyle::Gutters& gutters,
+    const Style::Gutters& gutters,
     CompactValue defaultValue) {
   if (!gutters[YGGutterRow].isUndefined()) {
     return gutters[YGGutterRow];
@@ -98,7 +99,7 @@ CompactValue YGNode::computeRowGap(
 }
 
 CompactValue YGNode::computeColumnGap(
-    const YGStyle::Gutters& gutters,
+    const Style::Gutters& gutters,
     CompactValue defaultValue) {
   if (!gutters[YGGutterColumn].isUndefined()) {
     return gutters[YGGutterColumn];
@@ -431,7 +432,7 @@ YGValue YGNode::resolveFlexBasisPtr() const {
 
 void YGNode::resolveDimension() {
   using namespace yoga;
-  const YGStyle& style = getStyle();
+  const Style& style = getStyle();
   for (auto dim : {YGDimensionWidth, YGDimensionHeight}) {
     if (!style.maxDimensions()[dim].isUndefined() &&
         YGValueEqual(style.maxDimensions()[dim], style.minDimensions()[dim])) {

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -9,11 +9,12 @@
 
 #include <cstdint>
 #include <stdio.h>
-#include "CompactValue.h"
 #include "YGConfig.h"
 #include "YGLayout.h"
-#include "YGStyle.h"
-#include "Yoga-internal.h"
+#include <yoga/Yoga-internal.h>
+
+#include <yoga/style/CompactValue.h>
+#include <yoga/style/Style.h>
 
 YGConfigRef YGConfigGetDefault();
 
@@ -52,7 +53,7 @@ private:
     PrintWithContextFn withContext;
   } print_ = {nullptr};
   YGDirtiedFunc dirtied_ = nullptr;
-  YGStyle style_ = {};
+  facebook::yoga::Style style_ = {};
   YGLayout layout_ = {};
   uint32_t lineIndex_ = 0;
   YGNodeRef owner_ = nullptr;
@@ -80,7 +81,7 @@ private:
   // DO NOT CHANGE THE VISIBILITY OF THIS METHOD!
   YGNode& operator=(YGNode&&) = default;
 
-  using CompactValue = facebook::yoga::detail::CompactValue;
+  using CompactValue = facebook::yoga::CompactValue;
 
 public:
   YGNode() : YGNode{YGConfigGetDefault()} { flags_.hasNewLayout = true; }
@@ -123,9 +124,9 @@ public:
   YGDirtiedFunc getDirtied() const { return dirtied_; }
 
   // For Performance reasons passing as reference.
-  YGStyle& getStyle() { return style_; }
+  facebook::yoga::Style& getStyle() { return style_; }
 
-  const YGStyle& getStyle() const { return style_; }
+  const facebook::yoga::Style& getStyle() const { return style_; }
 
   // For Performance reasons passing as reference.
   YGLayout& getLayout() { return layout_; }
@@ -178,22 +179,22 @@ public:
   }
 
   static CompactValue computeEdgeValueForColumn(
-      const YGStyle::Edges& edges,
+      const facebook::yoga::Style::Edges& edges,
       YGEdge edge,
       CompactValue defaultValue);
 
   static CompactValue computeEdgeValueForRow(
-      const YGStyle::Edges& edges,
+      const facebook::yoga::Style::Edges& edges,
       YGEdge rowEdge,
       YGEdge edge,
       CompactValue defaultValue);
 
   static CompactValue computeRowGap(
-      const YGStyle::Gutters& gutters,
+      const facebook::yoga::Style::Gutters& gutters,
       CompactValue defaultValue);
 
   static CompactValue computeColumnGap(
-      const YGStyle::Gutters& gutters,
+      const facebook::yoga::Style::Gutters& gutters,
       CompactValue defaultValue);
 
   // Methods related to positions, margin, padding and border
@@ -273,7 +274,7 @@ public:
 
   void setDirtiedFunc(YGDirtiedFunc dirtiedFunc) { dirtied_ = dirtiedFunc; }
 
-  void setStyle(const YGStyle& style) { style_ = style; }
+  void setStyle(const facebook::yoga::Style& style) { style_ = style; }
 
   void setLayout(const YGLayout& layout) { layout_ = layout; }
 

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -9,14 +9,12 @@
 
 #include <cstdint>
 #include <stdio.h>
-#include "YGConfig.h"
+#include <yoga/config/Config.h>
 #include "YGLayout.h"
 #include <yoga/Yoga-internal.h>
 
 #include <yoga/style/CompactValue.h>
 #include <yoga/style/Style.h>
-
-YGConfigRef YGConfigGetDefault();
 
 #pragma pack(push)
 #pragma pack(1)
@@ -58,7 +56,7 @@ private:
   uint32_t lineIndex_ = 0;
   YGNodeRef owner_ = nullptr;
   YGVector children_ = {};
-  YGConfigRef config_;
+  facebook::yoga::Config* config_;
   std::array<YGValue, 2> resolvedDimensions_ = {
       {YGValueUndefined, YGValueUndefined}};
 
@@ -84,8 +82,11 @@ private:
   using CompactValue = facebook::yoga::CompactValue;
 
 public:
-  YGNode() : YGNode{YGConfigGetDefault()} { flags_.hasNewLayout = true; }
-  explicit YGNode(const YGConfigRef config);
+  YGNode()
+      : YGNode{static_cast<facebook::yoga::Config*>(YGConfigGetDefault())} {
+    flags_.hasNewLayout = true;
+  }
+  explicit YGNode(facebook::yoga::Config* config);
   ~YGNode() = default; // cleanup of owner/children relationships in YGNodeFree
 
   YGNode(YGNode&&);
@@ -166,7 +167,7 @@ public:
 
   YGNodeRef getChild(uint32_t index) const { return children_.at(index); }
 
-  YGConfigRef getConfig() const { return config_; }
+  facebook::yoga::Config* getConfig() const { return config_; }
 
   bool isDirty() const { return flags_.isDirty; }
 
@@ -290,7 +291,7 @@ public:
 
   // TODO: rvalue override for setChildren
 
-  void setConfig(YGConfigRef config);
+  void setConfig(facebook::yoga::Config* config);
 
   void setDirty(bool isDirty);
   void setLayoutLastOwnerDirection(YGDirection direction);

--- a/yoga/YGNodePrint.cpp
+++ b/yoga/YGNodePrint.cpp
@@ -13,7 +13,7 @@
 
 #include "YGNodePrint.h"
 #include "YGNode.h"
-#include "Yoga-internal.h"
+#include <yoga/Yoga-internal.h>
 #include "Utils.h"
 
 namespace facebook::yoga {
@@ -25,7 +25,7 @@ static void indent(string& base, uint32_t level) {
   }
 }
 
-static bool areFourValuesEqual(const YGStyle::Edges& four) {
+static bool areFourValuesEqual(const Style::Edges& four) {
   return YGValueEqual(four[0], four[1]) && YGValueEqual(four[0], four[2]) &&
       YGValueEqual(four[0], four[3]);
 }
@@ -90,10 +90,10 @@ static void appendNumberIfNotZero(
 static void appendEdges(
     string& base,
     const string& key,
-    const YGStyle::Edges& edges) {
+    const Style::Edges& edges) {
   if (areFourValuesEqual(edges)) {
     auto edgeValue = YGNode::computeEdgeValueForColumn(
-        edges, YGEdgeLeft, detail::CompactValue::ofZero());
+        edges, YGEdgeLeft, CompactValue::ofZero());
     appendNumberIfNotZero(base, key, edgeValue);
   } else {
     for (int edge = YGEdgeLeft; edge != YGEdgeAll; ++edge) {
@@ -106,14 +106,14 @@ static void appendEdges(
 static void appendEdgeIfNotUndefined(
     string& base,
     const string& str,
-    const YGStyle::Edges& edges,
+    const Style::Edges& edges,
     const YGEdge edge) {
   // TODO: this doesn't take RTL / YGEdgeStart / YGEdgeEnd into account
   auto value = (edge == YGEdgeLeft || edge == YGEdgeRight)
       ? YGNode::computeEdgeValueForRow(
-            edges, edge, edge, detail::CompactValue::ofUndefined())
+            edges, edge, edge, CompactValue::ofUndefined())
       : YGNode::computeEdgeValueForColumn(
-            edges, edge, detail::CompactValue::ofUndefined());
+            edges, edge, CompactValue::ofUndefined());
   appendNumberIfNotUndefined(base, str, value);
 }
 
@@ -188,17 +188,15 @@ void YGNodeToString(
     appendEdges(str, "padding", style.padding());
     appendEdges(str, "border", style.border());
 
-    if (YGNode::computeColumnGap(
-            style.gap(), detail::CompactValue::ofUndefined()) !=
+    if (YGNode::computeColumnGap(style.gap(), CompactValue::ofUndefined()) !=
         YGNode::computeColumnGap(
-            YGNode().getStyle().gap(), detail::CompactValue::ofUndefined())) {
+            YGNode().getStyle().gap(), CompactValue::ofUndefined())) {
       appendNumberIfNotUndefined(
           str, "column-gap", style.gap()[YGGutterColumn]);
     }
-    if (YGNode::computeRowGap(
-            style.gap(), detail::CompactValue::ofUndefined()) !=
+    if (YGNode::computeRowGap(style.gap(), CompactValue::ofUndefined()) !=
         YGNode::computeRowGap(
-            YGNode().getStyle().gap(), detail::CompactValue::ofUndefined())) {
+            YGNode().getStyle().gap(), CompactValue::ofUndefined())) {
       appendNumberIfNotUndefined(str, "row-gap", style.gap()[YGGutterRow]);
     }
 

--- a/yoga/YGNodePrint.cpp
+++ b/yoga/YGNodePrint.cpp
@@ -12,9 +12,8 @@
 #include <yoga/YGEnums.h>
 
 #include "YGNodePrint.h"
-#include "YGNode.h"
 #include <yoga/Yoga-internal.h>
-#include "Utils.h"
+#include <yoga/Utils.h>
 
 namespace facebook::yoga {
 typedef std::string string;
@@ -92,7 +91,7 @@ static void appendEdges(
     const string& key,
     const Style::Edges& edges) {
   if (areFourValuesEqual(edges)) {
-    auto edgeValue = YGNode::computeEdgeValueForColumn(
+    auto edgeValue = yoga::Node::computeEdgeValueForColumn(
         edges, YGEdgeLeft, CompactValue::ofZero());
     appendNumberIfNotZero(base, key, edgeValue);
   } else {
@@ -110,16 +109,16 @@ static void appendEdgeIfNotUndefined(
     const YGEdge edge) {
   // TODO: this doesn't take RTL / YGEdgeStart / YGEdgeEnd into account
   auto value = (edge == YGEdgeLeft || edge == YGEdgeRight)
-      ? YGNode::computeEdgeValueForRow(
+      ? yoga::Node::computeEdgeValueForRow(
             edges, edge, edge, CompactValue::ofUndefined())
-      : YGNode::computeEdgeValueForColumn(
+      : yoga::Node::computeEdgeValueForColumn(
             edges, edge, CompactValue::ofUndefined());
   appendNumberIfNotUndefined(base, str, value);
 }
 
 void YGNodeToString(
     std::string& str,
-    YGNodeRef node,
+    yoga::Node* node,
     YGPrintOptions options,
     uint32_t level) {
   indent(str, level);
@@ -141,27 +140,27 @@ void YGNodeToString(
   if (options & YGPrintOptionsStyle) {
     appendFormattedString(str, "style=\"");
     const auto& style = node->getStyle();
-    if (style.flexDirection() != YGNode().getStyle().flexDirection()) {
+    if (style.flexDirection() != yoga::Node{}.getStyle().flexDirection()) {
       appendFormattedString(
           str,
           "flex-direction: %s; ",
           YGFlexDirectionToString(style.flexDirection()));
     }
-    if (style.justifyContent() != YGNode().getStyle().justifyContent()) {
+    if (style.justifyContent() != yoga::Node{}.getStyle().justifyContent()) {
       appendFormattedString(
           str,
           "justify-content: %s; ",
           YGJustifyToString(style.justifyContent()));
     }
-    if (style.alignItems() != YGNode().getStyle().alignItems()) {
+    if (style.alignItems() != yoga::Node{}.getStyle().alignItems()) {
       appendFormattedString(
           str, "align-items: %s; ", YGAlignToString(style.alignItems()));
     }
-    if (style.alignContent() != YGNode().getStyle().alignContent()) {
+    if (style.alignContent() != yoga::Node{}.getStyle().alignContent()) {
       appendFormattedString(
           str, "align-content: %s; ", YGAlignToString(style.alignContent()));
     }
-    if (style.alignSelf() != YGNode().getStyle().alignSelf()) {
+    if (style.alignSelf() != yoga::Node{}.getStyle().alignSelf()) {
       appendFormattedString(
           str, "align-self: %s; ", YGAlignToString(style.alignSelf()));
     }
@@ -170,17 +169,17 @@ void YGNodeToString(
     appendNumberIfNotAuto(str, "flex-basis", style.flexBasis());
     appendFloatOptionalIfDefined(str, "flex", style.flex());
 
-    if (style.flexWrap() != YGNode().getStyle().flexWrap()) {
+    if (style.flexWrap() != yoga::Node{}.getStyle().flexWrap()) {
       appendFormattedString(
           str, "flex-wrap: %s; ", YGWrapToString(style.flexWrap()));
     }
 
-    if (style.overflow() != YGNode().getStyle().overflow()) {
+    if (style.overflow() != yoga::Node{}.getStyle().overflow()) {
       appendFormattedString(
           str, "overflow: %s; ", YGOverflowToString(style.overflow()));
     }
 
-    if (style.display() != YGNode().getStyle().display()) {
+    if (style.display() != yoga::Node{}.getStyle().display()) {
       appendFormattedString(
           str, "display: %s; ", YGDisplayToString(style.display()));
     }
@@ -188,15 +187,16 @@ void YGNodeToString(
     appendEdges(str, "padding", style.padding());
     appendEdges(str, "border", style.border());
 
-    if (YGNode::computeColumnGap(style.gap(), CompactValue::ofUndefined()) !=
-        YGNode::computeColumnGap(
-            YGNode().getStyle().gap(), CompactValue::ofUndefined())) {
+    if (yoga::Node::computeColumnGap(
+            style.gap(), CompactValue::ofUndefined()) !=
+        yoga::Node::computeColumnGap(
+            yoga::Node{}.getStyle().gap(), CompactValue::ofUndefined())) {
       appendNumberIfNotUndefined(
           str, "column-gap", style.gap()[YGGutterColumn]);
     }
-    if (YGNode::computeRowGap(style.gap(), CompactValue::ofUndefined()) !=
-        YGNode::computeRowGap(
-            YGNode().getStyle().gap(), CompactValue::ofUndefined())) {
+    if (yoga::Node::computeRowGap(style.gap(), CompactValue::ofUndefined()) !=
+        yoga::Node::computeRowGap(
+            yoga::Node{}.getStyle().gap(), CompactValue::ofUndefined())) {
       appendNumberIfNotUndefined(str, "row-gap", style.gap()[YGGutterRow]);
     }
 
@@ -211,7 +211,7 @@ void YGNodeToString(
     appendNumberIfNotAuto(
         str, "min-height", style.minDimensions()[YGDimensionHeight]);
 
-    if (style.positionType() != YGNode().getStyle().positionType()) {
+    if (style.positionType() != yoga::Node{}.getStyle().positionType()) {
       appendFormattedString(
           str, "position: %s; ", YGPositionTypeToString(style.positionType()));
     }
@@ -232,7 +232,7 @@ void YGNodeToString(
   if (options & YGPrintOptionsChildren && childCount > 0) {
     for (uint32_t i = 0; i < childCount; i++) {
       appendFormattedString(str, "\n");
-      YGNodeToString(str, YGNodeGetChild(node, i), options, level + 1);
+      YGNodeToString(str, node->getChild(i), options, level + 1);
     }
     appendFormattedString(str, "\n");
     indent(str, level);

--- a/yoga/YGNodePrint.h
+++ b/yoga/YGNodePrint.h
@@ -12,12 +12,13 @@
 #include <string>
 
 #include <yoga/Yoga.h>
+#include <yoga/node/Node.h>
 
 namespace facebook::yoga {
 
 void YGNodeToString(
     std::string& str,
-    YGNodeRef node,
+    yoga::Node* node,
     YGPrintOptions options,
     uint32_t level);
 

--- a/yoga/Yoga-internal.h
+++ b/yoga/Yoga-internal.h
@@ -16,8 +16,6 @@
 
 #include <yoga/style/CompactValue.h>
 
-using YGVector = std::vector<YGNodeRef>;
-
 YG_EXTERN_C_BEGIN
 
 void YGNodeCalculateLayoutWithContext(

--- a/yoga/Yoga-internal.h
+++ b/yoga/Yoga-internal.h
@@ -14,7 +14,7 @@
 
 #include <yoga/Yoga.h>
 
-#include "CompactValue.h"
+#include <yoga/style/CompactValue.h>
 
 using YGVector = std::vector<YGNodeRef>;
 

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -17,7 +17,7 @@
 #include "Utils.h"
 #include "YGNode.h"
 #include "YGNodePrint.h"
-#include "Yoga-internal.h"
+#include <yoga/Yoga-internal.h>
 #include "event/event.h"
 
 using namespace facebook::yoga;
@@ -480,26 +480,25 @@ void updateStyle(
 }
 
 template <typename Ref, typename T>
-void updateStyle(YGNode* node, Ref (YGStyle::*prop)(), T value) {
+void updateStyle(YGNode* node, Ref (Style::*prop)(), T value) {
   updateStyle(
       node,
       value,
-      [prop](YGStyle& s, T x) { return (s.*prop)() != x; },
-      [prop](YGStyle& s, T x) { (s.*prop)() = x; });
+      [prop](Style& s, T x) { return (s.*prop)() != x; },
+      [prop](Style& s, T x) { (s.*prop)() = x; });
 }
 
 template <typename Ref, typename Idx>
 void updateIndexedStyleProp(
     YGNode* node,
-    Ref (YGStyle::*prop)(),
+    Ref (Style::*prop)(),
     Idx idx,
-    detail::CompactValue value) {
-  using detail::CompactValue;
+    CompactValue value) {
   updateStyle(
       node,
       value,
-      [idx, prop](YGStyle& s, CompactValue x) { return (s.*prop)()[idx] != x; },
-      [idx, prop](YGStyle& s, CompactValue x) { (s.*prop)()[idx] = x; });
+      [idx, prop](Style& s, CompactValue x) { return (s.*prop)()[idx] != x; },
+      [idx, prop](Style& s, CompactValue x) { (s.*prop)()[idx] = x; });
 }
 
 } // namespace
@@ -509,12 +508,12 @@ void updateIndexedStyleProp(
 // overload like clang and GCC. For the purposes of updateStyle(), we can help
 // MSVC by specifying that return type explicitly. In combination with
 // decltype, MSVC will prefer the non-const version.
-#define MSVC_HINT(PROP) decltype(YGStyle{}.PROP())
+#define MSVC_HINT(PROP) decltype(Style{}.PROP())
 
 YOGA_EXPORT void YGNodeStyleSetDirection(
     const YGNodeRef node,
     const YGDirection value) {
-  updateStyle<MSVC_HINT(direction)>(node, &YGStyle::direction, value);
+  updateStyle<MSVC_HINT(direction)>(node, &Style::direction, value);
 }
 YOGA_EXPORT YGDirection YGNodeStyleGetDirection(const YGNodeConstRef node) {
   return node->getStyle().direction();
@@ -524,7 +523,7 @@ YOGA_EXPORT void YGNodeStyleSetFlexDirection(
     const YGNodeRef node,
     const YGFlexDirection flexDirection) {
   updateStyle<MSVC_HINT(flexDirection)>(
-      node, &YGStyle::flexDirection, flexDirection);
+      node, &Style::flexDirection, flexDirection);
 }
 YOGA_EXPORT YGFlexDirection
 YGNodeStyleGetFlexDirection(const YGNodeConstRef node) {
@@ -535,7 +534,7 @@ YOGA_EXPORT void YGNodeStyleSetJustifyContent(
     const YGNodeRef node,
     const YGJustify justifyContent) {
   updateStyle<MSVC_HINT(justifyContent)>(
-      node, &YGStyle::justifyContent, justifyContent);
+      node, &Style::justifyContent, justifyContent);
 }
 YOGA_EXPORT YGJustify YGNodeStyleGetJustifyContent(const YGNodeConstRef node) {
   return node->getStyle().justifyContent();
@@ -545,7 +544,7 @@ YOGA_EXPORT void YGNodeStyleSetAlignContent(
     const YGNodeRef node,
     const YGAlign alignContent) {
   updateStyle<MSVC_HINT(alignContent)>(
-      node, &YGStyle::alignContent, alignContent);
+      node, &Style::alignContent, alignContent);
 }
 YOGA_EXPORT YGAlign YGNodeStyleGetAlignContent(const YGNodeConstRef node) {
   return node->getStyle().alignContent();
@@ -554,7 +553,7 @@ YOGA_EXPORT YGAlign YGNodeStyleGetAlignContent(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetAlignItems(
     const YGNodeRef node,
     const YGAlign alignItems) {
-  updateStyle<MSVC_HINT(alignItems)>(node, &YGStyle::alignItems, alignItems);
+  updateStyle<MSVC_HINT(alignItems)>(node, &Style::alignItems, alignItems);
 }
 YOGA_EXPORT YGAlign YGNodeStyleGetAlignItems(const YGNodeConstRef node) {
   return node->getStyle().alignItems();
@@ -563,7 +562,7 @@ YOGA_EXPORT YGAlign YGNodeStyleGetAlignItems(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetAlignSelf(
     const YGNodeRef node,
     const YGAlign alignSelf) {
-  updateStyle<MSVC_HINT(alignSelf)>(node, &YGStyle::alignSelf, alignSelf);
+  updateStyle<MSVC_HINT(alignSelf)>(node, &Style::alignSelf, alignSelf);
 }
 YOGA_EXPORT YGAlign YGNodeStyleGetAlignSelf(const YGNodeConstRef node) {
   return node->getStyle().alignSelf();
@@ -573,7 +572,7 @@ YOGA_EXPORT void YGNodeStyleSetPositionType(
     const YGNodeRef node,
     const YGPositionType positionType) {
   updateStyle<MSVC_HINT(positionType)>(
-      node, &YGStyle::positionType, positionType);
+      node, &Style::positionType, positionType);
 }
 YOGA_EXPORT YGPositionType
 YGNodeStyleGetPositionType(const YGNodeConstRef node) {
@@ -583,7 +582,7 @@ YGNodeStyleGetPositionType(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetFlexWrap(
     const YGNodeRef node,
     const YGWrap flexWrap) {
-  updateStyle<MSVC_HINT(flexWrap)>(node, &YGStyle::flexWrap, flexWrap);
+  updateStyle<MSVC_HINT(flexWrap)>(node, &Style::flexWrap, flexWrap);
 }
 YOGA_EXPORT YGWrap YGNodeStyleGetFlexWrap(const YGNodeConstRef node) {
   return node->getStyle().flexWrap();
@@ -592,7 +591,7 @@ YOGA_EXPORT YGWrap YGNodeStyleGetFlexWrap(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetOverflow(
     const YGNodeRef node,
     const YGOverflow overflow) {
-  updateStyle<MSVC_HINT(overflow)>(node, &YGStyle::overflow, overflow);
+  updateStyle<MSVC_HINT(overflow)>(node, &Style::overflow, overflow);
 }
 YOGA_EXPORT YGOverflow YGNodeStyleGetOverflow(const YGNodeConstRef node) {
   return node->getStyle().overflow();
@@ -601,7 +600,7 @@ YOGA_EXPORT YGOverflow YGNodeStyleGetOverflow(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetDisplay(
     const YGNodeRef node,
     const YGDisplay display) {
-  updateStyle<MSVC_HINT(display)>(node, &YGStyle::display, display);
+  updateStyle<MSVC_HINT(display)>(node, &Style::display, display);
 }
 YOGA_EXPORT YGDisplay YGNodeStyleGetDisplay(const YGNodeConstRef node) {
   return node->getStyle().display();
@@ -609,7 +608,7 @@ YOGA_EXPORT YGDisplay YGNodeStyleGetDisplay(const YGNodeConstRef node) {
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
 YOGA_EXPORT void YGNodeStyleSetFlex(const YGNodeRef node, const float flex) {
-  updateStyle<MSVC_HINT(flex)>(node, &YGStyle::flex, YGFloatOptional{flex});
+  updateStyle<MSVC_HINT(flex)>(node, &Style::flex, YGFloatOptional{flex});
 }
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
@@ -624,7 +623,7 @@ YOGA_EXPORT void YGNodeStyleSetFlexGrow(
     const YGNodeRef node,
     const float flexGrow) {
   updateStyle<MSVC_HINT(flexGrow)>(
-      node, &YGStyle::flexGrow, YGFloatOptional{flexGrow});
+      node, &Style::flexGrow, YGFloatOptional{flexGrow});
 }
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
@@ -632,7 +631,7 @@ YOGA_EXPORT void YGNodeStyleSetFlexShrink(
     const YGNodeRef node,
     const float flexShrink) {
   updateStyle<MSVC_HINT(flexShrink)>(
-      node, &YGStyle::flexShrink, YGFloatOptional{flexShrink});
+      node, &Style::flexShrink, YGFloatOptional{flexShrink});
 }
 
 YOGA_EXPORT YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
@@ -647,37 +646,37 @@ YOGA_EXPORT YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetFlexBasis(
     const YGNodeRef node,
     const float flexBasis) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(flexBasis);
-  updateStyle<MSVC_HINT(flexBasis)>(node, &YGStyle::flexBasis, value);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(flexBasis);
+  updateStyle<MSVC_HINT(flexBasis)>(node, &Style::flexBasis, value);
 }
 
 YOGA_EXPORT void YGNodeStyleSetFlexBasisPercent(
     const YGNodeRef node,
     const float flexBasisPercent) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(flexBasisPercent);
-  updateStyle<MSVC_HINT(flexBasis)>(node, &YGStyle::flexBasis, value);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(flexBasisPercent);
+  updateStyle<MSVC_HINT(flexBasis)>(node, &Style::flexBasis, value);
 }
 
 YOGA_EXPORT void YGNodeStyleSetFlexBasisAuto(const YGNodeRef node) {
   updateStyle<MSVC_HINT(flexBasis)>(
-      node, &YGStyle::flexBasis, detail::CompactValue::ofAuto());
+      node, &Style::flexBasis, CompactValue::ofAuto());
 }
 
 YOGA_EXPORT void YGNodeStyleSetPosition(
     YGNodeRef node,
     YGEdge edge,
     float points) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(points);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<MSVC_HINT(position)>(
-      node, &YGStyle::position, edge, value);
+      node, &Style::position, edge, value);
 }
 YOGA_EXPORT void YGNodeStyleSetPositionPercent(
     YGNodeRef node,
     YGEdge edge,
     float percent) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(percent);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<MSVC_HINT(position)>(
-      node, &YGStyle::position, edge, value);
+      node, &Style::position, edge, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge) {
   return node->getStyle().position()[edge];
@@ -687,21 +686,19 @@ YOGA_EXPORT void YGNodeStyleSetMargin(
     YGNodeRef node,
     YGEdge edge,
     float points) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(points);
-  updateIndexedStyleProp<MSVC_HINT(margin)>(
-      node, &YGStyle::margin, edge, value);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
+  updateIndexedStyleProp<MSVC_HINT(margin)>(node, &Style::margin, edge, value);
 }
 YOGA_EXPORT void YGNodeStyleSetMarginPercent(
     YGNodeRef node,
     YGEdge edge,
     float percent) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(percent);
-  updateIndexedStyleProp<MSVC_HINT(margin)>(
-      node, &YGStyle::margin, edge, value);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
+  updateIndexedStyleProp<MSVC_HINT(margin)>(node, &Style::margin, edge, value);
 }
 YOGA_EXPORT void YGNodeStyleSetMarginAuto(YGNodeRef node, YGEdge edge) {
   updateIndexedStyleProp<MSVC_HINT(margin)>(
-      node, &YGStyle::margin, edge, detail::CompactValue::ofAuto());
+      node, &Style::margin, edge, CompactValue::ofAuto());
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge) {
   return node->getStyle().margin()[edge];
@@ -711,17 +708,17 @@ YOGA_EXPORT void YGNodeStyleSetPadding(
     YGNodeRef node,
     YGEdge edge,
     float points) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(points);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<MSVC_HINT(padding)>(
-      node, &YGStyle::padding, edge, value);
+      node, &Style::padding, edge, value);
 }
 YOGA_EXPORT void YGNodeStyleSetPaddingPercent(
     YGNodeRef node,
     YGEdge edge,
     float percent) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(percent);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<MSVC_HINT(padding)>(
-      node, &YGStyle::padding, edge, value);
+      node, &Style::padding, edge, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetPadding(YGNodeConstRef node, YGEdge edge) {
   return node->getStyle().padding()[edge];
@@ -732,9 +729,8 @@ YOGA_EXPORT void YGNodeStyleSetBorder(
     const YGNodeRef node,
     const YGEdge edge,
     const float border) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(border);
-  updateIndexedStyleProp<MSVC_HINT(border)>(
-      node, &YGStyle::border, edge, value);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(border);
+  updateIndexedStyleProp<MSVC_HINT(border)>(node, &Style::border, edge, value);
 }
 
 YOGA_EXPORT float YGNodeStyleGetBorder(
@@ -754,8 +750,8 @@ YOGA_EXPORT void YGNodeStyleSetGap(
     const YGNodeRef node,
     const YGGutter gutter,
     const float gapLength) {
-  auto length = detail::CompactValue::ofMaybe<YGUnitPoint>(gapLength);
-  updateIndexedStyleProp<MSVC_HINT(gap)>(node, &YGStyle::gap, gutter, length);
+  auto length = CompactValue::ofMaybe<YGUnitPoint>(gapLength);
+  updateIndexedStyleProp<MSVC_HINT(gap)>(node, &Style::gap, gutter, length);
 }
 
 YOGA_EXPORT float YGNodeStyleGetGap(
@@ -784,46 +780,40 @@ YOGA_EXPORT void YGNodeStyleSetAspectRatio(
     const YGNodeRef node,
     const float aspectRatio) {
   updateStyle<MSVC_HINT(aspectRatio)>(
-      node, &YGStyle::aspectRatio, YGFloatOptional{aspectRatio});
+      node, &Style::aspectRatio, YGFloatOptional{aspectRatio});
 }
 
 YOGA_EXPORT void YGNodeStyleSetWidth(YGNodeRef node, float points) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(points);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
-      node, &YGStyle::dimensions, YGDimensionWidth, value);
+      node, &Style::dimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT void YGNodeStyleSetWidthPercent(YGNodeRef node, float percent) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(percent);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
-      node, &YGStyle::dimensions, YGDimensionWidth, value);
+      node, &Style::dimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT void YGNodeStyleSetWidthAuto(YGNodeRef node) {
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
-      node,
-      &YGStyle::dimensions,
-      YGDimensionWidth,
-      detail::CompactValue::ofAuto());
+      node, &Style::dimensions, YGDimensionWidth, CompactValue::ofAuto());
 }
 YOGA_EXPORT YGValue YGNodeStyleGetWidth(YGNodeConstRef node) {
   return node->getStyle().dimensions()[YGDimensionWidth];
 }
 
 YOGA_EXPORT void YGNodeStyleSetHeight(YGNodeRef node, float points) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(points);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
-      node, &YGStyle::dimensions, YGDimensionHeight, value);
+      node, &Style::dimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT void YGNodeStyleSetHeightPercent(YGNodeRef node, float percent) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(percent);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
-      node, &YGStyle::dimensions, YGDimensionHeight, value);
+      node, &Style::dimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT void YGNodeStyleSetHeightAuto(YGNodeRef node) {
   updateIndexedStyleProp<MSVC_HINT(dimensions)>(
-      node,
-      &YGStyle::dimensions,
-      YGDimensionHeight,
-      detail::CompactValue::ofAuto());
+      node, &Style::dimensions, YGDimensionHeight, CompactValue::ofAuto());
 }
 YOGA_EXPORT YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
   return node->getStyle().dimensions()[YGDimensionHeight];
@@ -832,16 +822,16 @@ YOGA_EXPORT YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetMinWidth(
     const YGNodeRef node,
     const float minWidth) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(minWidth);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(minWidth);
   updateIndexedStyleProp<MSVC_HINT(minDimensions)>(
-      node, &YGStyle::minDimensions, YGDimensionWidth, value);
+      node, &Style::minDimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT void YGNodeStyleSetMinWidthPercent(
     const YGNodeRef node,
     const float minWidth) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(minWidth);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(minWidth);
   updateIndexedStyleProp<MSVC_HINT(minDimensions)>(
-      node, &YGStyle::minDimensions, YGDimensionWidth, value);
+      node, &Style::minDimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
   return node->getStyle().minDimensions()[YGDimensionWidth];
@@ -850,16 +840,16 @@ YOGA_EXPORT YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetMinHeight(
     const YGNodeRef node,
     const float minHeight) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(minHeight);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(minHeight);
   updateIndexedStyleProp<MSVC_HINT(minDimensions)>(
-      node, &YGStyle::minDimensions, YGDimensionHeight, value);
+      node, &Style::minDimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT void YGNodeStyleSetMinHeightPercent(
     const YGNodeRef node,
     const float minHeight) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(minHeight);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(minHeight);
   updateIndexedStyleProp<MSVC_HINT(minDimensions)>(
-      node, &YGStyle::minDimensions, YGDimensionHeight, value);
+      node, &Style::minDimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
   return node->getStyle().minDimensions()[YGDimensionHeight];
@@ -868,16 +858,16 @@ YOGA_EXPORT YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetMaxWidth(
     const YGNodeRef node,
     const float maxWidth) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(maxWidth);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(maxWidth);
   updateIndexedStyleProp<MSVC_HINT(maxDimensions)>(
-      node, &YGStyle::maxDimensions, YGDimensionWidth, value);
+      node, &Style::maxDimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT void YGNodeStyleSetMaxWidthPercent(
     const YGNodeRef node,
     const float maxWidth) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(maxWidth);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(maxWidth);
   updateIndexedStyleProp<MSVC_HINT(maxDimensions)>(
-      node, &YGStyle::maxDimensions, YGDimensionWidth, value);
+      node, &Style::maxDimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
   return node->getStyle().maxDimensions()[YGDimensionWidth];
@@ -886,16 +876,16 @@ YOGA_EXPORT YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeStyleSetMaxHeight(
     const YGNodeRef node,
     const float maxHeight) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPoint>(maxHeight);
+  auto value = CompactValue::ofMaybe<YGUnitPoint>(maxHeight);
   updateIndexedStyleProp<MSVC_HINT(maxDimensions)>(
-      node, &YGStyle::maxDimensions, YGDimensionHeight, value);
+      node, &Style::maxDimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT void YGNodeStyleSetMaxHeightPercent(
     const YGNodeRef node,
     const float maxHeight) {
-  auto value = detail::CompactValue::ofMaybe<YGUnitPercent>(maxHeight);
+  auto value = CompactValue::ofMaybe<YGUnitPercent>(maxHeight);
   updateIndexedStyleProp<MSVC_HINT(maxDimensions)>(
-      node, &YGStyle::maxDimensions, YGDimensionHeight, value);
+      node, &Style::maxDimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMaxHeight(const YGNodeConstRef node) {
   return node->getStyle().maxDimensions()[YGDimensionHeight];
@@ -2519,7 +2509,7 @@ static void YGJustifyMainAxis(
        i < collectedFlexItemsValues.endOfLineIndex;
        i++) {
     const YGNodeRef child = node->getChild(i);
-    const YGStyle& childStyle = child->getStyle();
+    const Style& childStyle = child->getStyle();
     const YGLayout childLayout = child->getLayout();
     const bool isLastChild = i == collectedFlexItemsValues.endOfLineIndex - 1;
     // remove the gap if it is the last element of the line

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -343,7 +343,6 @@ void YGConfigSetUseLegacyStretchBehaviour(
 // YGConfig
 WIN_EXPORT YGConfigRef YGConfigNew(void);
 WIN_EXPORT void YGConfigFree(YGConfigRef config);
-WIN_EXPORT void YGConfigCopy(YGConfigRef dest, YGConfigRef src);
 WIN_EXPORT int32_t YGConfigGetInstanceCount(void);
 
 WIN_EXPORT void YGConfigSetExperimentalFeatureEnabled(

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -79,7 +79,7 @@ WIN_EXPORT void YGNodeRemoveAllChildren(YGNodeRef node);
 WIN_EXPORT YGNodeRef YGNodeGetChild(YGNodeRef node, uint32_t index);
 WIN_EXPORT YGNodeRef YGNodeGetOwner(YGNodeRef node);
 WIN_EXPORT YGNodeRef YGNodeGetParent(YGNodeRef node);
-WIN_EXPORT uint32_t YGNodeGetChildCount(YGNodeRef node);
+WIN_EXPORT uint32_t YGNodeGetChildCount(YGNodeConstRef node);
 WIN_EXPORT void YGNodeSetChildren(
     YGNodeRef owner,
     const YGNodeRef* children,

--- a/yoga/config/Config.cpp
+++ b/yoga/config/Config.cpp
@@ -5,133 +5,129 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "YGConfig.h"
-
-using namespace facebook::yoga;
+#include <yoga/config/Config.h>
 
 namespace facebook::yoga {
-bool configUpdateInvalidatesLayout(YGConfigRef a, YGConfigRef b) {
+
+bool configUpdateInvalidatesLayout(Config* a, Config* b) {
   return a->getErrata() != b->getErrata() ||
       a->getEnabledExperiments() != b->getEnabledExperiments() ||
       a->getPointScaleFactor() != b->getPointScaleFactor() ||
       a->useWebDefaults() != b->useWebDefaults();
 }
-} // namespace facebook::yoga
 
-YGConfig::YGConfig(YGLogger logger) : cloneNodeCallback_{nullptr} {
+Config::Config(YGLogger logger) : cloneNodeCallback_{nullptr} {
   setLogger(logger);
 }
 
-void YGConfig::setUseWebDefaults(bool useWebDefaults) {
+void Config::setUseWebDefaults(bool useWebDefaults) {
   flags_.useWebDefaults = useWebDefaults;
 }
 
-bool YGConfig::useWebDefaults() const {
+bool Config::useWebDefaults() const {
   return flags_.useWebDefaults;
 }
 
-void YGConfig::setShouldPrintTree(bool printTree) {
+void Config::setShouldPrintTree(bool printTree) {
   flags_.printTree = printTree;
 }
 
-bool YGConfig::shouldPrintTree() const {
+bool Config::shouldPrintTree() const {
   return flags_.printTree;
 }
 
-void YGConfig::setExperimentalFeatureEnabled(
+void Config::setExperimentalFeatureEnabled(
     YGExperimentalFeature feature,
     bool enabled) {
   experimentalFeatures_.set(feature, enabled);
 }
 
-bool YGConfig::isExperimentalFeatureEnabled(
-    YGExperimentalFeature feature) const {
+bool Config::isExperimentalFeatureEnabled(YGExperimentalFeature feature) const {
   return experimentalFeatures_.test(feature);
 }
 
-ExperimentalFeatureSet YGConfig::getEnabledExperiments() const {
+ExperimentalFeatureSet Config::getEnabledExperiments() const {
   return experimentalFeatures_;
 }
 
-void YGConfig::setErrata(YGErrata errata) {
+void Config::setErrata(YGErrata errata) {
   errata_ = errata;
 }
 
-void YGConfig::addErrata(YGErrata errata) {
+void Config::addErrata(YGErrata errata) {
   errata_ |= errata;
 }
 
-void YGConfig::removeErrata(YGErrata errata) {
+void Config::removeErrata(YGErrata errata) {
   errata_ &= (~errata);
 }
 
-YGErrata YGConfig::getErrata() const {
+YGErrata Config::getErrata() const {
   return errata_;
 }
 
-bool YGConfig::hasErrata(YGErrata errata) const {
+bool Config::hasErrata(YGErrata errata) const {
   return (errata_ & errata) != YGErrataNone;
 }
 
-void YGConfig::setPointScaleFactor(float pointScaleFactor) {
+void Config::setPointScaleFactor(float pointScaleFactor) {
   pointScaleFactor_ = pointScaleFactor;
 }
 
-float YGConfig::getPointScaleFactor() const {
+float Config::getPointScaleFactor() const {
   return pointScaleFactor_;
 }
 
-void YGConfig::setContext(void* context) {
+void Config::setContext(void* context) {
   context_ = context;
 }
 
-void* YGConfig::getContext() const {
+void* Config::getContext() const {
   return context_;
 }
 
-void YGConfig::setLogger(YGLogger logger) {
+void Config::setLogger(YGLogger logger) {
   logger_.noContext = logger;
   flags_.loggerUsesContext = false;
 }
 
-void YGConfig::setLogger(LogWithContextFn logger) {
+void Config::setLogger(LogWithContextFn logger) {
   logger_.withContext = logger;
   flags_.loggerUsesContext = true;
 }
 
-void YGConfig::setLogger(std::nullptr_t) {
+void Config::setLogger(std::nullptr_t) {
   setLogger(YGLogger{nullptr});
 }
 
-void YGConfig::log(
-    YGConfig* config,
-    YGNode* node,
+void Config::log(
+    YGNodeRef node,
     YGLogLevel logLevel,
     void* logContext,
     const char* format,
-    va_list args) const {
+    va_list args) {
   if (flags_.loggerUsesContext) {
-    logger_.withContext(config, node, logLevel, logContext, format, args);
+    logger_.withContext(this, node, logLevel, logContext, format, args);
   } else {
-    logger_.noContext(config, node, logLevel, format, args);
+    logger_.noContext(this, node, logLevel, format, args);
   }
 }
 
-void YGConfig::setCloneNodeCallback(YGCloneNodeFunc cloneNode) {
+void Config::setCloneNodeCallback(YGCloneNodeFunc cloneNode) {
   cloneNodeCallback_.noContext = cloneNode;
   flags_.cloneNodeUsesContext = false;
 }
 
-void YGConfig::setCloneNodeCallback(CloneWithContextFn cloneNode) {
+void Config::setCloneNodeCallback(CloneWithContextFn cloneNode) {
   cloneNodeCallback_.withContext = cloneNode;
   flags_.cloneNodeUsesContext = true;
 }
 
-void YGConfig::setCloneNodeCallback(std::nullptr_t) {
+void Config::setCloneNodeCallback(std::nullptr_t) {
   setCloneNodeCallback(YGCloneNodeFunc{nullptr});
 }
 
-YGNodeRef YGConfig::cloneNode(
+YGNodeRef Config::cloneNode(
     YGNodeRef node,
     YGNodeRef owner,
     int childIndex,
@@ -147,3 +143,5 @@ YGNodeRef YGConfig::cloneNode(
   }
   return clone;
 }
+
+} // namespace facebook::yoga

--- a/yoga/config/Config.h
+++ b/yoga/config/Config.h
@@ -12,11 +12,16 @@
 #include <yoga/BitUtils.h>
 #include <yoga/Yoga-internal.h>
 
+// Tag struct used to form the opaque YGConfigRef for the public C API
+struct YGConfig {};
+
 namespace facebook::yoga {
+
+class Config;
 
 // Whether moving a node from config "a" to config "b" should dirty previously
 // calculated layout results.
-bool configUpdateInvalidatesLayout(YGConfigRef a, YGConfigRef b);
+bool configUpdateInvalidatesLayout(Config* a, Config* b);
 
 // Internal variants of log functions, currently used only by JNI bindings.
 // TODO: Reconcile this with the public API
@@ -33,13 +38,12 @@ using CloneWithContextFn = YGNodeRef (*)(
     int childIndex,
     void* cloneContext);
 
-using ExperimentalFeatureSet =
-    facebook::yoga::detail::EnumBitset<YGExperimentalFeature>;
+using ExperimentalFeatureSet = detail::EnumBitset<YGExperimentalFeature>;
 
 #pragma pack(push)
 #pragma pack(1)
 // Packed structure of <32-bit options to miminize size per node.
-struct YGConfigFlags {
+struct ConfigFlags {
   bool useWebDefaults : 1;
   bool printTree : 1;
   bool cloneNodeUsesContext : 1;
@@ -47,10 +51,9 @@ struct YGConfigFlags {
 };
 #pragma pack(pop)
 
-} // namespace facebook::yoga
-
-struct YOGA_EXPORT YGConfig {
-  YGConfig(YGLogger logger);
+class YOGA_EXPORT Config : public ::YGConfig {
+public:
+  Config(YGLogger logger);
 
   void setUseWebDefaults(bool useWebDefaults);
   bool useWebDefaults() const;
@@ -62,7 +65,7 @@ struct YOGA_EXPORT YGConfig {
       YGExperimentalFeature feature,
       bool enabled);
   bool isExperimentalFeatureEnabled(YGExperimentalFeature feature) const;
-  facebook::yoga::ExperimentalFeatureSet getEnabledExperiments() const;
+  ExperimentalFeatureSet getEnabledExperiments() const;
 
   void setErrata(YGErrata errata);
   void addErrata(YGErrata errata);
@@ -77,12 +80,12 @@ struct YOGA_EXPORT YGConfig {
   void* getContext() const;
 
   void setLogger(YGLogger logger);
-  void setLogger(facebook::yoga::LogWithContextFn logger);
+  void setLogger(LogWithContextFn logger);
   void setLogger(std::nullptr_t);
-  void log(YGConfig*, YGNode*, YGLogLevel, void*, const char*, va_list) const;
+  void log(YGNodeRef, YGLogLevel, void*, const char*, va_list);
 
   void setCloneNodeCallback(YGCloneNodeFunc cloneNode);
-  void setCloneNodeCallback(facebook::yoga::CloneWithContextFn cloneNode);
+  void setCloneNodeCallback(CloneWithContextFn cloneNode);
   void setCloneNodeCallback(std::nullptr_t);
   YGNodeRef cloneNode(
       YGNodeRef node,
@@ -92,17 +95,19 @@ struct YOGA_EXPORT YGConfig {
 
 private:
   union {
-    facebook::yoga::CloneWithContextFn withContext;
+    CloneWithContextFn withContext;
     YGCloneNodeFunc noContext;
   } cloneNodeCallback_;
   union {
-    facebook::yoga::LogWithContextFn withContext;
+    LogWithContextFn withContext;
     YGLogger noContext;
   } logger_;
 
-  facebook::yoga::YGConfigFlags flags_{};
-  facebook::yoga::ExperimentalFeatureSet experimentalFeatures_{};
+  ConfigFlags flags_{};
+  ExperimentalFeatureSet experimentalFeatures_{};
   YGErrata errata_ = YGErrataNone;
   float pointScaleFactor_ = 1.0f;
   void* context_ = nullptr;
 };
+
+} // namespace facebook::yoga

--- a/yoga/event/event.cpp
+++ b/yoga/event/event.cpp
@@ -73,7 +73,10 @@ void Event::subscribe(std::function<Subscriber>&& subscriber) {
   push(new Node{std::move(subscriber)});
 }
 
-void Event::publish(const YGNode& node, Type eventType, const Data& eventData) {
+void Event::publish(
+    YGNodeConstRef node,
+    Type eventType,
+    const Data& eventData) {
   for (auto subscriber = subscribers.load(std::memory_order_relaxed);
        subscriber != nullptr;
        subscriber = subscriber->next) {

--- a/yoga/event/event.h
+++ b/yoga/event/event.h
@@ -7,14 +7,12 @@
 
 #pragma once
 
+#include <yoga/Yoga.h>
+
 #include <functional>
 #include <vector>
 #include <array>
-#include <yoga/YGEnums.h>
 #include <stdint.h>
-
-struct YGConfig;
-struct YGNode;
 
 namespace facebook::yoga {
 
@@ -63,7 +61,7 @@ struct YOGA_EXPORT Event {
     NodeBaselineEnd,
   };
   class Data;
-  using Subscriber = void(const YGNode&, Type, Data);
+  using Subscriber = void(YGNodeConstRef, Type, Data);
   using Subscribers = std::vector<std::function<Subscriber>>;
 
   template <Type E>
@@ -87,27 +85,22 @@ struct YOGA_EXPORT Event {
   static void subscribe(std::function<Subscriber>&& subscriber);
 
   template <Type E>
-  static void publish(const YGNode& node, const TypedData<E>& eventData = {}) {
+  static void publish(YGNodeConstRef node, const TypedData<E>& eventData = {}) {
     publish(node, E, Data{eventData});
   }
 
-  template <Type E>
-  static void publish(const YGNode* node, const TypedData<E>& eventData = {}) {
-    publish<E>(*node, eventData);
-  }
-
 private:
-  static void publish(const YGNode&, Type, const Data&);
+  static void publish(YGNodeConstRef, Type, const Data&);
 };
 
 template <>
 struct Event::TypedData<Event::NodeAllocation> {
-  YGConfig* config;
+  YGConfigRef config;
 };
 
 template <>
 struct Event::TypedData<Event::NodeDeallocation> {
-  YGConfig* config;
+  YGConfigRef config;
 };
 
 template <>

--- a/yoga/log.cpp
+++ b/yoga/log.cpp
@@ -8,7 +8,7 @@
 #include <yoga/Yoga.h>
 
 #include "log.h"
-#include "YGConfig.h"
+#include <yoga/config/Config.h>
 #include "YGNode.h"
 
 namespace facebook::yoga::detail {
@@ -16,14 +16,16 @@ namespace facebook::yoga::detail {
 namespace {
 
 void vlog(
-    YGConfig* config,
+    yoga::Config* config,
     YGNode* node,
     YGLogLevel level,
     void* context,
     const char* format,
     va_list args) {
-  YGConfig* logConfig = config != nullptr ? config : YGConfigGetDefault();
-  logConfig->log(logConfig, node, level, context, format, args);
+  yoga::Config* logConfig = config != nullptr
+      ? config
+      : static_cast<yoga::Config*>(YGConfigGetDefault());
+  logConfig->log(node, level, context, format, args);
 }
 } // namespace
 
@@ -46,7 +48,7 @@ YOGA_EXPORT void Log::log(
 }
 
 void Log::log(
-    YGConfig* config,
+    yoga::Config* config,
     YGLogLevel level,
     void* context,
     const char* format,

--- a/yoga/log.cpp
+++ b/yoga/log.cpp
@@ -9,7 +9,7 @@
 
 #include "log.h"
 #include <yoga/config/Config.h>
-#include "YGNode.h"
+#include <yoga/node/Node.h>
 
 namespace facebook::yoga::detail {
 
@@ -17,7 +17,7 @@ namespace {
 
 void vlog(
     yoga::Config* config,
-    YGNode* node,
+    yoga::Node* node,
     YGLogLevel level,
     void* context,
     const char* format,
@@ -30,7 +30,7 @@ void vlog(
 } // namespace
 
 YOGA_EXPORT void Log::log(
-    YGNode* node,
+    yoga::Node* node,
     YGLogLevel level,
     void* context,
     const char* format,

--- a/yoga/log.h
+++ b/yoga/log.h
@@ -8,16 +8,14 @@
 #pragma once
 
 #include <yoga/YGEnums.h>
+#include <yoga/node/Node.h>
 #include <yoga/config/Config.h>
-
-struct YGNode;
-struct YGConfig;
 
 namespace facebook::yoga::detail {
 
 struct Log {
   static void log(
-      YGNode* node,
+      yoga::Node* node,
       YGLogLevel level,
       void*,
       const char* message,

--- a/yoga/log.h
+++ b/yoga/log.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <yoga/YGEnums.h>
+#include <yoga/config/Config.h>
 
 struct YGNode;
 struct YGConfig;
@@ -23,7 +24,7 @@ struct Log {
       ...) noexcept;
 
   static void log(
-      YGConfig* config,
+      yoga::Config* config,
       YGLogLevel level,
       void*,
       const char* format,

--- a/yoga/node/LayoutResults.cpp
+++ b/yoga/node/LayoutResults.cpp
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "YGLayout.h"
-#include "Utils.h"
+#include <yoga/node/LayoutResults.h>
+#include <yoga/Utils.h>
 
-using namespace facebook;
+namespace facebook::yoga {
 
-bool YGLayout::operator==(YGLayout layout) const {
+bool LayoutResults::operator==(LayoutResults layout) const {
   bool isEqual = YGFloatArrayEqual(position, layout.position) &&
       YGFloatArrayEqual(dimensions, layout.dimensions) &&
       YGFloatArrayEqual(margin, layout.margin) &&
@@ -40,3 +40,5 @@ bool YGLayout::operator==(YGLayout layout) const {
 
   return isEqual;
 }
+
+} // namespace facebook::yoga

--- a/yoga/node/LayoutResults.h
+++ b/yoga/node/LayoutResults.h
@@ -11,7 +11,9 @@
 #include <yoga/YGFloatOptional.h>
 #include <yoga/Yoga-internal.h>
 
-struct YGLayout {
+namespace facebook::yoga {
+
+struct LayoutResults {
   std::array<float, 4> position = {};
   std::array<float, 2> dimensions = {{YGUndefined, YGUndefined}};
   std::array<float, 4> margin = {};
@@ -58,6 +60,8 @@ public:
         flags, hadOverflowOffset, hadOverflow);
   }
 
-  bool operator==(YGLayout layout) const;
-  bool operator!=(YGLayout layout) const { return !(*this == layout); }
+  bool operator==(LayoutResults layout) const;
+  bool operator!=(LayoutResults layout) const { return !(*this == layout); }
 };
+
+} // namespace facebook::yoga

--- a/yoga/node/Node.cpp
+++ b/yoga/node/Node.cpp
@@ -5,18 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "YGNode.h"
+#include <yoga/node/Node.h>
 #include <algorithm>
 #include <iostream>
-#include "Utils.h"
+#include <yoga/Utils.h>
 
-using namespace facebook;
-using namespace facebook::yoga;
-using facebook::yoga::CompactValue;
+namespace facebook::yoga {
 
-YGNode::YGNode(yoga::Config* config) : config_{config} {
-  YGAssert(
-      config != nullptr, "Attempting to construct YGNode with null config");
+Node::Node(yoga::Config* config) : config_{config} {
+  YGAssert(config != nullptr, "Attempting to construct Node with null config");
 
   flags_.hasNewLayout = true;
   if (config->useWebDefaults()) {
@@ -24,7 +21,7 @@ YGNode::YGNode(yoga::Config* config) : config_{config} {
   }
 }
 
-YGNode::YGNode(YGNode&& node) {
+Node::Node(Node&& node) {
   context_ = node.context_;
   flags_ = node.flags_;
   measure_ = node.measure_;
@@ -43,7 +40,7 @@ YGNode::YGNode(YGNode&& node) {
   }
 }
 
-void YGNode::print(void* printContext) {
+void Node::print(void* printContext) {
   if (print_.noContext != nullptr) {
     if (flags_.printUsesContext) {
       print_.withContext(this, printContext);
@@ -53,7 +50,7 @@ void YGNode::print(void* printContext) {
   }
 }
 
-CompactValue YGNode::computeEdgeValueForRow(
+CompactValue Node::computeEdgeValueForRow(
     const Style::Edges& edges,
     YGEdge rowEdge,
     YGEdge edge,
@@ -71,7 +68,7 @@ CompactValue YGNode::computeEdgeValueForRow(
   }
 }
 
-CompactValue YGNode::computeEdgeValueForColumn(
+CompactValue Node::computeEdgeValueForColumn(
     const Style::Edges& edges,
     YGEdge edge,
     CompactValue defaultValue) {
@@ -86,7 +83,7 @@ CompactValue YGNode::computeEdgeValueForColumn(
   }
 }
 
-CompactValue YGNode::computeRowGap(
+CompactValue Node::computeRowGap(
     const Style::Gutters& gutters,
     CompactValue defaultValue) {
   if (!gutters[YGGutterRow].isUndefined()) {
@@ -98,7 +95,7 @@ CompactValue YGNode::computeRowGap(
   }
 }
 
-CompactValue YGNode::computeColumnGap(
+CompactValue Node::computeColumnGap(
     const Style::Gutters& gutters,
     CompactValue defaultValue) {
   if (!gutters[YGGutterColumn].isUndefined()) {
@@ -110,7 +107,7 @@ CompactValue YGNode::computeColumnGap(
   }
 }
 
-YGFloatOptional YGNode::getLeadingPosition(
+YGFloatOptional Node::getLeadingPosition(
     const YGFlexDirection axis,
     const float axisSize) const {
   auto leadingPosition = YGFlexDirectionIsRow(axis)
@@ -124,7 +121,7 @@ YGFloatOptional YGNode::getLeadingPosition(
   return YGResolveValue(leadingPosition, axisSize);
 }
 
-YGFloatOptional YGNode::getTrailingPosition(
+YGFloatOptional Node::getTrailingPosition(
     const YGFlexDirection axis,
     const float axisSize) const {
   auto trailingPosition = YGFlexDirectionIsRow(axis)
@@ -138,7 +135,7 @@ YGFloatOptional YGNode::getTrailingPosition(
   return YGResolveValue(trailingPosition, axisSize);
 }
 
-bool YGNode::isLeadingPositionDefined(const YGFlexDirection axis) const {
+bool Node::isLeadingPositionDefined(const YGFlexDirection axis) const {
   auto leadingPosition = YGFlexDirectionIsRow(axis)
       ? computeEdgeValueForRow(
             style_.position(),
@@ -150,7 +147,7 @@ bool YGNode::isLeadingPositionDefined(const YGFlexDirection axis) const {
   return !leadingPosition.isUndefined();
 }
 
-bool YGNode::isTrailingPosDefined(const YGFlexDirection axis) const {
+bool Node::isTrailingPosDefined(const YGFlexDirection axis) const {
   auto trailingPosition = YGFlexDirectionIsRow(axis)
       ? computeEdgeValueForRow(
             style_.position(),
@@ -162,7 +159,7 @@ bool YGNode::isTrailingPosDefined(const YGFlexDirection axis) const {
   return !trailingPosition.isUndefined();
 }
 
-YGFloatOptional YGNode::getLeadingMargin(
+YGFloatOptional Node::getLeadingMargin(
     const YGFlexDirection axis,
     const float widthSize) const {
   auto leadingMargin = YGFlexDirectionIsRow(axis)
@@ -173,7 +170,7 @@ YGFloatOptional YGNode::getLeadingMargin(
   return YGResolveValueMargin(leadingMargin, widthSize);
 }
 
-YGFloatOptional YGNode::getTrailingMargin(
+YGFloatOptional Node::getTrailingMargin(
     const YGFlexDirection axis,
     const float widthSize) const {
   auto trailingMargin = YGFlexDirectionIsRow(axis)
@@ -184,13 +181,13 @@ YGFloatOptional YGNode::getTrailingMargin(
   return YGResolveValueMargin(trailingMargin, widthSize);
 }
 
-YGFloatOptional YGNode::getMarginForAxis(
+YGFloatOptional Node::getMarginForAxis(
     const YGFlexDirection axis,
     const float widthSize) const {
   return getLeadingMargin(axis, widthSize) + getTrailingMargin(axis, widthSize);
 }
 
-YGFloatOptional YGNode::getGapForAxis(
+YGFloatOptional Node::getGapForAxis(
     const YGFlexDirection axis,
     const float widthSize) const {
   auto gap = YGFlexDirectionIsRow(axis)
@@ -199,7 +196,7 @@ YGFloatOptional YGNode::getGapForAxis(
   return YGResolveValue(gap, widthSize);
 }
 
-YGSize YGNode::measure(
+YGSize Node::measure(
     float width,
     YGMeasureMode widthMode,
     float height,
@@ -211,7 +208,7 @@ YGSize YGNode::measure(
       : measure_.noContext(this, width, widthMode, height, heightMode);
 }
 
-float YGNode::baseline(float width, float height, void* layoutContext) {
+float Node::baseline(float width, float height, void* layoutContext) {
   return flags_.baselineUsesContext
       ? baseline_.withContext(this, width, height, layoutContext)
       : baseline_.noContext(this, width, height);
@@ -219,7 +216,7 @@ float YGNode::baseline(float width, float height, void* layoutContext) {
 
 // Setters
 
-void YGNode::setMeasureFunc(decltype(YGNode::measure_) measureFunc) {
+void Node::setMeasureFunc(decltype(Node::measure_) measureFunc) {
   if (measureFunc.noContext == nullptr) {
     // TODO: t18095186 Move nodeType to opt-in function and mark appropriate
     // places in Litho
@@ -238,38 +235,38 @@ void YGNode::setMeasureFunc(decltype(YGNode::measure_) measureFunc) {
   measure_ = measureFunc;
 }
 
-void YGNode::setMeasureFunc(YGMeasureFunc measureFunc) {
+void Node::setMeasureFunc(YGMeasureFunc measureFunc) {
   flags_.measureUsesContext = false;
-  decltype(YGNode::measure_) m;
+  decltype(Node::measure_) m;
   m.noContext = measureFunc;
   setMeasureFunc(m);
 }
 
-YOGA_EXPORT void YGNode::setMeasureFunc(MeasureWithContextFn measureFunc) {
+YOGA_EXPORT void Node::setMeasureFunc(MeasureWithContextFn measureFunc) {
   flags_.measureUsesContext = true;
-  decltype(YGNode::measure_) m;
+  decltype(Node::measure_) m;
   m.withContext = measureFunc;
   setMeasureFunc(m);
 }
 
-void YGNode::replaceChild(YGNodeRef child, uint32_t index) {
+void Node::replaceChild(Node* child, uint32_t index) {
   children_[index] = child;
 }
 
-void YGNode::replaceChild(YGNodeRef oldChild, YGNodeRef newChild) {
+void Node::replaceChild(Node* oldChild, Node* newChild) {
   std::replace(children_.begin(), children_.end(), oldChild, newChild);
 }
 
-void YGNode::insertChild(YGNodeRef child, uint32_t index) {
+void Node::insertChild(Node* child, uint32_t index) {
   children_.insert(children_.begin() + index, child);
 }
 
-void YGNode::setConfig(yoga::Config* config) {
-  YGAssert(config != nullptr, "Attempting to set a null config on a YGNode");
+void Node::setConfig(yoga::Config* config) {
+  YGAssert(config != nullptr, "Attempting to set a null config on a Node");
   YGAssertWithConfig(
       config,
       config->useWebDefaults() == config_->useWebDefaults(),
-      "UseWebDefaults may not be changed after constructing a YGNode");
+      "UseWebDefaults may not be changed after constructing a Node");
 
   if (yoga::configUpdateInvalidatesLayout(config_, config)) {
     markDirtyAndPropagate();
@@ -278,7 +275,7 @@ void YGNode::setConfig(yoga::Config* config) {
   config_ = config;
 }
 
-void YGNode::setDirty(bool isDirty) {
+void Node::setDirty(bool isDirty) {
   if (isDirty == flags_.isDirty) {
     return;
   }
@@ -288,8 +285,8 @@ void YGNode::setDirty(bool isDirty) {
   }
 }
 
-bool YGNode::removeChild(YGNodeRef child) {
-  std::vector<YGNodeRef>::iterator p =
+bool Node::removeChild(Node* child) {
+  std::vector<Node*>::iterator p =
       std::find(children_.begin(), children_.end(), child);
   if (p != children_.end()) {
     children_.erase(p);
@@ -298,59 +295,58 @@ bool YGNode::removeChild(YGNodeRef child) {
   return false;
 }
 
-void YGNode::removeChild(uint32_t index) {
+void Node::removeChild(uint32_t index) {
   children_.erase(children_.begin() + index);
 }
 
-void YGNode::setLayoutDirection(YGDirection direction) {
+void Node::setLayoutDirection(YGDirection direction) {
   layout_.setDirection(direction);
 }
 
-void YGNode::setLayoutMargin(float margin, int index) {
+void Node::setLayoutMargin(float margin, int index) {
   layout_.margin[index] = margin;
 }
 
-void YGNode::setLayoutBorder(float border, int index) {
+void Node::setLayoutBorder(float border, int index) {
   layout_.border[index] = border;
 }
 
-void YGNode::setLayoutPadding(float padding, int index) {
+void Node::setLayoutPadding(float padding, int index) {
   layout_.padding[index] = padding;
 }
 
-void YGNode::setLayoutLastOwnerDirection(YGDirection direction) {
+void Node::setLayoutLastOwnerDirection(YGDirection direction) {
   layout_.lastOwnerDirection = direction;
 }
 
-void YGNode::setLayoutComputedFlexBasis(
-    const YGFloatOptional computedFlexBasis) {
+void Node::setLayoutComputedFlexBasis(const YGFloatOptional computedFlexBasis) {
   layout_.computedFlexBasis = computedFlexBasis;
 }
 
-void YGNode::setLayoutPosition(float position, int index) {
+void Node::setLayoutPosition(float position, int index) {
   layout_.position[index] = position;
 }
 
-void YGNode::setLayoutComputedFlexBasisGeneration(
+void Node::setLayoutComputedFlexBasisGeneration(
     uint32_t computedFlexBasisGeneration) {
   layout_.computedFlexBasisGeneration = computedFlexBasisGeneration;
 }
 
-void YGNode::setLayoutMeasuredDimension(float measuredDimension, int index) {
+void Node::setLayoutMeasuredDimension(float measuredDimension, int index) {
   layout_.measuredDimensions[index] = measuredDimension;
 }
 
-void YGNode::setLayoutHadOverflow(bool hadOverflow) {
+void Node::setLayoutHadOverflow(bool hadOverflow) {
   layout_.setHadOverflow(hadOverflow);
 }
 
-void YGNode::setLayoutDimension(float dimension, int index) {
+void Node::setLayoutDimension(float dimension, int index) {
   layout_.dimensions[index] = dimension;
 }
 
 // If both left and right are defined, then use left. Otherwise return +left or
 // -right depending on which is defined.
-YGFloatOptional YGNode::relativePosition(
+YGFloatOptional Node::relativePosition(
     const YGFlexDirection axis,
     const float axisSize) const {
   if (isLeadingPositionDefined(axis)) {
@@ -364,7 +360,7 @@ YGFloatOptional YGNode::relativePosition(
   return trailingPosition;
 }
 
-void YGNode::setPosition(
+void Node::setPosition(
     const YGDirection direction,
     const float mainSize,
     const float crossSize,
@@ -402,7 +398,7 @@ void YGNode::setPosition(
       trailing[crossAxis]);
 }
 
-YGValue YGNode::marginLeadingValue(const YGFlexDirection axis) const {
+YGValue Node::marginLeadingValue(const YGFlexDirection axis) const {
   if (YGFlexDirectionIsRow(axis) &&
       !style_.margin()[YGEdgeStart].isUndefined()) {
     return style_.margin()[YGEdgeStart];
@@ -411,7 +407,7 @@ YGValue YGNode::marginLeadingValue(const YGFlexDirection axis) const {
   }
 }
 
-YGValue YGNode::marginTrailingValue(const YGFlexDirection axis) const {
+YGValue Node::marginTrailingValue(const YGFlexDirection axis) const {
   if (YGFlexDirectionIsRow(axis) && !style_.margin()[YGEdgeEnd].isUndefined()) {
     return style_.margin()[YGEdgeEnd];
   } else {
@@ -419,7 +415,7 @@ YGValue YGNode::marginTrailingValue(const YGFlexDirection axis) const {
   }
 }
 
-YGValue YGNode::resolveFlexBasisPtr() const {
+YGValue Node::resolveFlexBasisPtr() const {
   YGValue flexBasis = style_.flexBasis();
   if (flexBasis.unit != YGUnitAuto && flexBasis.unit != YGUnitUndefined) {
     return flexBasis;
@@ -430,7 +426,7 @@ YGValue YGNode::resolveFlexBasisPtr() const {
   return YGValueAuto;
 }
 
-void YGNode::resolveDimension() {
+void Node::resolveDimension() {
   using namespace yoga;
   const Style& style = getStyle();
   for (auto dim : {YGDimensionWidth, YGDimensionHeight}) {
@@ -443,7 +439,7 @@ void YGNode::resolveDimension() {
   }
 }
 
-YGDirection YGNode::resolveDirection(const YGDirection ownerDirection) {
+YGDirection Node::resolveDirection(const YGDirection ownerDirection) {
   if (style_.direction() == YGDirectionInherit) {
     return ownerDirection > YGDirectionInherit ? ownerDirection
                                                : YGDirectionLTR;
@@ -452,18 +448,18 @@ YGDirection YGNode::resolveDirection(const YGDirection ownerDirection) {
   }
 }
 
-YOGA_EXPORT void YGNode::clearChildren() {
+YOGA_EXPORT void Node::clearChildren() {
   children_.clear();
   children_.shrink_to_fit();
 }
 
 // Other Methods
 
-void YGNode::cloneChildrenIfNeeded(void* cloneContext) {
-  iterChildrenAfterCloningIfNeeded([](YGNodeRef, void*) {}, cloneContext);
+void Node::cloneChildrenIfNeeded(void* cloneContext) {
+  iterChildrenAfterCloningIfNeeded([](Node*, void*) {}, cloneContext);
 }
 
-void YGNode::markDirtyAndPropagate() {
+void Node::markDirtyAndPropagate() {
   if (!flags_.isDirty) {
     setDirty(true);
     setLayoutComputedFlexBasis(YGFloatOptional());
@@ -473,14 +469,14 @@ void YGNode::markDirtyAndPropagate() {
   }
 }
 
-void YGNode::markDirtyAndPropagateDownwards() {
+void Node::markDirtyAndPropagateDownwards() {
   flags_.isDirty = true;
-  for_each(children_.begin(), children_.end(), [](YGNodeRef childNode) {
+  for_each(children_.begin(), children_.end(), [](Node* childNode) {
     childNode->markDirtyAndPropagateDownwards();
   });
 }
 
-float YGNode::resolveFlexGrow() const {
+float Node::resolveFlexGrow() const {
   // Root nodes flexGrow should always be 0
   if (owner_ == nullptr) {
     return 0.0;
@@ -494,7 +490,7 @@ float YGNode::resolveFlexGrow() const {
   return kDefaultFlexGrow;
 }
 
-float YGNode::resolveFlexShrink() const {
+float Node::resolveFlexShrink() const {
   if (owner_ == nullptr) {
     return 0.0;
   }
@@ -508,13 +504,13 @@ float YGNode::resolveFlexShrink() const {
   return config_->useWebDefaults() ? kWebDefaultFlexShrink : kDefaultFlexShrink;
 }
 
-bool YGNode::isNodeFlexible() {
+bool Node::isNodeFlexible() {
   return (
       (style_.positionType() != YGPositionTypeAbsolute) &&
       (resolveFlexGrow() != 0 || resolveFlexShrink() != 0));
 }
 
-float YGNode::getLeadingBorder(const YGFlexDirection axis) const {
+float Node::getLeadingBorder(const YGFlexDirection axis) const {
   YGValue leadingBorder = YGFlexDirectionIsRow(axis)
       ? computeEdgeValueForRow(
             style_.border(), YGEdgeStart, leading[axis], CompactValue::ofZero())
@@ -523,7 +519,7 @@ float YGNode::getLeadingBorder(const YGFlexDirection axis) const {
   return fmaxf(leadingBorder.value, 0.0f);
 }
 
-float YGNode::getTrailingBorder(const YGFlexDirection axis) const {
+float Node::getTrailingBorder(const YGFlexDirection axis) const {
   YGValue trailingBorder = YGFlexDirectionIsRow(axis)
       ? computeEdgeValueForRow(
             style_.border(), YGEdgeEnd, trailing[axis], CompactValue::ofZero())
@@ -532,7 +528,7 @@ float YGNode::getTrailingBorder(const YGFlexDirection axis) const {
   return fmaxf(trailingBorder.value, 0.0f);
 }
 
-YGFloatOptional YGNode::getLeadingPadding(
+YGFloatOptional Node::getLeadingPadding(
     const YGFlexDirection axis,
     const float widthSize) const {
   auto leadingPadding = YGFlexDirectionIsRow(axis)
@@ -547,7 +543,7 @@ YGFloatOptional YGNode::getLeadingPadding(
       YGResolveValue(leadingPadding, widthSize), YGFloatOptional(0.0f));
 }
 
-YGFloatOptional YGNode::getTrailingPadding(
+YGFloatOptional Node::getTrailingPadding(
     const YGFlexDirection axis,
     const float widthSize) const {
   auto trailingPadding = YGFlexDirectionIsRow(axis)
@@ -559,21 +555,21 @@ YGFloatOptional YGNode::getTrailingPadding(
       YGResolveValue(trailingPadding, widthSize), YGFloatOptional(0.0f));
 }
 
-YGFloatOptional YGNode::getLeadingPaddingAndBorder(
+YGFloatOptional Node::getLeadingPaddingAndBorder(
     const YGFlexDirection axis,
     const float widthSize) const {
   return getLeadingPadding(axis, widthSize) +
       YGFloatOptional(getLeadingBorder(axis));
 }
 
-YGFloatOptional YGNode::getTrailingPaddingAndBorder(
+YGFloatOptional Node::getTrailingPaddingAndBorder(
     const YGFlexDirection axis,
     const float widthSize) const {
   return getTrailingPadding(axis, widthSize) +
       YGFloatOptional(getTrailingBorder(axis));
 }
 
-void YGNode::reset() {
+void Node::reset() {
   YGAssertWithNode(
       this,
       children_.size() == 0,
@@ -581,5 +577,7 @@ void YGNode::reset() {
   YGAssertWithNode(
       this, owner_ == nullptr, "Cannot reset a node still attached to a owner");
 
-  *this = YGNode{getConfig()};
+  *this = Node{getConfig()};
 }
+
+} // namespace facebook::yoga

--- a/yoga/style/CompactValue.h
+++ b/yoga/style/CompactValue.h
@@ -38,7 +38,7 @@ static_assert(
 #define VISIBLE_FOR_TESTING private:
 #endif
 
-namespace facebook::yoga::detail {
+namespace facebook::yoga {
 
 // This class stores YGValue in 32 bits.
 // - The value does not matter for Undefined and Auto. NaNs are used for their
@@ -207,4 +207,4 @@ constexpr bool operator!=(CompactValue a, CompactValue b) noexcept {
   return !(a == b);
 }
 
-} // namespace facebook::yoga::detail
+} // namespace facebook::yoga

--- a/yoga/style/Style.cpp
+++ b/yoga/style/Style.cpp
@@ -5,11 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "YGStyle.h"
-#include "Utils.h"
+#include <yoga/style/Style.h>
+#include <yoga/Utils.h>
+
+namespace facebook::yoga {
 
 // Yoga specific properties, not compatible with flexbox specification
-bool operator==(const YGStyle& lhs, const YGStyle& rhs) {
+bool operator==(const Style& lhs, const Style& rhs) {
   bool areNonFloatValuesEqual = lhs.direction() == rhs.direction() &&
       lhs.flexDirection() == rhs.flexDirection() &&
       lhs.justifyContent() == rhs.justifyContent() &&
@@ -54,3 +56,5 @@ bool operator==(const YGStyle& lhs, const YGStyle& rhs) {
 
   return areNonFloatValuesEqual;
 }
+
+} // namespace facebook::yoga

--- a/yoga/style/Style.h
+++ b/yoga/style/Style.h
@@ -13,17 +13,17 @@
 #include <type_traits>
 
 #include <yoga/Yoga.h>
+#include <yoga/YGFloatOptional.h>
+#include <yoga/Yoga-internal.h>
+#include <yoga/BitUtils.h>
 
-#include "CompactValue.h"
-#include "YGFloatOptional.h"
-#include "Yoga-internal.h"
-#include "BitUtils.h"
+#include <yoga/style/CompactValue.h>
 
-class YOGA_EXPORT YGStyle {
+namespace facebook::yoga {
+
+class YOGA_EXPORT Style {
   template <typename Enum>
-  using Values =
-      facebook::yoga::detail::Values<facebook::yoga::enums::count<Enum>()>;
-  using CompactValue = facebook::yoga::detail::CompactValue;
+  using Values = detail::Values<enums::count<Enum>()>;
 
 public:
   using Dimensions = Values<YGDimension>;
@@ -32,7 +32,7 @@ public:
 
   template <typename T>
   struct BitfieldRef {
-    YGStyle& style;
+    Style& style;
     size_t offset;
     operator T() const {
       return facebook::yoga::detail::getEnumData<T>(style.flags, offset);
@@ -43,9 +43,9 @@ public:
     }
   };
 
-  template <typename T, T YGStyle::*Prop>
+  template <typename T, T Style::*Prop>
   struct Ref {
-    YGStyle& style;
+    Style& style;
     operator T() const { return style.*Prop; }
     Ref<T, Prop>& operator=(T value) {
       style.*Prop = value;
@@ -53,10 +53,10 @@ public:
     }
   };
 
-  template <typename Idx, Values<Idx> YGStyle::*Prop>
+  template <typename Idx, Values<Idx> Style::*Prop>
   struct IdxRef {
     struct Ref {
-      YGStyle& style;
+      Style& style;
       Idx idx;
       operator CompactValue() const { return (style.*Prop)[idx]; }
       operator YGValue() const { return (style.*Prop)[idx]; }
@@ -66,7 +66,7 @@ public:
       }
     };
 
-    YGStyle& style;
+    Style& style;
     IdxRef<Idx, Prop>& operator=(const Values<Idx>& values) {
       style.*Prop = values;
       return *this;
@@ -76,11 +76,11 @@ public:
     CompactValue operator[](Idx idx) const { return (style.*Prop)[idx]; }
   };
 
-  YGStyle() {
+  Style() {
     alignContent() = YGAlignFlexStart;
     alignItems() = YGAlignStretch;
   }
-  ~YGStyle() = default;
+  ~Style() = default;
 
 private:
   static constexpr size_t directionOffset = 0;
@@ -188,51 +188,52 @@ public:
   BitfieldRef<YGDisplay> display() { return {*this, displayOffset}; }
 
   YGFloatOptional flex() const { return flex_; }
-  Ref<YGFloatOptional, &YGStyle::flex_> flex() { return {*this}; }
+  Ref<YGFloatOptional, &Style::flex_> flex() { return {*this}; }
 
   YGFloatOptional flexGrow() const { return flexGrow_; }
-  Ref<YGFloatOptional, &YGStyle::flexGrow_> flexGrow() { return {*this}; }
+  Ref<YGFloatOptional, &Style::flexGrow_> flexGrow() { return {*this}; }
 
   YGFloatOptional flexShrink() const { return flexShrink_; }
-  Ref<YGFloatOptional, &YGStyle::flexShrink_> flexShrink() { return {*this}; }
+  Ref<YGFloatOptional, &Style::flexShrink_> flexShrink() { return {*this}; }
 
   CompactValue flexBasis() const { return flexBasis_; }
-  Ref<CompactValue, &YGStyle::flexBasis_> flexBasis() { return {*this}; }
+  Ref<CompactValue, &Style::flexBasis_> flexBasis() { return {*this}; }
 
   const Edges& margin() const { return margin_; }
-  IdxRef<YGEdge, &YGStyle::margin_> margin() { return {*this}; }
+  IdxRef<YGEdge, &Style::margin_> margin() { return {*this}; }
 
   const Edges& position() const { return position_; }
-  IdxRef<YGEdge, &YGStyle::position_> position() { return {*this}; }
+  IdxRef<YGEdge, &Style::position_> position() { return {*this}; }
 
   const Edges& padding() const { return padding_; }
-  IdxRef<YGEdge, &YGStyle::padding_> padding() { return {*this}; }
+  IdxRef<YGEdge, &Style::padding_> padding() { return {*this}; }
 
   const Edges& border() const { return border_; }
-  IdxRef<YGEdge, &YGStyle::border_> border() { return {*this}; }
+  IdxRef<YGEdge, &Style::border_> border() { return {*this}; }
 
   const Gutters& gap() const { return gap_; }
-  IdxRef<YGGutter, &YGStyle::gap_> gap() { return {*this}; }
+  IdxRef<YGGutter, &Style::gap_> gap() { return {*this}; }
 
   const Dimensions& dimensions() const { return dimensions_; }
-  IdxRef<YGDimension, &YGStyle::dimensions_> dimensions() { return {*this}; }
+  IdxRef<YGDimension, &Style::dimensions_> dimensions() { return {*this}; }
 
   const Dimensions& minDimensions() const { return minDimensions_; }
-  IdxRef<YGDimension, &YGStyle::minDimensions_> minDimensions() {
+  IdxRef<YGDimension, &Style::minDimensions_> minDimensions() {
     return {*this};
   }
 
   const Dimensions& maxDimensions() const { return maxDimensions_; }
-  IdxRef<YGDimension, &YGStyle::maxDimensions_> maxDimensions() {
+  IdxRef<YGDimension, &Style::maxDimensions_> maxDimensions() {
     return {*this};
   }
 
   // Yoga specific properties, not compatible with flexbox specification
   YGFloatOptional aspectRatio() const { return aspectRatio_; }
-  Ref<YGFloatOptional, &YGStyle::aspectRatio_> aspectRatio() { return {*this}; }
+  Ref<YGFloatOptional, &Style::aspectRatio_> aspectRatio() { return {*this}; }
 };
 
-YOGA_EXPORT bool operator==(const YGStyle& lhs, const YGStyle& rhs);
-YOGA_EXPORT inline bool operator!=(const YGStyle& lhs, const YGStyle& rhs) {
+YOGA_EXPORT bool operator==(const Style& lhs, const Style& rhs);
+YOGA_EXPORT inline bool operator!=(const Style& lhs, const Style& rhs) {
   return !(lhs == rhs);
 }
+} // namespace facebook::yoga


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/react-native/pull/39170

## This diff

This diff adds a top level `node` directory for code related to Yoga nodes and data structures on them (inc moving `YGLayout` to `LayoutResults`).

The public API for config handles is `YGNodeRef`, which is forward declared to be a pointer to a struct named `YGNode`. The existing `YGNode` is split into `yoga::Node`, as the private C++ implementation, inheriting from `YGNode`, a marker type represented as an empty struct. The public API continues to accept `YGNodeRef`, which continues to be `YGNode *`, but it must be cast to its concrete internal representation at the API boundary before doing work on it.

This change ends up needing to touch quite a bit, due to the amount of code that mixed and matched private and public APIs. Don't be scared though, because these changes are very mechanical, and Phabricator's line-count is 3x the actual amount due to mirrors and dirsyncs.

## This stack

The organization of the C++ internals of Yoga are in need of attention.
1. Some of the C++ internals are namespaced, but others not.
2. Some of the namespaces include `detail`, but are meant to be used outside of the translation unit (FB Clang Tidy rules warn on any usage of these)
2. Most of the files are in a flat hierarchy, except for event tracing in its own folder
3. Some files and functions begin with YG, others don’t
4. Some functions are uppercase, others are not
5. Almost all of the interesting logic is in Yoga.cpp, and the file is too large to reason about
6. There are multiple grab bag files where folks put random functions they need in (Utils, BitUtils, Yoga-Internal.h)
7. There is no clear indication from file structure or type naming what is private vs not
8. Handles like `YGNodeRef` and `YGConfigRef` can be used to access internals just by importing headers

This stack does some much needed spring cleaning:
1. All non-public headers and C++ implementation details are in separate folders from the root level `yoga`. This will give us room to split up logic and add more files without too large a flat hierarchy
3. All private C++ internals are under the `facebook::yoga` namespace. Details namespaces are only ever used within the same header, as they are intended
4. Utils files are split
5. Most C++ internals drop the YG prefix
6. Most C++ internal function names are all lower camel case
7. We start to split up Yoga.cpp
8. Every header beginning with YG or at the top-level directory is public and C only, with the exception of Yoga-Internal.h which has non-public functions for bindings
9. It is not possible to use private APIs without static casting handles to internal classes

This will give us more leeway to continue splitting monolithic files, and consistent guidelines for style in new files as well.

These changes should not be breaking to any project using only public Yoga headers. This includes every usage of Yoga in fbsource except for RN Fabric which is currently tied to internals. This refactor should make that boundary clearer.

Changelog: [Internal]

Differential Revision: D48712710

