### PR TITLE
Try using modern Android libc++ in Yoga and React Native

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@
  */
 
 plugins {
-    id("com.android.library") version "8.1.1" apply false
-    id("com.android.application") version "8.1.1" apply false
+    id("com.android.library") version "8.2.0-beta06" apply false
+    id("com.android.application") version "8.2.0-beta06" apply false
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -23,7 +23,7 @@ android {
   namespace = "com.facebook.yoga"
   compileSdk = 34
   buildToolsVersion = "34.0.0"
-  ndkVersion = "25.1.8937393"
+  ndkVersion = "26.0.10792818"
 
   defaultConfig {
     minSdk = 21


### PR DESCRIPTION
Summary:
Android NDK 25 uses a version of libc++ that is more than three years old, missing a lot of basic features of C++ 20. This is rectified in NDK 26 (latest LTS NDK), which brings us up to date with latest Clang, and later NDK versions will now also bump libc++ as part of bumping LLVM/Clang.

This requires an beta AGP version, which is... spooky, and we would need to update that before shipping RN 0.74/Yoga 3.0. It does bring us closer to what we want to ship then however.

Differential Revision: D49895949


