### PR TITLE
Add linker flags to workaround iOS 14 runtime crash

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,8 @@ let package = Package(
                 .headerSearchPath(".")
             ],
             linkerSettings: [
+                // Binaries using symbols with a weak definition crash at runtime on iOS 14/macOS 12 or older
+                // when using the Xcode 15 toolchain (FB13097713)
                 .unsafeFlags(["-Wl", "-ld_classic"])
             ]
         )

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,9 @@ let package = Package(
             publicHeadersPath: ".",
             cxxSettings: [
                 .headerSearchPath(".")
+            ],
+            linkerSettings: [
+                .unsafeFlags(["-Wl", "-ld_classic"])
             ]
         )
     ],


### PR DESCRIPTION
Resolves #1390