### PR TITLE
Fix issue where marginStart and marginEnd were not working with rowReverse flex direction

### DIFF
--- a/enums.py
+++ b/enums.py
@@ -67,6 +67,8 @@ ENUMS = {
         # Allows main-axis flex basis to be stretched without flexGrow being
         # set (previously referred to as "UseLegacyStretchBehaviour")
         ("StretchFlexBasis", 1 << 0),
+        # Solely uses the flex-direction to determine starting and ending edges
+        ("StartingEndingEdgeFromFlexDirection", 1 << 1),
         # Enable all incorrect behavior (preserve compatibility)
         ("All", 0x7FFFFFFF),
         # Enable all errata except for "StretchFlexBasis" (Defaults behavior

--- a/java/com/facebook/yoga/YogaErrata.java
+++ b/java/com/facebook/yoga/YogaErrata.java
@@ -12,6 +12,7 @@ package com.facebook.yoga;
 public enum YogaErrata {
   NONE(0),
   STRETCH_FLEX_BASIS(1),
+  STARTING_ENDING_EDGE_FROM_FLEX_DIRECTION(2),
   ALL(2147483647),
   CLASSIC(2147483646);
 
@@ -29,6 +30,7 @@ public enum YogaErrata {
     switch (value) {
       case 0: return NONE;
       case 1: return STRETCH_FLEX_BASIS;
+      case 2: return STARTING_ENDING_EDGE_FROM_FLEX_DIRECTION;
       case 2147483647: return ALL;
       case 2147483646: return CLASSIC;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);

--- a/javascript/src/generated/YGEnums.ts
+++ b/javascript/src/generated/YGEnums.ts
@@ -49,6 +49,7 @@ export enum Edge {
 export enum Errata {
   None = 0,
   StretchFlexBasis = 1,
+  StartingEndingEdgeFromFlexDirection = 2,
   All = 2147483647,
   Classic = 2147483646,
 }
@@ -158,6 +159,7 @@ const constants = {
   EDGE_ALL: Edge.All,
   ERRATA_NONE: Errata.None,
   ERRATA_STRETCH_FLEX_BASIS: Errata.StretchFlexBasis,
+  ERRATA_STARTING_ENDING_EDGE_FROM_FLEX_DIRECTION: Errata.StartingEndingEdgeFromFlexDirection,
   ERRATA_ALL: Errata.All,
   ERRATA_CLASSIC: Errata.Classic,
   EXPERIMENTAL_FEATURE_WEB_FLEX_BASIS: ExperimentalFeature.WebFlexBasis,

--- a/yoga/YGEnums.cpp
+++ b/yoga/YGEnums.cpp
@@ -93,6 +93,8 @@ const char* YGErrataToString(const YGErrata value) {
       return "none";
     case YGErrataStretchFlexBasis:
       return "stretch-flex-basis";
+    case YGErrataStartingEndingEdgeFromFlexDirection:
+      return "starting-ending-edge-from-flex-direction";
     case YGErrataAll:
       return "all";
     case YGErrataClassic:

--- a/yoga/YGEnums.h
+++ b/yoga/YGEnums.h
@@ -55,6 +55,7 @@ YG_ENUM_DECL(
     YGErrata,
     YGErrataNone = 0,
     YGErrataStretchFlexBasis = 1,
+    YGErrataStartingEndingEdgeFromFlexDirection = 2,
     YGErrataAll = 2147483647,
     YGErrataClassic = 2147483646)
 YG_DEFINE_ENUM_FLAG_OPERATORS(YGErrata)

--- a/yoga/algorithm/FlexDirection.h
+++ b/yoga/algorithm/FlexDirection.h
@@ -77,6 +77,26 @@ inline YGEdge trailingEdge(const FlexDirection flexDirection) {
   fatalWithMessage("Invalid FlexDirection");
 }
 
+inline YGEdge leadingLayoutEdge(
+    const FlexDirection flexDirection,
+    const Direction direction) {
+  if (isRow(flexDirection)) {
+    return direction == Direction::RTL ? YGEdgeRight : YGEdgeLeft;
+  }
+
+  return YGEdgeTop;
+}
+
+inline YGEdge trailingLayoutEdge(
+    const FlexDirection flexDirection,
+    const Direction direction) {
+  if (isRow(flexDirection)) {
+    return direction == Direction::RTL ? YGEdgeLeft : YGEdgeRight;
+  }
+
+  return YGEdgeBottom;
+}
+
 inline Dimension dimension(const FlexDirection flexDirection) {
   switch (flexDirection) {
     case FlexDirection::Column:

--- a/yoga/enums/Errata.h
+++ b/yoga/enums/Errata.h
@@ -18,6 +18,7 @@ namespace facebook::yoga {
 enum class Errata : uint32_t {
   None = YGErrataNone,
   StretchFlexBasis = YGErrataStretchFlexBasis,
+  StartingEndingEdgeFromFlexDirection = YGErrataStartingEndingEdgeFromFlexDirection,
   All = YGErrataAll,
   Classic = YGErrataClassic,
 };
@@ -26,12 +27,12 @@ YG_DEFINE_ENUM_FLAG_OPERATORS(Errata)
 
 template <>
 constexpr inline int32_t ordinalCount<Errata>() {
-  return 4;
+  return 5;
 } 
 
 template <>
 constexpr inline int32_t bitCount<Errata>() {
-  return 2;
+  return 3;
 } 
 
 constexpr inline Errata scopedEnum(YGErrata unscoped) {

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -50,6 +50,13 @@ class YG_EXPORT Node : public ::YGNode {
 
   float relativePosition(FlexDirection axis, const float axisSize) const;
 
+  YGEdge getLeadingLayoutEdgeUsingErrata(
+      FlexDirection flexDirection,
+      Direction direction) const;
+  YGEdge getTrailingLayoutEdgeUsingErrata(
+      FlexDirection flexDirection,
+      Direction direction) const;
+
   void useWebDefaults() {
     style_.flexDirection() = FlexDirection::Row;
     style_.alignContent() = Align::Stretch;
@@ -193,8 +200,14 @@ class YG_EXPORT Node : public ::YGNode {
   bool isTrailingPosDefined(FlexDirection axis) const;
   float getLeadingPosition(FlexDirection axis, float axisSize) const;
   float getTrailingPosition(FlexDirection axis, float axisSize) const;
-  float getLeadingMargin(FlexDirection axis, float widthSize) const;
-  float getTrailingMargin(FlexDirection axis, float widthSize) const;
+  float getLeadingMargin(
+      FlexDirection axis,
+      Direction direction,
+      float widthSize) const;
+  float getTrailingMargin(
+      FlexDirection axis,
+      Direction direction,
+      float widthSize) const;
   float getLeadingBorder(FlexDirection flexDirection) const;
   float getTrailingBorder(FlexDirection flexDirection) const;
   float getLeadingPadding(FlexDirection axis, float widthSize) const;


### PR DESCRIPTION
Summary:
This stack is ultimately aiming to solve https://github.com/facebook/yoga/issues/1208

**The problem**
Turns out that we do not even check direction when determining which edge is the leading (start) and trailing (end) edges. This is not how web does it as the start/end is based on the writing direction NOT the flex direction: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox#start_and_end_lines. While web does not have marginStart and marginEnd, they do have margin-inline-start/end which relies on the writing mode to determine the "start"/"end": https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start.

This means that if you do something like
```
export default function Playground(props: Props): React.Node {
  return (
    <View style={styles.container}>
      <View style={styles.item} />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    marginEnd: 100,
    flexDirection: 'row-reverse',
    backgroundColor: 'red',
    display: 'flex',
    width: 100,
    height: 100,
  },
  item: {
    backgroundColor: 'blue',
    width: 10,
  },
});
```

You get  {F1116264350}
As you can see the margin gets applied to the left edge even thought the direction is ltr and it should be applied to the right edge.

**The solution**
I ended up fixing this by creating a new `leadingLayoutEdge` and `trailingLayoutEdge` function that take the flex direction as well as the direction. Based on the errata, the a few functions will use these new functions to determine which `YGEdge` is the starting/ending.

You might be wondering why I did not put this logic inside of `leadingEdge(flexDirection)` / `trailingEdge(flexDirection)` since other areas could potentially have the same bug like `getLeadingPadding`. These functions are a bit overloaded and there are cases where we actually want to use the flexDirection to get the edge in question. For example, many of the calls to `setLayoutPosition` in `CalculateLayout.cpp` call `leadingEdge()` / `trailingEdge()` to set the proper position for cases like row-reverse where items need to line up in a different direction.

Differential Revision: D50140503

