### PR TITLE
Simplify bitfields

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,5 +28,5 @@ let package = Package(
             ]
         )
     ],
-    cxxLanguageStandard: CXXLanguageStandard(rawValue: "c++17")
+    cxxLanguageStandard: CXXLanguageStandard(rawValue: "c++20")
 )

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Yoga is an embeddable and performant flexbox layout engine with bindings for mul
 
 
 ## Building
-Yoga's main implementation targets C++ 17 with accompanying build logic in CMake. A wrapper is provided to build the main library and run unit tests.
+Yoga's main implementation targets C++ 20 with accompanying build logic in CMake. A wrapper is provided to build the main library and run unit tests.
 
 ```sh
 ./unit_tests <Debug|Release>

--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |spec|
       '-Werror',
       '-Wextra',
       '-Wconversion',
-      '-std=c++17',
+      '-std=c++20',
       '-fPIC'
   ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@
  */
 
 plugins {
-    id("com.android.library") version "8.0.1" apply false
-    id("com.android.application") version "8.0.1" apply false
+    id("com.android.library") version "8.1.1" apply false
+    id("com.android.application") version "8.1.1" apply false
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 }
 

--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -21,9 +21,9 @@ val ndkVersionProperty: String by rootProject.extra
 
 android {
   namespace = "com.facebook.yoga"
-  compileSdk = 33
-  buildToolsVersion = "33.0.0"
-  ndkVersion = "23.1.7779620"
+  compileSdk = 34
+  buildToolsVersion = "34.0.0"
+  ndkVersion = "25.1.8937393"
 
   defaultConfig {
     minSdk = 21

--- a/javascript/CMakeLists.txt
+++ b/javascript/CMakeLists.txt
@@ -14,7 +14,7 @@ file(GLOB SOURCES CONFIGURE_DEPENDS
 
 include_directories(..)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 add_compile_definitions(
     EMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0)

--- a/yoga/bits/BitCast.h
+++ b/yoga/bits/BitCast.h
@@ -14,6 +14,7 @@ namespace facebook::yoga {
 
 // Polyfill for std::bit_cast() from C++20, to allow safe type punning
 // https://en.cppreference.com/w/cpp/numeric/bit_cast
+// TODO: Remove when we upgrade to NDK 26+
 template <class To, class From>
 std::enable_if_t<
     sizeof(To) == sizeof(From) && std::is_trivially_copyable_v<From> &&

--- a/yoga/config/Config.cpp
+++ b/yoga/config/Config.cpp
@@ -25,19 +25,19 @@ Config::Config(YGLogger logger) : cloneNodeCallback_{nullptr} {
 }
 
 void Config::setUseWebDefaults(bool useWebDefaults) {
-  flags_.useWebDefaults = useWebDefaults;
+  useWebDefaults_ = useWebDefaults;
 }
 
 bool Config::useWebDefaults() const {
-  return flags_.useWebDefaults;
+  return useWebDefaults_;
 }
 
 void Config::setShouldPrintTree(bool printTree) {
-  flags_.printTree = printTree;
+  printTree_ = printTree;
 }
 
 bool Config::shouldPrintTree() const {
-  return flags_.printTree;
+  return printTree_;
 }
 
 void Config::setExperimentalFeatureEnabled(

--- a/yoga/config/Config.h
+++ b/yoga/config/Config.h
@@ -30,15 +30,6 @@ bool configUpdateInvalidatesLayout(
     const Config& oldConfig,
     const Config& newConfig);
 
-#pragma pack(push)
-#pragma pack(1)
-// Packed structure of <32-bit options to miminize size per node.
-struct ConfigFlags {
-  bool useWebDefaults : 1;
-  bool printTree : 1;
-};
-#pragma pack(pop)
-
 class YG_EXPORT Config : public ::YGConfig {
  public:
   Config(YGLogger logger);
@@ -82,7 +73,9 @@ class YG_EXPORT Config : public ::YGConfig {
   YGCloneNodeFunc cloneNodeCallback_;
   YGLogger logger_;
 
-  ConfigFlags flags_{};
+  bool useWebDefaults_ : 1 = false;
+  bool printTree_ : 1 = false;
+
   ExperimentalFeatureSet experimentalFeatures_{};
   Errata errata_ = Errata::None;
   float pointScaleFactor_ = 1.0f;

--- a/yoga/node/LayoutResults.h
+++ b/yoga/node/LayoutResults.h
@@ -15,14 +15,6 @@
 
 namespace facebook::yoga {
 
-#pragma pack(push)
-#pragma pack(1)
-struct LayoutResultFlags {
-  uint32_t direction : 2;
-  bool hadOverflow : 1;
-};
-#pragma pack(pop)
-
 struct LayoutResults {
   // This value was chosen based on empirical data:
   // 98% of analyzed layouts require less than 8 entries.
@@ -35,7 +27,8 @@ struct LayoutResults {
   std::array<float, 4> padding = {};
 
  private:
-  LayoutResultFlags flags_{};
+  uint32_t direction_ : 2 = static_cast<uint32_t>(YGDirectionInherit) & 0x03;
+  bool hadOverflow_ : 1 = false;
 
  public:
   uint32_t computedFlexBasisGeneration = 0;
@@ -53,18 +46,18 @@ struct LayoutResults {
   CachedMeasurement cachedLayout{};
 
   YGDirection direction() const {
-    return static_cast<YGDirection>(flags_.direction);
+    return static_cast<YGDirection>(direction_);
   }
 
   void setDirection(YGDirection direction) {
-    flags_.direction = static_cast<uint32_t>(direction) & 0x03;
+    direction_ = static_cast<uint32_t>(direction) & 0x03;
   }
 
   bool hadOverflow() const {
-    return flags_.hadOverflow;
+    return hadOverflow_;
   }
   void setHadOverflow(bool hadOverflow) {
-    flags_.hadOverflow = hadOverflow;
+    hadOverflow_ = hadOverflow;
   }
 
   bool operator==(LayoutResults layout) const;

--- a/yoga/node/Node.cpp
+++ b/yoga/node/Node.cpp
@@ -23,15 +23,17 @@ Node::Node(const yoga::Config* config) : config_{config} {
   yoga::assertFatal(
       config != nullptr, "Attempting to construct Node with null config");
 
-  flags_.hasNewLayout = true;
   if (config->useWebDefaults()) {
     useWebDefaults();
   }
 }
 
 Node::Node(Node&& node) {
+  hasNewLayout_ = node.hasNewLayout_;
+  isReferenceBaseline_ = node.isReferenceBaseline_;
+  isDirty_ = node.isDirty_;
+  nodeType_ = node.nodeType_;
   context_ = node.context_;
-  flags_ = node.flags_;
   measureFunc_ = node.measureFunc_;
   baselineFunc_ = node.baselineFunc_;
   printFunc_ = node.printFunc_;
@@ -271,10 +273,10 @@ void Node::setConfig(yoga::Config* config) {
 }
 
 void Node::setDirty(bool isDirty) {
-  if (isDirty == flags_.isDirty) {
+  if (isDirty == isDirty_) {
     return;
   }
-  flags_.isDirty = isDirty;
+  isDirty_ = isDirty;
   if (isDirty && dirtiedFunc_) {
     dirtiedFunc_(this);
   }
@@ -473,7 +475,7 @@ void Node::cloneChildrenIfNeeded() {
 }
 
 void Node::markDirtyAndPropagate() {
-  if (!flags_.isDirty) {
+  if (!isDirty_) {
     setDirty(true);
     setLayoutComputedFlexBasis(FloatOptional());
     if (owner_) {
@@ -483,7 +485,7 @@ void Node::markDirtyAndPropagate() {
 }
 
 void Node::markDirtyAndPropagateDownwards() {
-  flags_.isDirty = true;
+  isDirty_ = true;
   for_each(children_.begin(), children_.end(), [](Node* childNode) {
     childNode->markDirtyAndPropagateDownwards();
   });

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -26,20 +26,13 @@ struct YGNode {};
 
 namespace facebook::yoga {
 
-#pragma pack(push)
-#pragma pack(1)
-struct NodeFlags {
-  bool hasNewLayout : 1;
-  bool isReferenceBaseline : 1;
-  bool isDirty : 1;
-  NodeType nodeType : bitCount<NodeType>();
-};
-#pragma pack(pop)
-
 class YG_EXPORT Node : public ::YGNode {
  private:
+  bool hasNewLayout_ : 1 = true;
+  bool isReferenceBaseline_ : 1 = false;
+  bool isDirty_ : 1 = false;
+  NodeType nodeType_ : bitCount<NodeType>() = NodeType::Default;
   void* context_ = nullptr;
-  NodeFlags flags_ = {};
   YGMeasureFunc measureFunc_ = {nullptr};
   YGBaselineFunc baselineFunc_ = {nullptr};
   YGPrintFunc printFunc_ = {nullptr};
@@ -92,11 +85,11 @@ class YG_EXPORT Node : public ::YGNode {
   void print();
 
   bool getHasNewLayout() const {
-    return flags_.hasNewLayout;
+    return hasNewLayout_;
   }
 
   NodeType getNodeType() const {
-    return flags_.nodeType;
+    return nodeType_;
   }
 
   bool hasMeasureFunc() const noexcept {
@@ -142,7 +135,7 @@ class YG_EXPORT Node : public ::YGNode {
   }
 
   bool isReferenceBaseline() const {
-    return flags_.isReferenceBaseline;
+    return isReferenceBaseline_;
   }
 
   // returns the Node that owns this Node. An owner is used to identify
@@ -175,7 +168,7 @@ class YG_EXPORT Node : public ::YGNode {
   }
 
   bool isDirty() const {
-    return flags_.isDirty;
+    return isDirty_;
   }
 
   std::array<YGValue, 2> getResolvedDimensions() const {
@@ -250,11 +243,11 @@ class YG_EXPORT Node : public ::YGNode {
   }
 
   void setHasNewLayout(bool hasNewLayout) {
-    flags_.hasNewLayout = hasNewLayout;
+    hasNewLayout_ = hasNewLayout;
   }
 
   void setNodeType(NodeType nodeType) {
-    flags_.nodeType = nodeType;
+    nodeType_ = nodeType;
   }
 
   void setMeasureFunc(YGMeasureFunc measureFunc);
@@ -280,7 +273,7 @@ class YG_EXPORT Node : public ::YGNode {
   }
 
   void setIsReferenceBaseline(bool isReferenceBaseline) {
-    flags_.isReferenceBaseline = isReferenceBaseline;
+    isReferenceBaseline_ = isReferenceBaseline;
   }
 
   void setOwner(Node* owner) {


### PR DESCRIPTION
Summary:
These were previously packed into structs to allow zero initializing all the flags at once without needing a ctor. C++ 20 has in-class member initializer support for bitfields, which makes these look more like normal member variables.

Setting enum values is a bit jank right now, due to relying on C enums which are efftively int32_t, along with GCC `-Wconversion` being a bit aggressive in needing to explicitly mask. I have some ideas to fix this later (e.g. using scoped enums internally).

Differential Revision: D49265967

