### PR TITLE
Add errata for fix to marginStart/End for row-reverse flex direction

### DIFF
--- a/enums.py
+++ b/enums.py
@@ -67,6 +67,8 @@ ENUMS = {
         # Allows main-axis flex basis to be stretched without flexGrow being
         # set (previously referred to as "UseLegacyStretchBehaviour")
         ("StretchFlexBasis", 1 << 0),
+        # Solely uses the flex-direction to determine starting and ending edges
+        ("StartingEndingEdgeFromFlexDirection", 1 << 1),
         # Enable all incorrect behavior (preserve compatibility)
         ("All", 0x7FFFFFFF),
         # Enable all errata except for "StretchFlexBasis" (Defaults behavior

--- a/java/com/facebook/yoga/YogaErrata.java
+++ b/java/com/facebook/yoga/YogaErrata.java
@@ -12,6 +12,7 @@ package com.facebook.yoga;
 public enum YogaErrata {
   NONE(0),
   STRETCH_FLEX_BASIS(1),
+  STARTING_ENDING_EDGE_FROM_FLEX_DIRECTION(2),
   ALL(2147483647),
   CLASSIC(2147483646);
 
@@ -29,6 +30,7 @@ public enum YogaErrata {
     switch (value) {
       case 0: return NONE;
       case 1: return STRETCH_FLEX_BASIS;
+      case 2: return STARTING_ENDING_EDGE_FROM_FLEX_DIRECTION;
       case 2147483647: return ALL;
       case 2147483646: return CLASSIC;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);

--- a/javascript/src/generated/YGEnums.ts
+++ b/javascript/src/generated/YGEnums.ts
@@ -49,6 +49,7 @@ export enum Edge {
 export enum Errata {
   None = 0,
   StretchFlexBasis = 1,
+  StartingEndingEdgeFromFlexDirection = 2,
   All = 2147483647,
   Classic = 2147483646,
 }
@@ -158,6 +159,7 @@ const constants = {
   EDGE_ALL: Edge.All,
   ERRATA_NONE: Errata.None,
   ERRATA_STRETCH_FLEX_BASIS: Errata.StretchFlexBasis,
+  ERRATA_STARTING_ENDING_EDGE_FROM_FLEX_DIRECTION: Errata.StartingEndingEdgeFromFlexDirection,
   ERRATA_ALL: Errata.All,
   ERRATA_CLASSIC: Errata.Classic,
   EXPERIMENTAL_FEATURE_WEB_FLEX_BASIS: ExperimentalFeature.WebFlexBasis,

--- a/yoga/YGEnums.cpp
+++ b/yoga/YGEnums.cpp
@@ -93,6 +93,8 @@ const char* YGErrataToString(const YGErrata value) {
       return "none";
     case YGErrataStretchFlexBasis:
       return "stretch-flex-basis";
+    case YGErrataStartingEndingEdgeFromFlexDirection:
+      return "starting-ending-edge-from-flex-direction";
     case YGErrataAll:
       return "all";
     case YGErrataClassic:

--- a/yoga/YGEnums.h
+++ b/yoga/YGEnums.h
@@ -55,6 +55,7 @@ YG_ENUM_DECL(
     YGErrata,
     YGErrataNone = 0,
     YGErrataStretchFlexBasis = 1,
+    YGErrataStartingEndingEdgeFromFlexDirection = 2,
     YGErrataAll = 2147483647,
     YGErrataClassic = 2147483646)
 YG_DEFINE_ENUM_FLAG_OPERATORS(YGErrata)

--- a/yoga/enums/Errata.h
+++ b/yoga/enums/Errata.h
@@ -18,6 +18,7 @@ namespace facebook::yoga {
 enum class Errata : uint32_t {
   None = YGErrataNone,
   StretchFlexBasis = YGErrataStretchFlexBasis,
+  StartingEndingEdgeFromFlexDirection = YGErrataStartingEndingEdgeFromFlexDirection,
   All = YGErrataAll,
   Classic = YGErrataClassic,
 };
@@ -26,12 +27,12 @@ YG_DEFINE_ENUM_FLAG_OPERATORS(Errata)
 
 template <>
 constexpr inline int32_t ordinalCount<Errata>() {
-  return 4;
+  return 5;
 } 
 
 template <>
 constexpr inline int32_t bitCount<Errata>() {
-  return 2;
+  return 3;
 } 
 
 constexpr inline Errata scopedEnum(YGErrata unscoped) {


### PR DESCRIPTION
Summary:
This stack is ultimately aiming to solve https://github.com/facebook/yoga/issues/1208

This adds an value to the Errata enum. I will use this to gate this fix as there is potential for users to rely on this bug or have a hack in place to fix it and this would be a breaking change.

Differential Revision: D50145273


