### PR TITLE
FloatOptional GCC build fix and more constexpr

### DIFF
--- a/tests/FloatOptionalTest.cpp
+++ b/tests/FloatOptionalTest.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cmath>
+
 #include <gtest/gtest.h>
 
 #include <yoga/YGValue.h>

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -1223,7 +1223,7 @@ static void justifyMainAxis(
       const float occupiedSpaceByChildNodes =
           availableInnerMainDim - flexLine.layout.remainingFreeSpace;
       flexLine.layout.remainingFreeSpace = yoga::maxOrDefined(
-          0, minAvailableMainDim - occupiedSpaceByChildNodes);
+          0.0f, minAvailableMainDim - occupiedSpaceByChildNodes);
     } else {
       flexLine.layout.remainingFreeSpace = 0;
     }

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -1260,7 +1260,7 @@ static void justifyMainAxis(
       case Justify::SpaceBetween:
         if (flexLine.itemsInFlow.size() > 1) {
           betweenMainDim +=
-              yoga::maxOrDefined(flexLine.layout.remainingFreeSpace, 0) /
+              yoga::maxOrDefined(flexLine.layout.remainingFreeSpace, 0.0f) /
               static_cast<float>(flexLine.itemsInFlow.size() - 1);
         }
         break;

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -563,10 +563,10 @@ static void measureNodeWithMeasureFunc(
   // We want to make sure we don't call measure with negative size
   const float innerWidth = yoga::isUndefined(availableWidth)
       ? availableWidth
-      : yoga::maxOrDefined(0, availableWidth - paddingAndBorderAxisRow);
+      : yoga::maxOrDefined(0.0f, availableWidth - paddingAndBorderAxisRow);
   const float innerHeight = yoga::isUndefined(availableHeight)
       ? availableHeight
-      : yoga::maxOrDefined(0, availableHeight - paddingAndBorderAxisColumn);
+      : yoga::maxOrDefined(0.0f, availableHeight - paddingAndBorderAxisColumn);
 
   if (widthMeasureMode == MeasureMode::Exactly &&
       heightMeasureMode == MeasureMode::Exactly) {

--- a/yoga/numeric/Comparison.h
+++ b/yoga/numeric/Comparison.h
@@ -36,16 +36,6 @@ inline float minOrDefined(const float a, const float b) {
   return yoga::isUndefined(a) ? b : a;
 }
 
-inline FloatOptional maxOrDefined(FloatOptional op1, FloatOptional op2) {
-  if (op1 >= op2) {
-    return op1;
-  }
-  if (op2 > op1) {
-    return op2;
-  }
-  return op1.isUndefined() ? op2 : op1;
-}
-
 // Custom equality functions using a hardcoded epsilon of 0.0001f, or returning
 // true if both floats are NaN.
 inline bool inexactEquals(const float a, const float b) {
@@ -60,10 +50,6 @@ inline bool inexactEquals(const double a, const double b) {
     return fabs(a - b) < 0.0001;
   }
   return yoga::isUndefined(a) && yoga::isUndefined(b);
-}
-
-inline bool inexactEquals(const FloatOptional a, const FloatOptional b) {
-  return inexactEquals(a.unwrap(), b.unwrap());
 }
 
 inline bool inexactEquals(const YGValue& a, const YGValue& b) {

--- a/yoga/numeric/Comparison.h
+++ b/yoga/numeric/Comparison.h
@@ -16,7 +16,7 @@
 namespace facebook::yoga {
 
 constexpr bool isUndefined(std::floating_point auto value) {
-  // Can be replaced by constexpr std::isnan in C++ 23
+  // is NaN
   return value != value;
 }
 

--- a/yoga/numeric/Comparison.h
+++ b/yoga/numeric/Comparison.h
@@ -8,15 +8,16 @@
 #pragma once
 
 #include <array>
+#include <concepts>
 
 #include <yoga/Yoga.h>
 #include <yoga/numeric/FloatOptional.h>
 
 namespace facebook::yoga {
 
-template <typename FloatT>
-inline bool isUndefined(FloatT value) {
-  return std::isnan(value);
+constexpr bool isUndefined(std::floating_point auto value) {
+  // Can be replaced by constexpr std::isnan in C++ 23
+  return value != value;
 }
 
 inline float maxOrDefined(const float a, const float b) {

--- a/yoga/numeric/Comparison.h
+++ b/yoga/numeric/Comparison.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <array>
+#include <cmath>
 #include <concepts>
 
 #include <yoga/Yoga.h>

--- a/yoga/numeric/Comparison.h
+++ b/yoga/numeric/Comparison.h
@@ -10,28 +10,23 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
-#include <concepts>
 
 #include <yoga/Yoga.h>
 
 namespace facebook::yoga {
 
-constexpr bool isUndefined(std::floating_point auto value) {
+constexpr bool isUndefined(auto value) {
   return value != value;
 }
 
-constexpr float maxOrDefined(
-    std::floating_point auto a,
-    std::floating_point auto b) {
+constexpr float maxOrDefined(auto a, auto b) {
   if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
     return std::max(a, b);
   }
   return yoga::isUndefined(a) ? b : a;
 }
 
-constexpr float minOrDefined(
-    std::floating_point auto a,
-    std::floating_point auto b) {
+constexpr float minOrDefined(auto a, auto b) {
   if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
     return std::min(a, b);
   }

--- a/yoga/numeric/Comparison.h
+++ b/yoga/numeric/Comparison.h
@@ -12,7 +12,6 @@
 #include <concepts>
 
 #include <yoga/Yoga.h>
-#include <yoga/numeric/FloatOptional.h>
 
 namespace facebook::yoga {
 

--- a/yoga/numeric/Comparison.h
+++ b/yoga/numeric/Comparison.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <concepts>
@@ -16,20 +17,23 @@
 namespace facebook::yoga {
 
 constexpr bool isUndefined(std::floating_point auto value) {
-  // is NaN
   return value != value;
 }
 
-inline float maxOrDefined(const float a, const float b) {
+constexpr float maxOrDefined(
+    std::floating_point auto a,
+    std::floating_point auto b) {
   if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
-    return fmaxf(a, b);
+    return std::max(a, b);
   }
   return yoga::isUndefined(a) ? b : a;
 }
 
-inline float minOrDefined(const float a, const float b) {
+constexpr float minOrDefined(
+    std::floating_point auto a,
+    std::floating_point auto b) {
   if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
-    return fminf(a, b);
+    return std::min(a, b);
   }
 
   return yoga::isUndefined(a) ? b : a;
@@ -37,16 +41,16 @@ inline float minOrDefined(const float a, const float b) {
 
 // Custom equality functions using a hardcoded epsilon of 0.0001f, or returning
 // true if both floats are NaN.
-inline bool inexactEquals(const float a, const float b) {
+inline bool inexactEquals(float a, float b) {
   if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
-    return fabs(a - b) < 0.0001f;
+    return std::abs(a - b) < 0.0001f;
   }
   return yoga::isUndefined(a) && yoga::isUndefined(b);
 }
 
-inline bool inexactEquals(const double a, const double b) {
+inline bool inexactEquals(double a, double b) {
   if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
-    return fabs(a - b) < 0.0001;
+    return std::abs(a - b) < 0.0001;
   }
   return yoga::isUndefined(a) && yoga::isUndefined(b);
 }

--- a/yoga/numeric/FloatOptional.h
+++ b/yoga/numeric/FloatOptional.h
@@ -79,11 +79,11 @@ constexpr bool operator<=(FloatOptional lhs, FloatOptional rhs) {
 }
 
 constexpr FloatOptional maxOrDefined(FloatOptional op1, FloatOptional op2) {
-  return maxOrDefined(op1.unwrap(), op2.unwrap());
+  return yoga::maxOrDefined(op1.unwrap(), op2.unwrap());
 }
 
 constexpr bool inexactEquals(const FloatOptional a, const FloatOptional b) {
-  return inexactEquals(a.unwrap(), b.unwrap());
+  return yoga::inexactEquals(a.unwrap(), b.unwrap());
 }
 
 } // namespace facebook::yoga

--- a/yoga/numeric/FloatOptional.h
+++ b/yoga/numeric/FloatOptional.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <yoga/numeric/Comparison.h>
 #include <limits>
+#include <yoga/numeric/Comparison.h>
 
 namespace facebook::yoga {
 

--- a/yoga/numeric/FloatOptional.h
+++ b/yoga/numeric/FloatOptional.h
@@ -79,7 +79,7 @@ constexpr bool operator<=(FloatOptional lhs, FloatOptional rhs) {
 }
 
 constexpr FloatOptional maxOrDefined(FloatOptional op1, FloatOptional op2) {
-  return yoga::maxOrDefined(op1.unwrap(), op2.unwrap());
+  return FloatOptional{yoga::maxOrDefined(op1.unwrap(), op2.unwrap())};
 }
 
 constexpr bool inexactEquals(const FloatOptional a, const FloatOptional b) {

--- a/yoga/numeric/FloatOptional.h
+++ b/yoga/numeric/FloatOptional.h
@@ -78,11 +78,11 @@ constexpr bool operator<=(FloatOptional lhs, FloatOptional rhs) {
   return lhs < rhs || lhs == rhs;
 }
 
-constexpr FloatOptional maxOrDefined(FloatOptional op1, FloatOptional op2) {
-  return FloatOptional{yoga::maxOrDefined(op1.unwrap(), op2.unwrap())};
+constexpr FloatOptional maxOrDefined(FloatOptional a, FloatOptional b) {
+  return FloatOptional{yoga::maxOrDefined(a.unwrap(), b.unwrap())};
 }
 
-constexpr bool inexactEquals(const FloatOptional a, const FloatOptional b) {
+constexpr bool inexactEquals(FloatOptional a, FloatOptional b) {
   return yoga::inexactEquals(a.unwrap(), b.unwrap());
 }
 

--- a/yoga/numeric/FloatOptional.h
+++ b/yoga/numeric/FloatOptional.h
@@ -36,53 +36,53 @@ struct FloatOptional {
 
 // operators take FloatOptional by value, as it is a 32bit value
 
-inline bool operator==(FloatOptional lhs, FloatOptional rhs) {
+constexpr bool operator==(FloatOptional lhs, FloatOptional rhs) {
   return lhs.unwrap() == rhs.unwrap() ||
       (lhs.isUndefined() && rhs.isUndefined());
 }
-inline bool operator!=(FloatOptional lhs, FloatOptional rhs) {
+constexpr bool operator!=(FloatOptional lhs, FloatOptional rhs) {
   return !(lhs == rhs);
 }
 
-inline bool operator==(FloatOptional lhs, float rhs) {
+constexpr bool operator==(FloatOptional lhs, float rhs) {
   return lhs == FloatOptional{rhs};
 }
-inline bool operator!=(FloatOptional lhs, float rhs) {
+constexpr bool operator!=(FloatOptional lhs, float rhs) {
   return !(lhs == rhs);
 }
 
-inline bool operator==(float lhs, FloatOptional rhs) {
+constexpr bool operator==(float lhs, FloatOptional rhs) {
   return rhs == lhs;
 }
-inline bool operator!=(float lhs, FloatOptional rhs) {
+constexpr bool operator!=(float lhs, FloatOptional rhs) {
   return !(lhs == rhs);
 }
 
-inline FloatOptional operator+(FloatOptional lhs, FloatOptional rhs) {
+constexpr FloatOptional operator+(FloatOptional lhs, FloatOptional rhs) {
   return FloatOptional{lhs.unwrap() + rhs.unwrap()};
 }
 
-inline bool operator>(FloatOptional lhs, FloatOptional rhs) {
+constexpr bool operator>(FloatOptional lhs, FloatOptional rhs) {
   return lhs.unwrap() > rhs.unwrap();
 }
 
-inline bool operator<(FloatOptional lhs, FloatOptional rhs) {
+constexpr bool operator<(FloatOptional lhs, FloatOptional rhs) {
   return lhs.unwrap() < rhs.unwrap();
 }
 
-inline bool operator>=(FloatOptional lhs, FloatOptional rhs) {
+constexpr bool operator>=(FloatOptional lhs, FloatOptional rhs) {
   return lhs > rhs || lhs == rhs;
 }
 
-inline bool operator<=(FloatOptional lhs, FloatOptional rhs) {
+constexpr bool operator<=(FloatOptional lhs, FloatOptional rhs) {
   return lhs < rhs || lhs == rhs;
 }
 
-inline FloatOptional maxOrDefined(FloatOptional op1, FloatOptional op2) {
+constexpr FloatOptional maxOrDefined(FloatOptional op1, FloatOptional op2) {
   return maxOrDefined(op1.unwrap(), op2.unwrap());
 }
 
-inline bool inexactEquals(const FloatOptional a, const FloatOptional b) {
+constexpr bool inexactEquals(const FloatOptional a, const FloatOptional b) {
   return inexactEquals(a.unwrap(), b.unwrap());
 }
 

--- a/yoga/numeric/FloatOptional.h
+++ b/yoga/numeric/FloatOptional.h
@@ -29,7 +29,7 @@ struct FloatOptional {
     return isUndefined() ? defaultValue : value_;
   }
 
-  bool isUndefined() const {
+  constexpr bool isUndefined() const {
     return std::isnan(value_);
   }
 };

--- a/yoga/numeric/FloatOptional.h
+++ b/yoga/numeric/FloatOptional.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cmath>
+#include <yoga/numeric/Comparison.h>
 #include <limits>
 
 namespace facebook::yoga {
@@ -30,7 +30,7 @@ struct FloatOptional {
   }
 
   constexpr bool isUndefined() const {
-    return std::isnan(value_);
+    return yoga::isUndefined(value);
   }
 };
 

--- a/yoga/numeric/FloatOptional.h
+++ b/yoga/numeric/FloatOptional.h
@@ -78,12 +78,12 @@ constexpr bool operator<=(FloatOptional lhs, FloatOptional rhs) {
   return lhs < rhs || lhs == rhs;
 }
 
-constexpr FloatOptional maxOrDefined(FloatOptional a, FloatOptional b) {
-  return FloatOptional{yoga::maxOrDefined(a.unwrap(), b.unwrap())};
+constexpr FloatOptional maxOrDefined(FloatOptional lhs, FloatOptional rhs) {
+  return FloatOptional{yoga::maxOrDefined(lhs.unwrap(), rhs.unwrap())};
 }
 
-constexpr bool inexactEquals(FloatOptional a, FloatOptional b) {
-  return yoga::inexactEquals(a.unwrap(), b.unwrap());
+constexpr bool inexactEquals(FloatOptional lhs, FloatOptional rhs) {
+  return yoga::inexactEquals(lhs.unwrap(), rhs.unwrap());
 }
 
 } // namespace facebook::yoga

--- a/yoga/numeric/FloatOptional.h
+++ b/yoga/numeric/FloatOptional.h
@@ -78,4 +78,12 @@ inline bool operator<=(FloatOptional lhs, FloatOptional rhs) {
   return lhs < rhs || lhs == rhs;
 }
 
+inline FloatOptional maxOrDefined(FloatOptional op1, FloatOptional op2) {
+  return maxOrDefined(op1.unwrap(), op2.unwrap());
+}
+
+inline bool inexactEquals(const FloatOptional a, const FloatOptional b) {
+  return inexactEquals(a.unwrap(), b.unwrap());
+}
+
 } // namespace facebook::yoga

--- a/yoga/numeric/FloatOptional.h
+++ b/yoga/numeric/FloatOptional.h
@@ -30,7 +30,7 @@ struct FloatOptional {
   }
 
   constexpr bool isUndefined() const {
-    return yoga::isUndefined(value);
+    return yoga::isUndefined(value_);
   }
 };
 

--- a/yoga/numeric/FloatOptional.h
+++ b/yoga/numeric/FloatOptional.h
@@ -82,7 +82,7 @@ constexpr FloatOptional maxOrDefined(FloatOptional lhs, FloatOptional rhs) {
   return FloatOptional{yoga::maxOrDefined(lhs.unwrap(), rhs.unwrap())};
 }
 
-constexpr bool inexactEquals(FloatOptional lhs, FloatOptional rhs) {
+inline bool inexactEquals(FloatOptional lhs, FloatOptional rhs) {
   return yoga::inexactEquals(lhs.unwrap(), rhs.unwrap());
 }
 


### PR DESCRIPTION
GCC flags that is is not declared `constexpr` but that `unwrapOrDefault()` is. `std::isnan` is not constexpr until C++ 23 (because we cannot have nice things), so I made `yoga::isUndefined()` constexpr, using the same code `std::isnan()` boils down to. I then made `FloatOptional` depend on `Comparison.h` (instead of the other way around), so we can use it.