### PR TITLE
Descriptive error if building with too old C++ version

### DIFF
--- a/yoga/config/Config.h
+++ b/yoga/config/Config.h
@@ -10,9 +10,12 @@
 #include <bitset>
 
 #include <yoga/Yoga.h>
+#include <yoga/debug/CheckCppVersion.h>
 #include <yoga/enums/Errata.h>
 #include <yoga/enums/ExperimentalFeature.h>
 #include <yoga/enums/LogLevel.h>
+
+YG_CHECK_CPP_VERSION()
 
 // Tag struct used to form the opaque YGConfigRef for the public C API
 struct YGConfig {};

--- a/yoga/debug/CheckCppVersion.h
+++ b/yoga/debug/CheckCppVersion.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#define YG_CHECK_CPP_VERSION()
+#if (defined(_MSVC_LANG) && !(_MSVC_LANG > 201703L)) || \
+    (!defined(_MSVC_LANG) && defined(__cplusplus) && !(__cplusplus > 201703L))
+#error "This module must be compiled using '-std=c++20' or an equivalent."
+#else
+#endif

--- a/yoga/node/LayoutResults.h
+++ b/yoga/node/LayoutResults.h
@@ -10,9 +10,12 @@
 #include <array>
 
 #include <yoga/bits/NumericBitfield.h>
+#include <yoga/debug/CheckCppVersion.h>
 #include <yoga/enums/Direction.h>
 #include <yoga/node/CachedMeasurement.h>
 #include <yoga/numeric/FloatOptional.h>
+
+YG_CHECK_CPP_VERSION()
 
 namespace facebook::yoga {
 

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -14,6 +14,7 @@
 #include <yoga/Yoga.h>
 
 #include <yoga/config/Config.h>
+#include <yoga/debug/CheckCppVersion.h>
 #include <yoga/enums/Direction.h>
 #include <yoga/enums/Errata.h>
 #include <yoga/enums/MeasureMode.h>
@@ -21,6 +22,8 @@
 #include <yoga/node/LayoutResults.h>
 #include <yoga/style/CompactValue.h>
 #include <yoga/style/Style.h>
+
+YG_CHECK_CPP_VERSION()
 
 // Tag struct used to form the opaque YGNodeRef for the public C API
 struct YGNode {};

--- a/yoga/style/Style.h
+++ b/yoga/style/Style.h
@@ -15,6 +15,7 @@
 #include <yoga/Yoga.h>
 
 #include <yoga/bits/NumericBitfield.h>
+#include <yoga/debug/CheckCppVersion.h>
 #include <yoga/enums/Align.h>
 #include <yoga/enums/Direction.h>
 #include <yoga/enums/Display.h>
@@ -25,6 +26,8 @@
 #include <yoga/enums/Wrap.h>
 #include <yoga/numeric/FloatOptional.h>
 #include <yoga/style/CompactValue.h>
+
+YG_CHECK_CPP_VERSION()
 
 namespace facebook::yoga {
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/react-native/pull/39536

There are a couple cases where the C++ 20 deprecation will show up:

1. Third-paty code importing React Native renderer headers may need to update their build logic to build with C++ 20, since RN exports the Yoga private API (and is now targetting C++ 20 itself)

2. Yoga users previously building with an older version.

This adds a friendlier error message than a compile error on specific syntax. We allow any version after C++ 17 to be specified (e.g. 2a), since we are not using too many 20 features yet.

Reviewed By: cortinico

Differential Revision: D49414591


