### PR TITLE
Per-node pointScaleFactor

### DIFF
--- a/java/jni/LayoutContext.cpp
+++ b/java/jni/LayoutContext.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "LayoutContext.h"
+
+namespace facebook::yoga::vanillajni {
+
+thread_local std::stack<PtrJNodeMapVanilla*> LayoutContext::contexts_;
+
+} // namespace facebook::yoga::vanillajni

--- a/java/jni/LayoutContext.h
+++ b/java/jni/LayoutContext.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stack>
+#include "YGJTypesVanilla.h"
+
+namespace facebook::yoga::vanillajni {
+
+class LayoutContext {
+public:
+  struct Holder {
+    explicit Holder(PtrJNodeMapVanilla* data) {
+      LayoutContext::contexts_.push(data);
+    }
+    ~Holder() { LayoutContext::contexts_.pop(); }
+  };
+
+  static PtrJNodeMapVanilla* getCurrent() {
+    return contexts_.empty() ? nullptr : contexts_.top();
+  }
+
+private:
+  static thread_local std::stack<PtrJNodeMapVanilla*> contexts_;
+};
+
+} // namespace facebook::yoga::vanillajni

--- a/java/jni/YGJNIVanilla.cpp
+++ b/java/jni/YGJNIVanilla.cpp
@@ -14,22 +14,17 @@
 #include <iostream>
 #include <memory>
 #include "YogaJniException.h"
+#include "LayoutContext.h"
 
 #include <yoga/Yoga-internal.h>
 #include <yoga/bits/BitCast.h>
-
-// TODO: Reconcile missing layoutContext functionality from callbacks in the C
-// API and use that
-#include <yoga/node/Node.h>
 
 using namespace facebook;
 using namespace facebook::yoga;
 using namespace facebook::yoga::vanillajni;
 
-static inline ScopedLocalRef<jobject> YGNodeJobject(
-    YGNodeConstRef node,
-    void* layoutContext) {
-  return reinterpret_cast<PtrJNodeMapVanilla*>(layoutContext)->ref(node);
+static inline ScopedLocalRef<jobject> YGNodeJobject(YGNodeConstRef node) {
+  return LayoutContext::getCurrent()->ref(node);
 }
 
 static inline YGNodeRef _jlong2YGNodeRef(jlong addr) {
@@ -129,7 +124,6 @@ static int YGJNILogFunc(
     const YGConfigConstRef config,
     const YGNodeConstRef /*node*/,
     YGLogLevel level,
-    void* /*layoutContext*/,
     const char* format,
     va_list args) {
   va_list argsCopy;
@@ -187,7 +181,7 @@ static void jni_YGConfigSetLoggerJNI(
     }
 
     *context = newGlobalRef(env, logger);
-    static_cast<yoga::Config*>(config)->setLogger(YGJNILogFunc);
+    YGConfigSetLogger(config, YGJNILogFunc);
   } else {
     if (context != nullptr) {
       delete context;
@@ -278,12 +272,11 @@ static void jni_YGNodeRemoveChildJNI(
 static void YGTransferLayoutOutputsRecursive(
     JNIEnv* env,
     jobject thiz,
-    YGNodeRef root,
-    void* layoutContext) {
+    YGNodeRef root) {
   if (!YGNodeGetHasNewLayout(root)) {
     return;
   }
-  auto obj = YGNodeJobject(root, layoutContext);
+  auto obj = YGNodeJobject(root);
   if (!obj) {
     return;
   }
@@ -351,8 +344,7 @@ static void YGTransferLayoutOutputsRecursive(
   YGNodeSetHasNewLayout(root, false);
 
   for (size_t i = 0; i < YGNodeGetChildCount(root); i++) {
-    YGTransferLayoutOutputsRecursive(
-        env, thiz, YGNodeGetChild(root, i), layoutContext);
+    YGTransferLayoutOutputsRecursive(env, thiz, YGNodeGetChild(root, i));
   }
 }
 
@@ -366,21 +358,22 @@ static void jni_YGNodeCalculateLayoutJNI(
     jobjectArray javaNodes) {
 
   try {
-    void* layoutContext = nullptr;
+    PtrJNodeMapVanilla* layoutContext = nullptr;
     auto map = PtrJNodeMapVanilla{};
     if (nativePointers) {
       map = PtrJNodeMapVanilla{nativePointers, javaNodes};
       layoutContext = &map;
     }
 
+    LayoutContext::Holder holder(layoutContext);
+
     const YGNodeRef root = _jlong2YGNodeRef(nativePointer);
-    YGNodeCalculateLayoutWithContext(
+    YGNodeCalculateLayout(
         root,
         static_cast<float>(width),
         static_cast<float>(height),
-        YGNodeStyleGetDirection(_jlong2YGNodeRef(nativePointer)),
-        layoutContext);
-    YGTransferLayoutOutputsRecursive(env, obj, root, layoutContext);
+        YGNodeStyleGetDirection(_jlong2YGNodeRef(nativePointer)));
+    YGTransferLayoutOutputsRecursive(env, obj, root);
   } catch (const YogaJniException& jniException) {
     ScopedLocalRef<jthrowable> throwable = jniException.getThrowable();
     if (throwable.get()) {
@@ -647,9 +640,8 @@ static YGSize YGJNIMeasureFunc(
     float width,
     YGMeasureMode widthMode,
     float height,
-    YGMeasureMode heightMode,
-    void* layoutContext) {
-  if (auto obj = YGNodeJobject(node, layoutContext)) {
+    YGMeasureMode heightMode) {
+  if (auto obj = YGNodeJobject(node)) {
     YGTransferLayoutDirection(node, obj.get());
     JNIEnv* env = getCurrentEnv();
     auto objectClass = facebook::yoga::vanillajni::make_local_ref(
@@ -683,16 +675,13 @@ static void jni_YGNodeSetHasMeasureFuncJNI(
     jobject /*obj*/,
     jlong nativePointer,
     jboolean hasMeasureFunc) {
-  static_cast<yoga::Node*>(_jlong2YGNodeRef(nativePointer))
-      ->setMeasureFunc(hasMeasureFunc ? YGJNIMeasureFunc : nullptr);
+  YGNodeSetMeasureFunc(
+      _jlong2YGNodeRef(nativePointer),
+      hasMeasureFunc ? YGJNIMeasureFunc : nullptr);
 }
 
-static float YGJNIBaselineFunc(
-    YGNodeConstRef node,
-    float width,
-    float height,
-    void* layoutContext) {
-  if (auto obj = YGNodeJobject(node, layoutContext)) {
+static float YGJNIBaselineFunc(YGNodeConstRef node, float width, float height) {
+  if (auto obj = YGNodeJobject(node)) {
     JNIEnv* env = getCurrentEnv();
     auto objectClass = facebook::yoga::vanillajni::make_local_ref(
         env, env->GetObjectClass(obj.get()));
@@ -710,8 +699,9 @@ static void jni_YGNodeSetHasBaselineFuncJNI(
     jobject /*obj*/,
     jlong nativePointer,
     jboolean hasBaselineFunc) {
-  static_cast<yoga::Node*>(_jlong2YGNodeRef(nativePointer))
-      ->setBaselineFunc(hasBaselineFunc ? YGJNIBaselineFunc : nullptr);
+  YGNodeSetBaselineFunc(
+      _jlong2YGNodeRef(nativePointer),
+      hasBaselineFunc ? YGJNIBaselineFunc : nullptr);
 }
 
 static void jni_YGNodePrintJNI(

--- a/java/jni/YGJTypesVanilla.h
+++ b/java/jni/YGJTypesVanilla.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <map>
 #include <vector>
 

--- a/tests/EventsTest.cpp
+++ b/tests/EventsTest.cpp
@@ -24,7 +24,6 @@ struct TypedEventTestData {};
 
 template <>
 struct TypedEventTestData<Event::LayoutPassEnd> {
-  void* layoutContext;
   LayoutData layoutData;
 };
 
@@ -329,7 +328,7 @@ void EventTest::listen(
     case Event::LayoutPassEnd: {
       auto& eventData = data.get<Event::LayoutPassEnd>();
       events.push_back(createArgs<Event::LayoutPassEnd>(
-          node, data, {eventData.layoutContext, *eventData.layoutData}));
+          node, data, {*eventData.layoutData}));
       break;
     }
 

--- a/tests/YGConfigTest.cpp
+++ b/tests/YGConfigTest.cpp
@@ -33,7 +33,7 @@ TEST_F(ConfigCloningTest, uses_values_provided_by_cloning_callback) {
   config->setCloneNodeCallback(cloneNode);
 
   yoga::Node node{}, owner{};
-  auto clone = config->cloneNode(&node, &owner, 0, nullptr);
+  auto clone = config->cloneNode(&node, &owner, 0);
 
   ASSERT_EQ(clone, &clonedNode);
 }
@@ -44,20 +44,10 @@ TEST_F(
   config->setCloneNodeCallback(doNotClone);
 
   yoga::Node node{}, owner{};
-  auto clone = config->cloneNode(&node, &owner, 0, nullptr);
+  auto clone = config->cloneNode(&node, &owner, 0);
 
   ASSERT_NE(clone, nullptr);
   YGNodeFree(clone);
-}
-
-TEST_F(ConfigCloningTest, can_clone_with_context) {
-  config->setCloneNodeCallback(
-      [](YGNodeConstRef, YGNodeConstRef, size_t, void* context) {
-        return (YGNodeRef) context;
-      });
-
-  yoga::Node node{}, owner{}, clone{};
-  ASSERT_EQ(config->cloneNode(&node, &owner, 0, &clone), &clone);
 }
 
 void ConfigCloningTest::SetUp() {

--- a/tests/YGNodeCallbackTest.cpp
+++ b/tests/YGNodeCallbackTest.cpp
@@ -38,38 +38,7 @@ TEST(Node, measure_with_measure_fn) {
       });
 
   ASSERT_EQ(
-      n.measure(23, YGMeasureModeExactly, 24, YGMeasureModeAtMost, nullptr),
-      (YGSize{23, 12}));
-}
-
-TEST(Node, measure_with_context_measure_fn) {
-  auto n = Node{};
-  n.setMeasureFunc([](YGNodeConstRef,
-                      float,
-                      YGMeasureMode,
-                      float,
-                      YGMeasureMode,
-                      void* ctx) { return *(YGSize*) ctx; });
-
-  auto result = YGSize{123.4f, -56.7f};
-  ASSERT_EQ(
-      n.measure(0, YGMeasureModeUndefined, 0, YGMeasureModeUndefined, &result),
-      result);
-}
-
-TEST(Node, switching_measure_fn_types) {
-  auto n = Node{};
-  n.setMeasureFunc(
-      [](YGNodeConstRef, float, YGMeasureMode, float, YGMeasureMode, void*) {
-        return YGSize{};
-      });
-  n.setMeasureFunc(
-      [](YGNodeConstRef, float w, YGMeasureMode wm, float h, YGMeasureMode hm) {
-        return YGSize{w * static_cast<float>(wm), h / static_cast<float>(hm)};
-      });
-
-  ASSERT_EQ(
-      n.measure(23, YGMeasureModeExactly, 24, YGMeasureModeAtMost, nullptr),
+      n.measure(23, YGMeasureModeExactly, 24, YGMeasureModeAtMost),
       (YGSize{23, 12}));
 }
 
@@ -77,17 +46,6 @@ TEST(Node, hasMeasureFunc_after_unset) {
   auto n = Node{};
   n.setMeasureFunc(
       [](YGNodeConstRef, float, YGMeasureMode, float, YGMeasureMode) {
-        return YGSize{};
-      });
-
-  n.setMeasureFunc(nullptr);
-  ASSERT_FALSE(n.hasMeasureFunc());
-}
-
-TEST(Node, hasMeasureFunc_after_unset_context) {
-  auto n = Node{};
-  n.setMeasureFunc(
-      [](YGNodeConstRef, float, YGMeasureMode, float, YGMeasureMode, void*) {
         return YGSize{};
       });
 
@@ -110,17 +68,7 @@ TEST(Node, baseline_with_baseline_fn) {
   auto n = Node{};
   n.setBaselineFunc([](YGNodeConstRef, float w, float h) { return w + h; });
 
-  ASSERT_EQ(n.baseline(1.25f, 2.5f, nullptr), 3.75f);
-}
-
-TEST(Node, baseline_with_context_baseline_fn) {
-  auto n = Node{};
-  n.setBaselineFunc([](YGNodeConstRef, float w, float h, void* ctx) {
-    return w + h + *(float*) ctx;
-  });
-
-  auto ctx = -10.0f;
-  ASSERT_EQ(n.baseline(1.25f, 2.5f, &ctx), -6.25f);
+  ASSERT_EQ(n.baseline(1.25f, 2.5f), 3.75f);
 }
 
 TEST(Node, hasBaselineFunc_after_unset) {
@@ -129,19 +77,4 @@ TEST(Node, hasBaselineFunc_after_unset) {
 
   n.setBaselineFunc(nullptr);
   ASSERT_FALSE(n.hasBaselineFunc());
-}
-
-TEST(Node, hasBaselineFunc_after_unset_context) {
-  auto n = Node{};
-  n.setBaselineFunc([](YGNodeConstRef, float, float, void*) { return 0.0f; });
-
-  n.setMeasureFunc(nullptr);
-  ASSERT_FALSE(n.hasMeasureFunc());
-}
-
-TEST(Node, switching_baseline_fn_types) {
-  auto n = Node{};
-  n.setBaselineFunc([](YGNodeConstRef, float, float, void*) { return 0.0f; });
-  n.setBaselineFunc([](YGNodeConstRef, float, float) { return 1.0f; });
-  ASSERT_EQ(n.baseline(1, 2, nullptr), 1.0f);
 }

--- a/tests/YGRoundingFunctionTest.cpp
+++ b/tests/YGRoundingFunctionTest.cpp
@@ -80,3 +80,45 @@ TEST(YogaTest, consistent_rounding_during_repeated_layouts) {
 
   YGConfigFree(config);
 }
+
+TEST(YogaTest, per_node_point_scale_factor) {
+  const YGConfigRef config1 = YGConfigNew();
+  YGConfigSetPointScaleFactor(config1, 2);
+
+  const YGConfigRef config2 = YGConfigNew();
+  YGConfigSetPointScaleFactor(config2, 1);
+
+  const YGConfigRef config3 = YGConfigNew();
+  YGConfigSetPointScaleFactor(config3, 0.5f);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config1);
+  YGNodeStyleSetWidth(root, 11.5);
+  YGNodeStyleSetHeight(root, 11.5);
+
+  const YGNodeRef node0 = YGNodeNewWithConfig(config2);
+  YGNodeStyleSetWidth(node0, 9.5);
+  YGNodeStyleSetHeight(node0, 9.5);
+  YGNodeInsertChild(root, node0, 0);
+
+  const YGNodeRef node1 = YGNodeNewWithConfig(config3);
+  YGNodeStyleSetWidth(node1, 7);
+  YGNodeStyleSetHeight(node1, 7);
+  YGNodeInsertChild(node0, node1, 0);
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_EQ(YGNodeLayoutGetWidth(root), 11.5);
+  ASSERT_EQ(YGNodeLayoutGetHeight(root), 11.5);
+
+  ASSERT_EQ(YGNodeLayoutGetWidth(node0), 10);
+  ASSERT_EQ(YGNodeLayoutGetHeight(node0), 10);
+
+  ASSERT_EQ(YGNodeLayoutGetWidth(node1), 8);
+  ASSERT_EQ(YGNodeLayoutGetHeight(node1), 8);
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config1);
+  YGConfigFree(config2);
+  YGConfigFree(config3);
+}

--- a/yoga/Yoga-internal.h
+++ b/yoga/Yoga-internal.h
@@ -15,13 +15,6 @@
 
 YG_EXTERN_C_BEGIN
 
-YG_EXPORT void YGNodeCalculateLayoutWithContext(
-    YGNodeRef node,
-    float availableWidth,
-    float availableHeight,
-    YGDirection ownerDirection,
-    void* layoutContext);
-
 // Deallocates a Yoga Node. Unlike YGNodeFree, does not remove the node from
 // its parent or children.
 YG_EXPORT void YGNodeDeallocate(YGNodeRef node);

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -57,7 +57,7 @@ void YGNodeSetBaselineFunc(YGNodeRef node, YGBaselineFunc baselineFunc) {
 }
 
 YGDirtiedFunc YGNodeGetDirtiedFunc(YGNodeConstRef node) {
-  return resolveRef(node)->getDirtied();
+  return resolveRef(node)->getDirtiedFunc();
 }
 
 void YGNodeSetDirtiedFunc(YGNodeRef node, YGDirtiedFunc dirtiedFunc) {
@@ -805,7 +805,7 @@ void YGNodePrint(const YGNodeConstRef nodeRef, const YGPrintOptions options) {
   const auto node = resolveRef(nodeRef);
   std::string str;
   yoga::nodeToString(str, node, options, 0);
-  yoga::log(node, YGLogLevelDebug, nullptr, str.c_str());
+  yoga::log(node, YGLogLevelDebug, str.c_str());
 }
 #endif
 
@@ -927,16 +927,6 @@ void YGNodeCalculateLayout(
     const float ownerWidth,
     const float ownerHeight,
     const YGDirection ownerDirection) {
-  YGNodeCalculateLayoutWithContext(
-      node, ownerWidth, ownerHeight, ownerDirection, nullptr);
-}
-
-void YGNodeCalculateLayoutWithContext(
-    const YGNodeRef node,
-    const float ownerWidth,
-    const float ownerHeight,
-    const YGDirection ownerDirection,
-    void* layoutContext) {
   yoga::calculateLayout(
-      resolveRef(node), ownerWidth, ownerHeight, ownerDirection, layoutContext);
+      resolveRef(node), ownerWidth, ownerHeight, ownerDirection);
 }

--- a/yoga/algorithm/Baseline.cpp
+++ b/yoga/algorithm/Baseline.cpp
@@ -14,15 +14,14 @@
 
 namespace facebook::yoga {
 
-float calculateBaseline(const yoga::Node* node, void* layoutContext) {
+float calculateBaseline(const yoga::Node* node) {
   if (node->hasBaselineFunc()) {
 
     Event::publish<Event::NodeBaselineStart>(node);
 
     const float baseline = node->baseline(
         node->getLayout().measuredDimensions[YGDimensionWidth],
-        node->getLayout().measuredDimensions[YGDimensionHeight],
-        layoutContext);
+        node->getLayout().measuredDimensions[YGDimensionHeight]);
 
     Event::publish<Event::NodeBaselineEnd>(node);
 
@@ -58,7 +57,7 @@ float calculateBaseline(const yoga::Node* node, void* layoutContext) {
     return node->getLayout().measuredDimensions[YGDimensionHeight];
   }
 
-  const float baseline = calculateBaseline(baselineChild, layoutContext);
+  const float baseline = calculateBaseline(baselineChild);
   return baseline + baselineChild->getLayout().position[YGEdgeTop];
 }
 

--- a/yoga/algorithm/Baseline.cpp
+++ b/yoga/algorithm/Baseline.cpp
@@ -62,4 +62,23 @@ float calculateBaseline(const yoga::Node* node, void* layoutContext) {
   return baseline + baselineChild->getLayout().position[YGEdgeTop];
 }
 
+bool isBaselineLayout(const yoga::Node* node) {
+  if (isColumn(node->getStyle().flexDirection())) {
+    return false;
+  }
+  if (node->getStyle().alignItems() == YGAlignBaseline) {
+    return true;
+  }
+  const auto childCount = node->getChildCount();
+  for (size_t i = 0; i < childCount; i++) {
+    auto child = node->getChild(i);
+    if (child->getStyle().positionType() != YGPositionTypeAbsolute &&
+        child->getStyle().alignSelf() == YGAlignBaseline) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 } // namespace facebook::yoga

--- a/yoga/algorithm/Baseline.h
+++ b/yoga/algorithm/Baseline.h
@@ -15,4 +15,7 @@ namespace facebook::yoga {
 // Calculate baseline represented as an offset from the top edge of the node.
 float calculateBaseline(const yoga::Node* node, void* layoutContext);
 
+// Whether any of the children of this node participate in baseline alignment
+bool isBaselineLayout(const yoga::Node* node);
+
 } // namespace facebook::yoga

--- a/yoga/algorithm/Baseline.h
+++ b/yoga/algorithm/Baseline.h
@@ -13,7 +13,7 @@
 namespace facebook::yoga {
 
 // Calculate baseline represented as an offset from the top edge of the node.
-float calculateBaseline(const yoga::Node* node, void* layoutContext);
+float calculateBaseline(const yoga::Node* node);
 
 // Whether any of the children of this node participate in baseline alignment
 bool isBaselineLayout(const yoga::Node* node);

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -50,25 +50,6 @@ bool calculateLayoutInternal(
     const uint32_t depth,
     const uint32_t generationCount);
 
-static bool isBaselineLayout(const yoga::Node* node) {
-  if (isColumn(node->getStyle().flexDirection())) {
-    return false;
-  }
-  if (node->getStyle().alignItems() == YGAlignBaseline) {
-    return true;
-  }
-  const auto childCount = node->getChildCount();
-  for (size_t i = 0; i < childCount; i++) {
-    auto child = node->getChild(i);
-    if (child->getStyle().positionType() != YGPositionTypeAbsolute &&
-        child->getStyle().alignSelf() == YGAlignBaseline) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 static inline float dimensionWithMargin(
     const yoga::Node* const node,
     const YGFlexDirection axis,

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -2487,7 +2487,7 @@ bool calculateLayoutInternal(
             layout->cachedLayout.computedHeight,
             marginAxisRow,
             marginAxisColumn,
-            config)) {
+            node->getConfig())) {
       cachedResults = &layout->cachedLayout;
     } else {
       // Try to use the measurement cache.
@@ -2505,7 +2505,7 @@ bool calculateLayoutInternal(
                 layout->cachedMeasurements[i].computedHeight,
                 marginAxisRow,
                 marginAxisColumn,
-                config)) {
+                node->getConfig())) {
           cachedResults = &layout->cachedMeasurements[i];
           break;
         }
@@ -2756,8 +2756,7 @@ void calculateLayout(
           gCurrentGenerationCount.load(std::memory_order_relaxed))) {
     node->setPosition(
         node->getLayout().direction(), ownerWidth, ownerHeight, ownerWidth);
-    roundLayoutResultsToPixelGrid(
-        node, node->getConfig()->getPointScaleFactor(), 0.0f, 0.0f);
+    roundLayoutResultsToPixelGrid(node, 0.0f, 0.0f);
 
 #ifdef DEBUG
     if (node->getConfig()->shouldPrintTree()) {

--- a/yoga/algorithm/CalculateLayout.h
+++ b/yoga/algorithm/CalculateLayout.h
@@ -16,7 +16,6 @@ void calculateLayout(
     yoga::Node* const node,
     const float ownerWidth,
     const float ownerHeight,
-    const YGDirection ownerDirection,
-    void* layoutContext);
+    const YGDirection ownerDirection);
 
 } // namespace facebook::yoga

--- a/yoga/algorithm/PixelGrid.cpp
+++ b/yoga/algorithm/PixelGrid.cpp
@@ -64,12 +64,9 @@ float roundValueToPixelGrid(
 
 void roundLayoutResultsToPixelGrid(
     yoga::Node* const node,
-    const double pointScaleFactor,
     const double absoluteLeft,
     const double absoluteTop) {
-  if (pointScaleFactor == 0.0f) {
-    return;
-  }
+  const auto pointScaleFactor = node->getConfig()->getPointScaleFactor();
 
   const double nodeLeft = node->getLayout().position[YGEdgeLeft];
   const double nodeTop = node->getLayout().position[YGEdgeTop];
@@ -83,52 +80,52 @@ void roundLayoutResultsToPixelGrid(
   const double absoluteNodeRight = absoluteNodeLeft + nodeWidth;
   const double absoluteNodeBottom = absoluteNodeTop + nodeHeight;
 
-  // If a node has a custom measure function we never want to round down its
-  // size as this could lead to unwanted text truncation.
-  const bool textRounding = node->getNodeType() == YGNodeTypeText;
+  if (pointScaleFactor != 0.0f) {
+    // If a node has a custom measure function we never want to round down its
+    // size as this could lead to unwanted text truncation.
+    const bool textRounding = node->getNodeType() == YGNodeTypeText;
 
-  node->setLayoutPosition(
-      roundValueToPixelGrid(nodeLeft, pointScaleFactor, false, textRounding),
-      YGEdgeLeft);
+    node->setLayoutPosition(
+        roundValueToPixelGrid(nodeLeft, pointScaleFactor, false, textRounding),
+        YGEdgeLeft);
 
-  node->setLayoutPosition(
-      roundValueToPixelGrid(nodeTop, pointScaleFactor, false, textRounding),
-      YGEdgeTop);
+    node->setLayoutPosition(
+        roundValueToPixelGrid(nodeTop, pointScaleFactor, false, textRounding),
+        YGEdgeTop);
 
-  // We multiply dimension by scale factor and if the result is close to the
-  // whole number, we don't have any fraction To verify if the result is close
-  // to whole number we want to check both floor and ceil numbers
-  const bool hasFractionalWidth =
-      !yoga::inexactEquals(fmod(nodeWidth * pointScaleFactor, 1.0), 0) &&
-      !yoga::inexactEquals(fmod(nodeWidth * pointScaleFactor, 1.0), 1.0);
-  const bool hasFractionalHeight =
-      !yoga::inexactEquals(fmod(nodeHeight * pointScaleFactor, 1.0), 0) &&
-      !yoga::inexactEquals(fmod(nodeHeight * pointScaleFactor, 1.0), 1.0);
+    // We multiply dimension by scale factor and if the result is close to the
+    // whole number, we don't have any fraction To verify if the result is close
+    // to whole number we want to check both floor and ceil numbers
+    const bool hasFractionalWidth =
+        !yoga::inexactEquals(fmod(nodeWidth * pointScaleFactor, 1.0), 0) &&
+        !yoga::inexactEquals(fmod(nodeWidth * pointScaleFactor, 1.0), 1.0);
+    const bool hasFractionalHeight =
+        !yoga::inexactEquals(fmod(nodeHeight * pointScaleFactor, 1.0), 0) &&
+        !yoga::inexactEquals(fmod(nodeHeight * pointScaleFactor, 1.0), 1.0);
 
-  node->setLayoutDimension(
-      roundValueToPixelGrid(
-          absoluteNodeRight,
-          pointScaleFactor,
-          (textRounding && hasFractionalWidth),
-          (textRounding && !hasFractionalWidth)) -
-          roundValueToPixelGrid(
-              absoluteNodeLeft, pointScaleFactor, false, textRounding),
-      YGDimensionWidth);
+    node->setLayoutDimension(
+        roundValueToPixelGrid(
+            absoluteNodeRight,
+            pointScaleFactor,
+            (textRounding && hasFractionalWidth),
+            (textRounding && !hasFractionalWidth)) -
+            roundValueToPixelGrid(
+                absoluteNodeLeft, pointScaleFactor, false, textRounding),
+        YGDimensionWidth);
 
-  node->setLayoutDimension(
-      roundValueToPixelGrid(
-          absoluteNodeBottom,
-          pointScaleFactor,
-          (textRounding && hasFractionalHeight),
-          (textRounding && !hasFractionalHeight)) -
-          roundValueToPixelGrid(
-              absoluteNodeTop, pointScaleFactor, false, textRounding),
-      YGDimensionHeight);
+    node->setLayoutDimension(
+        roundValueToPixelGrid(
+            absoluteNodeBottom,
+            pointScaleFactor,
+            (textRounding && hasFractionalHeight),
+            (textRounding && !hasFractionalHeight)) -
+            roundValueToPixelGrid(
+                absoluteNodeTop, pointScaleFactor, false, textRounding),
+        YGDimensionHeight);
+  }
 
-  const size_t childCount = node->getChildCount();
-  for (size_t i = 0; i < childCount; i++) {
-    roundLayoutResultsToPixelGrid(
-        node->getChild(i), pointScaleFactor, absoluteNodeLeft, absoluteNodeTop);
+  for (yoga::Node* child : node->getChildren()) {
+    roundLayoutResultsToPixelGrid(child, absoluteNodeLeft, absoluteNodeTop);
   }
 }
 

--- a/yoga/algorithm/PixelGrid.h
+++ b/yoga/algorithm/PixelGrid.h
@@ -23,7 +23,6 @@ float roundValueToPixelGrid(
 // Round the layout results of a node and its subtree to the pixel grid.
 void roundLayoutResultsToPixelGrid(
     yoga::Node* const node,
-    const double pointScaleFactor,
     const double absoluteLeft,
     const double absoluteTop);
 

--- a/yoga/config/Config.h
+++ b/yoga/config/Config.h
@@ -24,29 +24,12 @@ bool configUpdateInvalidatesLayout(
     const Config& oldConfig,
     const Config& newConfig);
 
-// Internal variants of log functions, currently used only by JNI bindings.
-// TODO: Reconcile this with the public API
-using LogWithContextFn = int (*)(
-    YGConfigConstRef config,
-    YGNodeConstRef node,
-    YGLogLevel level,
-    void* context,
-    const char* format,
-    va_list args);
-using CloneWithContextFn = YGNodeRef (*)(
-    YGNodeConstRef node,
-    YGNodeConstRef owner,
-    size_t childIndex,
-    void* cloneContext);
-
 #pragma pack(push)
 #pragma pack(1)
 // Packed structure of <32-bit options to miminize size per node.
 struct ConfigFlags {
   bool useWebDefaults : 1;
   bool printTree : 1;
-  bool cloneNodeUsesContext : 1;
-  bool loggerUsesContext : 1;
 };
 #pragma pack(pop)
 
@@ -79,35 +62,23 @@ public:
   void* getContext() const;
 
   void setLogger(YGLogger logger);
-  void setLogger(LogWithContextFn logger);
-  void setLogger(std::nullptr_t);
   void log(
       const yoga::Node* node,
       YGLogLevel logLevel,
-      void* logContext,
       const char* format,
       va_list args) const;
 
   void setCloneNodeCallback(YGCloneNodeFunc cloneNode);
-  void setCloneNodeCallback(CloneWithContextFn cloneNode);
-  void setCloneNodeCallback(std::nullptr_t);
   YGNodeRef cloneNode(
       YGNodeConstRef node,
       YGNodeConstRef owner,
-      size_t childIndex,
-      void* cloneContext) const;
+      size_t childIndex) const;
 
   static const Config& getDefault();
 
 private:
-  union {
-    CloneWithContextFn withContext;
-    YGCloneNodeFunc noContext;
-  } cloneNodeCallback_;
-  union {
-    LogWithContextFn withContext;
-    YGLogger noContext;
-  } logger_;
+  YGCloneNodeFunc cloneNodeCallback_;
+  YGLogger logger_;
 
   ConfigFlags flags_{};
   EnumBitset<YGExperimentalFeature> experimentalFeatures_{};

--- a/yoga/debug/AssertFatal.cpp
+++ b/yoga/debug/AssertFatal.cpp
@@ -22,7 +22,7 @@ namespace facebook::yoga {
 
 void assertFatal(const bool condition, const char* message) {
   if (!condition) {
-    yoga::log(YGLogLevelFatal, nullptr, "%s\n", message);
+    yoga::log(YGLogLevelFatal, "%s\n", message);
     fatalWithMessage(message);
   }
 }
@@ -32,7 +32,7 @@ void assertFatalWithNode(
     const bool condition,
     const char* message) {
   if (!condition) {
-    yoga::log(node, YGLogLevelFatal, nullptr, "%s\n", message);
+    yoga::log(node, YGLogLevelFatal, "%s\n", message);
     fatalWithMessage(message);
   }
 }
@@ -42,7 +42,7 @@ void assertFatalWithConfig(
     const bool condition,
     const char* message) {
   if (!condition) {
-    yoga::log(config, YGLogLevelFatal, nullptr, "%s\n", message);
+    yoga::log(config, YGLogLevelFatal, "%s\n", message);
     fatalWithMessage(message);
   }
 }

--- a/yoga/debug/Log.cpp
+++ b/yoga/debug/Log.cpp
@@ -19,51 +19,43 @@ void vlog(
     const yoga::Config* config,
     const yoga::Node* node,
     YGLogLevel level,
-    void* context,
     const char* format,
     va_list args) {
   if (config == nullptr) {
     getDefaultLogger()(nullptr, node, level, format, args);
   } else {
-    config->log(node, level, context, format, args);
+    config->log(node, level, format, args);
   }
 }
 } // namespace
 
-void log(YGLogLevel level, void* context, const char* format, ...) noexcept {
+void log(YGLogLevel level, const char* format, ...) noexcept {
   va_list args;
   va_start(args, format);
-  vlog(nullptr, nullptr, level, context, format, args);
+  vlog(nullptr, nullptr, level, format, args);
   va_end(args);
 }
 
 void log(
     const yoga::Node* node,
     YGLogLevel level,
-    void* context,
     const char* format,
     ...) noexcept {
   va_list args;
   va_start(args, format);
   vlog(
-      node == nullptr ? nullptr : node->getConfig(),
-      node,
-      level,
-      context,
-      format,
-      args);
+      node == nullptr ? nullptr : node->getConfig(), node, level, format, args);
   va_end(args);
 }
 
 void log(
     const yoga::Config* config,
     YGLogLevel level,
-    void* context,
     const char* format,
     ...) noexcept {
   va_list args;
   va_start(args, format);
-  vlog(config, nullptr, level, context, format, args);
+  vlog(config, nullptr, level, format, args);
   va_end(args);
 }
 

--- a/yoga/debug/Log.h
+++ b/yoga/debug/Log.h
@@ -15,19 +15,17 @@
 
 namespace facebook::yoga {
 
-void log(YGLogLevel level, void*, const char* format, ...) noexcept;
+void log(YGLogLevel level, const char* format, ...) noexcept;
 
 void log(
     const yoga::Node* node,
     YGLogLevel level,
-    void*,
     const char* message,
     ...) noexcept;
 
 void log(
     const yoga::Config* config,
     YGLogLevel level,
-    void*,
     const char* format,
     ...) noexcept;
 

--- a/yoga/event/event.h
+++ b/yoga/event/event.h
@@ -104,19 +104,12 @@ struct Event::TypedData<Event::NodeDeallocation> {
 };
 
 template <>
-struct Event::TypedData<Event::LayoutPassStart> {
-  void* layoutContext;
-};
-
-template <>
 struct Event::TypedData<Event::LayoutPassEnd> {
-  void* layoutContext;
   LayoutData* layoutData;
 };
 
 template <>
 struct Event::TypedData<Event::MeasureCallbackEnd> {
-  void* layoutContext;
   float width;
   YGMeasureMode widthMeasureMode;
   float height;
@@ -129,7 +122,6 @@ struct Event::TypedData<Event::MeasureCallbackEnd> {
 template <>
 struct Event::TypedData<Event::NodeLayout> {
   LayoutType layoutType;
-  void* layoutContext;
 };
 
 } // namespace facebook::yoga


### PR DESCRIPTION
Summary:
Right now we have a `pointScaleFactor` per-node, but only ever read the one of the root node. In most cases where config is global, these will be the same, but it is possible for these to differ.

This... doesn't make much sense from an API perspective, and there are edge cases where we may want to allow laying out a subtree with a different DPI then the rest of the tree (though I think there might be other solutions to that).

We should rethink some of what is currently on config being allowed per-node (do we really need each node to be able to have a separate logger?), but this makes the model consistent in the meantime.

Differential Revision: D49181131

