### PR TITLE
Extract isBaselineLayout()

### DIFF
--- a/yoga/algorithm/Baseline.cpp
+++ b/yoga/algorithm/Baseline.cpp
@@ -62,4 +62,23 @@ float calculateBaseline(const yoga::Node* node, void* layoutContext) {
   return baseline + baselineChild->getLayout().position[YGEdgeTop];
 }
 
+bool isBaselineLayout(const yoga::Node* node) {
+  if (isColumn(node->getStyle().flexDirection())) {
+    return false;
+  }
+  if (node->getStyle().alignItems() == YGAlignBaseline) {
+    return true;
+  }
+  const auto childCount = node->getChildCount();
+  for (size_t i = 0; i < childCount; i++) {
+    auto child = node->getChild(i);
+    if (child->getStyle().positionType() != YGPositionTypeAbsolute &&
+        child->getStyle().alignSelf() == YGAlignBaseline) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 } // namespace facebook::yoga

--- a/yoga/algorithm/Baseline.h
+++ b/yoga/algorithm/Baseline.h
@@ -15,4 +15,7 @@ namespace facebook::yoga {
 // Calculate baseline represented as an offset from the top edge of the node.
 float calculateBaseline(const yoga::Node* node, void* layoutContext);
 
+// Whether any of the children of this node participate in baseline alignment
+bool isBaselineLayout(const yoga::Node* node);
+
 } // namespace facebook::yoga

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -50,25 +50,6 @@ bool calculateLayoutInternal(
     const uint32_t depth,
     const uint32_t generationCount);
 
-static bool isBaselineLayout(const yoga::Node* node) {
-  if (isColumn(node->getStyle().flexDirection())) {
-    return false;
-  }
-  if (node->getStyle().alignItems() == YGAlignBaseline) {
-    return true;
-  }
-  const auto childCount = node->getChildCount();
-  for (size_t i = 0; i < childCount; i++) {
-    auto child = node->getChild(i);
-    if (child->getStyle().positionType() != YGPositionTypeAbsolute &&
-        child->getStyle().alignSelf() == YGAlignBaseline) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 static inline float dimensionWithMargin(
     const yoga::Node* const node,
     const YGFlexDirection axis,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/react-native/pull/39400

Moves `isBaselineLayout` out of `CalculateLayout` into `Baseline.h`. This function is called by flex line justification code, which I have been looking at extracting.

Differential Revision: D49177937


