### PR TITLE
C++ style enums 17/N: Gutter

### DIFF
--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -635,11 +635,12 @@ void YGNodeStyleSetGap(
     const YGGutter gutter,
     const float gapLength) {
   auto length = CompactValue::ofMaybe<YGUnitPoint>(gapLength);
-  updateIndexedStyleProp<&Style::gap, &Style::setGap>(node, gutter, length);
+  updateIndexedStyleProp<&Style::gap, &Style::setGap>(
+      node, scopedEnum(gutter), length);
 }
 
 float YGNodeStyleGetGap(const YGNodeConstRef node, const YGGutter gutter) {
-  auto gapLength = resolveRef(node)->getStyle().gap(gutter);
+  auto gapLength = resolveRef(node)->getStyle().gap(scopedEnum(gutter));
   if (gapLength.isUndefined() || gapLength.isAuto()) {
     return YGUndefined;
   }

--- a/yoga/debug/NodeToString.cpp
+++ b/yoga/debug/NodeToString.cpp
@@ -177,11 +177,11 @@ void nodeToString(
     appendEdges(str, "padding", style.padding());
     appendEdges(str, "border", style.border());
 
-    if (!style.gap(YGGutterAll).isUndefined()) {
-      appendNumberIfNotUndefined(str, "gap", style.gap(YGGutterAll));
+    if (!style.gap(Gutter::All).isUndefined()) {
+      appendNumberIfNotUndefined(str, "gap", style.gap(Gutter::All));
     } else {
-      appendNumberIfNotUndefined(str, "column-gap", style.gap(YGGutterColumn));
-      appendNumberIfNotUndefined(str, "row-gap", style.gap(YGGutterRow));
+      appendNumberIfNotUndefined(str, "column-gap", style.gap(Gutter::Column));
+      appendNumberIfNotUndefined(str, "row-gap", style.gap(Gutter::Row));
     }
 
     appendNumberIfNotAuto(str, "width", style.dimension(Dimension::Width));

--- a/yoga/style/Style.h
+++ b/yoga/style/Style.h
@@ -20,6 +20,7 @@
 #include <yoga/enums/Direction.h>
 #include <yoga/enums/Display.h>
 #include <yoga/enums/FlexDirection.h>
+#include <yoga/enums/Gutter.h>
 #include <yoga/enums/Justify.h>
 #include <yoga/enums/Overflow.h>
 #include <yoga/enums/PositionType.h>
@@ -36,7 +37,7 @@ class YG_EXPORT Style {
  public:
   using Dimensions = Values<Dimension>;
   using Edges = Values<YGEdge>;
-  using Gutters = Values<YGGutter>;
+  using Gutters = Values<Gutter>;
 
   static constexpr float DefaultFlexGrow = 0.0f;
   static constexpr float DefaultFlexShrink = 0.0f;
@@ -274,11 +275,11 @@ class YG_EXPORT Style {
     return {*this};
   }
 
-  CompactValue gap(YGGutter gutter) const {
-    return gap_[gutter];
+  CompactValue gap(Gutter gutter) const {
+    return gap_[yoga::to_underlying(gutter)];
   }
-  void setGap(YGGutter gutter, CompactValue value) {
-    gap_[gutter] = value;
+  void setGap(Gutter gutter, CompactValue value) {
+    gap_[yoga::to_underlying(gutter)] = value;
   }
 
   CompactValue dimension(Dimension axis) const {
@@ -311,18 +312,18 @@ class YG_EXPORT Style {
   }
 
   CompactValue resolveColumnGap() const {
-    if (!gap_[YGGutterColumn].isUndefined()) {
-      return gap_[YGGutterColumn];
+    if (!gap_[yoga::to_underlying(Gutter::Column)].isUndefined()) {
+      return gap_[yoga::to_underlying(Gutter::Column)];
     } else {
-      return gap_[YGGutterAll];
+      return gap_[yoga::to_underlying(Gutter::All)];
     }
   }
 
   CompactValue resolveRowGap() const {
-    if (!gap_[YGGutterRow].isUndefined()) {
-      return gap_[YGGutterRow];
+    if (!gap_[yoga::to_underlying(Gutter::Row)].isUndefined()) {
+      return gap_[yoga::to_underlying(Gutter::Row)];
     } else {
-      return gap_[YGGutterAll];
+      return gap_[yoga::to_underlying(Gutter::All)];
     }
   }
 


### PR DESCRIPTION
Summary:
Replaces internal usages of YGGutter with Gutter.

Changelog: [Internal]

Differential Revision: D49532100

