### PR TITLE
Breaking: Use C++ 20

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,5 +28,5 @@ let package = Package(
             ]
         )
     ],
-    cxxLanguageStandard: CXXLanguageStandard(rawValue: "c++17")
+    cxxLanguageStandard: CXXLanguageStandard(rawValue: "c++20")
 )

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Yoga is an embeddable and performant flexbox layout engine with bindings for mul
 
 
 ## Building
-Yoga's main implementation targets C++ 17 with accompanying build logic in CMake. A wrapper is provided to build the main library and run unit tests.
+Yoga's main implementation targets C++ 20 with accompanying build logic in CMake. A wrapper is provided to build the main library and run unit tests.
 
 ```sh
 ./unit_tests <Debug|Release>

--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |spec|
       '-Werror',
       '-Wextra',
       '-Wconversion',
-      '-std=c++17',
+      '-std=c++20',
       '-fPIC'
   ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@
  */
 
 plugins {
-    id("com.android.library") version "8.0.1" apply false
-    id("com.android.application") version "8.0.1" apply false
+    id("com.android.library") version "8.1.1" apply false
+    id("com.android.application") version "8.1.1" apply false
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 }
 

--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -21,9 +21,9 @@ val ndkVersionProperty: String by rootProject.extra
 
 android {
   namespace = "com.facebook.yoga"
-  compileSdk = 33
-  buildToolsVersion = "33.0.0"
-  ndkVersion = "23.1.7779620"
+  compileSdk = 34
+  buildToolsVersion = "34.0.0"
+  ndkVersion = "25.1.8937393"
 
   defaultConfig {
     minSdk = 21

--- a/javascript/CMakeLists.txt
+++ b/javascript/CMakeLists.txt
@@ -14,7 +14,7 @@ file(GLOB SOURCES CONFIGURE_DEPENDS
 
 include_directories(..)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 add_compile_definitions(
     EMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0)

--- a/yoga/bits/BitCast.h
+++ b/yoga/bits/BitCast.h
@@ -14,6 +14,7 @@ namespace facebook::yoga {
 
 // Polyfill for std::bit_cast() from C++20, to allow safe type punning
 // https://en.cppreference.com/w/cpp/numeric/bit_cast
+// TODO: Remove when we upgrade to NDK 26+
 template <class To, class From>
 std::enable_if_t<
     sizeof(To) == sizeof(From) && std::is_trivially_copyable_v<From> &&


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/react-native/pull/39437

Have been running into places where C++ 20 makes life easier for use like `std::bit_cast` (that one is easy to polyfill), in-class member initializer support for bitfields, designated initializers, defaulted comparison operator, concepts instead of SFINAE, and probably more.

Our other infra is in the process of making this jump, or already has. This tests it out everywhere, across the various reference builds, to see if we have any issues.

This is a bit more aggressive than I had previously communicated, but n - 1 is going to be a better long term place than n - 2.

If we wanted to use `std::bit_cast` we would need one of:
1. GCC 11+ (~2.5 years old)
1. Clang 14 (~2.5 years old)
1. VS 16.11 (~2 years old)

For mobile this means:
1. NDK 26 (still in Beta 😭)
1. XCode 14.3.0 (~6 months old)

https://en.cppreference.com/w/cpp/compiler_support/20

That isn't quite doable yet, but we can start taking advantage of language features in the meantime. More of these will be supported in older toolchains.

Anyone needing support for older C++ versions can lag behind on more recent changes. E.g. Yoga 2.0 supports C++ 14.
Differential Revision: D49261607


