### PR TITLE
Remove usage of Gutters arrays and YGGutter as index

### DIFF
--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -635,11 +635,11 @@ void YGNodeStyleSetGap(
     const YGGutter gutter,
     const float gapLength) {
   auto length = CompactValue::ofMaybe<YGUnitPoint>(gapLength);
-  updateIndexedStyleProp<MSVC_HINT(gap)>(node, &Style::gap, gutter, length);
+  updateIndexedStyleProp<&Style::gap, &Style::setGap>(node, gutter, length);
 }
 
 float YGNodeStyleGetGap(const YGNodeConstRef node, const YGGutter gutter) {
-  auto gapLength = resolveRef(node)->getStyle().gap()[gutter];
+  auto gapLength = resolveRef(node)->getStyle().gap(gutter);
   if (gapLength.isUndefined() || gapLength.isAuto()) {
     return YGUndefined;
   }

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -1215,7 +1215,7 @@ static void justifyMainAxis(
       node->getLeadingPaddingAndBorder(mainAxis, ownerWidth).unwrap();
   const float trailingPaddingAndBorderMain =
       node->getTrailingPaddingAndBorder(mainAxis, ownerWidth).unwrap();
-  const float gap = node->getGapForAxis(mainAxis, ownerWidth);
+  const float gap = node->getGapForAxis(mainAxis);
   // If we are using "at most" rules in the main axis, make sure that
   // remainingFreeSpace is 0 when min main dimension is not given
   if (measureModeMainDim == MeasureMode::AtMost &&
@@ -1666,8 +1666,8 @@ static void calculateLayoutImpl(
       generationCount);
 
   if (childCount > 1) {
-    totalMainDim += node->getGapForAxis(mainAxis, availableInnerCrossDim) *
-        static_cast<float>(childCount - 1);
+    totalMainDim +=
+        node->getGapForAxis(mainAxis) * static_cast<float>(childCount - 1);
   }
 
   const bool mainAxisOverflows =
@@ -1690,8 +1690,7 @@ static void calculateLayoutImpl(
   // Accumulated cross dimensions of all lines so far.
   float totalLineCrossDim = 0;
 
-  const float crossAxisGap =
-      node->getGapForAxis(crossAxis, availableInnerCrossDim);
+  const float crossAxisGap = node->getGapForAxis(crossAxis);
 
   // Max main dimension of all the lines.
   float maxLineMainDim = 0;

--- a/yoga/algorithm/FlexLine.cpp
+++ b/yoga/algorithm/FlexLine.cpp
@@ -34,7 +34,7 @@ FlexLine calculateFlexLine(
   const FlexDirection mainAxis = resolveDirection(
       node->getStyle().flexDirection(), node->resolveDirection(ownerDirection));
   const bool isNodeFlexWrap = node->getStyle().flexWrap() != Wrap::NoWrap;
-  const float gap = node->getGapForAxis(mainAxis, availableInnerWidth);
+  const float gap = node->getGapForAxis(mainAxis);
 
   // Add items to the current line until it's full or we run out of items.
   for (; endOfLineIndex < node->getChildren().size(); endOfLineIndex++) {

--- a/yoga/debug/NodeToString.cpp
+++ b/yoga/debug/NodeToString.cpp
@@ -180,17 +180,11 @@ void nodeToString(
     appendEdges(str, "padding", style.padding());
     appendEdges(str, "border", style.border());
 
-    if (yoga::Node::computeColumnGap(
-            style.gap(), CompactValue::ofUndefined()) !=
-        yoga::Node::computeColumnGap(
-            yoga::Node{}.getStyle().gap(), CompactValue::ofUndefined())) {
-      appendNumberIfNotUndefined(
-          str, "column-gap", style.gap()[YGGutterColumn]);
-    }
-    if (yoga::Node::computeRowGap(style.gap(), CompactValue::ofUndefined()) !=
-        yoga::Node::computeRowGap(
-            yoga::Node{}.getStyle().gap(), CompactValue::ofUndefined())) {
-      appendNumberIfNotUndefined(str, "row-gap", style.gap()[YGGutterRow]);
+    if (!style.gap(YGGutterAll).isUndefined()) {
+      appendNumberIfNotUndefined(str, "gap", style.gap(YGGutterAll));
+    } else {
+      appendNumberIfNotUndefined(str, "column-gap", style.gap(YGGutterColumn));
+      appendNumberIfNotUndefined(str, "row-gap", style.gap(YGGutterRow));
     }
 
     appendNumberIfNotAuto(str, "width", style.dimension(Dimension::Width));

--- a/yoga/node/Node.cpp
+++ b/yoga/node/Node.cpp
@@ -89,30 +89,6 @@ CompactValue Node::computeEdgeValueForColumn(
   }
 }
 
-CompactValue Node::computeRowGap(
-    const Style::Gutters& gutters,
-    CompactValue defaultValue) {
-  if (!gutters[YGGutterRow].isUndefined()) {
-    return gutters[YGGutterRow];
-  } else if (!gutters[YGGutterAll].isUndefined()) {
-    return gutters[YGGutterAll];
-  } else {
-    return defaultValue;
-  }
-}
-
-CompactValue Node::computeColumnGap(
-    const Style::Gutters& gutters,
-    CompactValue defaultValue) {
-  if (!gutters[YGGutterColumn].isUndefined()) {
-    return gutters[YGGutterColumn];
-  } else if (!gutters[YGGutterAll].isUndefined()) {
-    return gutters[YGGutterAll];
-  } else {
-    return defaultValue;
-  }
-}
-
 FloatOptional Node::getLeadingPosition(
     const FlexDirection axis,
     const float axisSize) const {
@@ -202,13 +178,12 @@ FloatOptional Node::getMarginForAxis(
   return getLeadingMargin(axis, widthSize) + getTrailingMargin(axis, widthSize);
 }
 
-float Node::getGapForAxis(const FlexDirection axis, const float widthSize)
-    const {
-  auto gap = isRow(axis)
-      ? computeColumnGap(style_.gap(), CompactValue::ofUndefined())
-      : computeRowGap(style_.gap(), CompactValue::ofUndefined());
-  auto resolvedGap = yoga::resolveValue(gap, widthSize);
-  return maxOrDefined(resolvedGap.unwrap(), 0);
+float Node::getGapForAxis(const FlexDirection axis) const {
+  auto gap = isRow(axis) ? style_.resolveColumnGap() : style_.resolveRowGap();
+  // TODO: Validate percentage gap, and expose ability to set percentage to
+  // public API
+  auto resolvedGap = yoga::resolveValue(gap, 0.0f /*ownerSize*/);
+  return maxOrDefined(resolvedGap.unwrap(), 0.0f);
 }
 
 YGSize Node::measure(

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -191,14 +191,6 @@ class YG_EXPORT Node : public ::YGNode {
       YGEdge edge,
       CompactValue defaultValue);
 
-  static CompactValue computeRowGap(
-      const Style::Gutters& gutters,
-      CompactValue defaultValue);
-
-  static CompactValue computeColumnGap(
-      const Style::Gutters& gutters,
-      CompactValue defaultValue);
-
   // Methods related to positions, margin, padding and border
   FloatOptional getLeadingPosition(
       const FlexDirection axis,
@@ -231,7 +223,7 @@ class YG_EXPORT Node : public ::YGNode {
   FloatOptional getMarginForAxis(
       const FlexDirection axis,
       const float widthSize) const;
-  float getGapForAxis(const FlexDirection axis, const float widthSize) const;
+  float getGapForAxis(const FlexDirection axis) const;
   // Setters
 
   void setContext(void* context) {

--- a/yoga/style/Style.h
+++ b/yoga/style/Style.h
@@ -274,11 +274,11 @@ class YG_EXPORT Style {
     return {*this};
   }
 
-  const Gutters& gap() const {
-    return gap_;
+  CompactValue gap(YGGutter gutter) const {
+    return gap_[gutter];
   }
-  IdxRef<YGGutter, &Style::gap_> gap() {
-    return {*this};
+  void setGap(YGGutter gutter, CompactValue value) {
+    gap_[gutter] = value;
   }
 
   CompactValue dimension(Dimension axis) const {
@@ -308,6 +308,22 @@ class YG_EXPORT Style {
   }
   Ref<FloatOptional, &Style::aspectRatio_> aspectRatio() {
     return {*this};
+  }
+
+  CompactValue resolveColumnGap() const {
+    if (!gap_[YGGutterColumn].isUndefined()) {
+      return gap_[YGGutterColumn];
+    } else {
+      return gap_[YGGutterAll];
+    }
+  }
+
+  CompactValue resolveRowGap() const {
+    if (!gap_[YGGutterRow].isUndefined()) {
+      return gap_[YGGutterRow];
+    } else {
+      return gap_[YGGutterAll];
+    }
   }
 
   bool operator==(const Style& other) const {


### PR DESCRIPTION
Summary:
Similar in vain to D49362819, we want to stop exposing pre-resolved CompactValue, and allow enum class usage without becoming annoying.

This also simplifies gap resolution a bit. I moved this to Style, to make it clear we aren't relying on any node state. I plan to do some similar cleanup for other resolution later.

Differential Revision: D49530923

