### PR TITLE
Support "align-content: space-evenly"

### DIFF
--- a/enums.py
+++ b/enums.py
@@ -29,6 +29,7 @@ ENUMS = {
         "Baseline",
         "SpaceBetween",
         "SpaceAround",
+        "SpaceEvenly",
     ],
     "PositionType": ["Static", "Relative", "Absolute"],
     "Display": ["Flex", "None"],

--- a/gentest/fixtures/YGAlignContentTest.html
+++ b/gentest/fixtures/YGAlignContentTest.html
@@ -1,9 +1,38 @@
-<div id="align_content_flex_start" style="width: 130px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: flex-start;">
+<!-- ALIGN CONTENT: FLEX-START -->
+
+<div id="align_content_flex_start_nowrap" style="width: 140px; height: 120px; flex-direction: row; align-content: flex-start;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<div id="align_content_flex_start_wrap" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: flex-start;">
   <div style="width: 50px; height: 10px;"></div>
   <div style="width: 50px; height: 10px;"></div>
   <div style="width: 50px; height: 10px;"></div>
   <div style="width: 50px; height: 10px;"></div>
   <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<!-- This tests the case where `flex-wrap: wrap` but the content does not actually wrap -->
+<div id="align_content_flex_start_wrap_singleline" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: flex-start;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<div id="align_content_flex_start_wrapped_negative_space" style="display: flex; flex-direction: column; width: 320px; height: 320px; border-width: 60px;">
+  <div style="display: flex; flex-direction: row; flex-wrap: wrap; align-content: flex-start; justify-content: center; height: 10px;">
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+  </div>
+</div>
+
+<div id="align_content_flex_start_wrapped_negative_space_gap" style="display: flex; flex-direction: column; width: 320px; height: 320px; border-width: 60px;">
+  <div style="display: flex; flex-direction: row; flex-wrap: wrap; align-content: flex-start; justify-content: center; height: 10px; gap: 10px;">
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+  </div>
 </div>
 
 <div id="align_content_flex_start_without_height_on_children" style="width: 100px; height: 100px; flex-wrap: wrap; flex-direction: column; align-content: flex-start;">
@@ -22,13 +51,195 @@
   <div style="width: 50px;"></div>
 </div>
 
-<div id="align_content_flex_end" style="width: 100px; height: 100px; flex-wrap: wrap; flex-direction: column; align-content: flex-end;">
+<!-- ALIGN CONTENT: FLEX-END -->
+
+<div id="align_content_flex_end_nowrap" style="width: 140px; height: 120px; flex-direction: row; align-content: flex-end;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<div id="align_content_flex_end_wrap" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: flex-end;">
   <div style="width: 50px; height: 10px;"></div>
   <div style="width: 50px; height: 10px;"></div>
   <div style="width: 50px; height: 10px;"></div>
   <div style="width: 50px; height: 10px;"></div>
   <div style="width: 50px; height: 10px;"></div>
 </div>
+
+<!-- This tests the case where `flex-wrap: wrap` but the content does not actually wrap -->
+<div id="align_content_flex_end_wrap_singleline" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: flex-end;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<div id="align_content_flex_end_wrapped_negative_space" style="display: flex; flex-direction: column; width: 320px; height: 320px; border-width: 60px;">
+  <div style="display: flex; flex-direction: row; flex-wrap: wrap; align-content: flex-end; justify-content: center; height: 10px;">
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+  </div>
+</div>
+
+<div id="align_content_flex_end_wrapped_negative_space_gap" style="display: flex; flex-direction: column; width: 320px; height: 320px; border-width: 60px;">
+  <div style="display: flex; flex-direction: row; flex-wrap: wrap; align-content: flex-end; justify-content: center; height: 10px; gap: 10px;">
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+  </div>
+</div>
+
+
+<!-- ALIGN CONTENT: CENTER -->
+
+<div id="align_content_center_nowrap" style="width: 140px; height: 120px; flex-direction: row; align-content: center;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<div id="align_content_center_wrap" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: center;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<!-- This tests the case where `flex-wrap: wrap` but the content does not actually wrap -->
+<div id="align_content_center_wrap_singleline" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: center;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<div id="align_content_center_wrapped_negative_space" style="display: flex; flex-direction: column; width: 320px; height: 320px; border-width: 60px;">
+  <div style="display: flex; flex-direction: row; flex-wrap: wrap; align-content: center; justify-content: center; height: 10px;">
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+  </div>
+</div>
+
+<div id="align_content_center_wrapped_negative_space_gap" style="display: flex; flex-direction: column; width: 320px; height: 320px; border-width: 60px;">
+  <div style="display: flex; flex-direction: row; flex-wrap: wrap; align-content: center; justify-content: center; height: 10px; gap: 10px;">
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+  </div>
+</div>
+
+<!-- ALIGN CONTENT: SPACE-BETWEEN -->
+
+<div id="align_content_space_between_nowrap" style="width: 140px; height: 120px; flex-direction: row; align-content: space-between;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<div id="align_content_space_between_wrap" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: space-between;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<!-- This tests the case where `flex-wrap: wrap` but the content does not actually wrap -->
+<div id="align_content_space_between_wrap_singleline" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: space-between;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<div id="align_content_space_between_wrapped_negative_space" style="display: flex; flex-direction: column; width: 320px; height: 320px; border-width: 60px;">
+  <div style="display: flex; flex-direction: row; flex-wrap: wrap; align-content: space-between; justify-content: center; height: 10px;">
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+  </div>
+</div>
+
+<div id="align_content_space_between_wrapped_negative_space_gap" style="display: flex; flex-direction: column; width: 320px; height: 320px; border-width: 60px;">
+  <div style="display: flex; flex-direction: row; flex-wrap: wrap; align-content: space-between; justify-content: center; height: 10px; gap: 10px;">
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+  </div>
+</div>
+
+<!-- ALIGN CONTENT: SPACE-AROUND -->
+
+<div id="align_content_space_around_nowrap" style="width: 140px; height: 120px; flex-direction: row; align-content: space-around;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<div id="align_content_space_around_wrap" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: space-around;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<!-- This tests the case where `flex-wrap: wrap` but the content does not actually wrap -->
+<div id="align_content_space_around_wrap_singleline" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: space-around;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<div id="align_content_space_around_wrapped_negative_space" style="display: flex; flex-direction: column; width: 320px; height: 320px; border-width: 60px;">
+  <div style="display: flex; flex-direction: row; flex-wrap: wrap; align-content: space-around; justify-content: center; height: 10px;">
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+  </div>
+</div>
+
+<div id="align_content_space_around_wrapped_negative_space_gap" style="display: flex; flex-direction: column; width: 320px; height: 320px; border-width: 60px;">
+  <div style="display: flex; flex-direction: row; flex-wrap: wrap; align-content: space-around; justify-content: center; height: 10px; gap: 10px;">
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+  </div>
+</div>
+
+
+<!-- ALIGN CONTENT: SPACE-EVENLY -->
+
+<div id="align_content_space_evenly_nowrap" style="width: 140px; height: 120px; flex-direction: row; align-content: space-evenly;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<div id="align_content_space_evenly_wrap" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: space-evenly;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<!-- This tests the case where `flex-wrap: wrap` but the content does not actually wrap -->
+<div id="align_content_space_evenly_wrap_singleline" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: space-evenly;">
+  <div style="width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+<div id="align_content_space_evenly_wrapped_negative_space" style="display: flex; flex-direction: column; width: 320px; height: 320px; border-width: 60px;">
+  <div style="display: flex; flex-direction: row; flex-wrap: wrap; align-content: space-evenly; justify-content: center; height: 10px;">
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+  </div>
+</div>
+
+<div id="align_content_space_evenly_wrapped_negative_space_gap" style="display: flex; flex-direction: column; width: 320px; height: 320px; border-width: 60px;">
+  <div style="display: flex; flex-direction: row; flex-wrap: wrap; align-content: space-evenly; justify-content: center; height: 10px; gap: 10px;">
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+    <div style="width: 80%; height: 20px; flex-shrink: 0;"></div>
+  </div>
+</div>
+
+
+<!-- ALIGN CONTENT: STRETCH -->
 
 <div id="align_content_stretch" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: column; align-content: stretch;">
   <div style="width: 50px;"></div>
@@ -36,22 +247,6 @@
   <div style="width: 50px;"></div>
   <div style="width: 50px;"></div>
   <div style="width: 50px;"></div>
-</div>
-
-<div id="align_content_spacebetween" style="width: 130px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: space-between;">
-  <div style="width: 50px; height: 10px;"></div>
-  <div style="width: 50px; height: 10px;"></div>
-  <div style="width: 50px; height: 10px;"></div>
-  <div style="width: 50px; height: 10px;"></div>
-  <div style="width: 50px; height: 10px;"></div>
-</div>
-
-<div id="align_content_spacearound" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: space-around;">
-  <div style="width: 50px; height: 10px;"></div>
-  <div style="width: 50px; height: 10px;"></div>
-  <div style="width: 50px; height: 10px;"></div>
-  <div style="width: 50px; height: 10px;"></div>
-  <div style="width: 50px; height: 10px;"></div>
 </div>
 
 <div id="align_content_stretch_row" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: stretch;">

--- a/gentest/gentest-cpp.js
+++ b/gentest/gentest-cpp.js
@@ -91,6 +91,7 @@ CPPEmitter.prototype = Object.create(Emitter.prototype, {
   YGAlignStretch: {value: 'YGAlignStretch'},
   YGAlignSpaceBetween: {value: 'YGAlignSpaceBetween'},
   YGAlignSpaceAround: {value: 'YGAlignSpaceAround'},
+  YGAlignSpaceEvenly: {value: 'YGAlignSpaceEvenly'},
   YGAlignBaseline: {value: 'YGAlignBaseline'},
 
   YGDirectionInherit: {value: 'YGDirectionInherit'},

--- a/gentest/gentest-java.js
+++ b/gentest/gentest-java.js
@@ -135,6 +135,7 @@ JavaEmitter.prototype = Object.create(Emitter.prototype, {
   YGAlignStretch: {value: 'YogaAlign.STRETCH'},
   YGAlignSpaceBetween: {value: 'YogaAlign.SPACE_BETWEEN'},
   YGAlignSpaceAround: {value: 'YogaAlign.SPACE_AROUND'},
+  YGAlignSpaceEvenly: {value: 'YogaAlign.SPACE_EVENLY'},
   YGAlignBaseline: {value: 'YogaAlign.BASELINE'},
 
   YGDirectionInherit: {value: 'YogaDirection.INHERIT'},

--- a/gentest/gentest-javascript.js
+++ b/gentest/gentest-javascript.js
@@ -120,6 +120,7 @@ JavascriptEmitter.prototype = Object.create(Emitter.prototype, {
   YGAlignStretch: {value: 'Align.Stretch'},
   YGAlignSpaceBetween: {value: 'Align.SpaceBetween'},
   YGAlignSpaceAround: {value: 'Align.SpaceAround'},
+  YGAlignSpaceEvenly: {value: 'Align.SpaceEvenly'},
   YGAlignBaseline: {value: 'Align.Baseline'},
 
   YGDirectionInherit: {value: 'Direction.Inherit'},

--- a/gentest/gentest.js
+++ b/gentest/gentest.js
@@ -608,6 +608,8 @@ function alignValue(e, value) {
       return e.YGAlignSpaceBetween;
     case 'space-around':
       return e.YGAlignSpaceAround;
+    case 'space-evenly':
+      return e.YGAlignSpaceEvenly;
     case 'baseline':
       return e.YGAlignBaseline;
   }

--- a/java/com/facebook/yoga/YogaAlign.java
+++ b/java/com/facebook/yoga/YogaAlign.java
@@ -17,7 +17,8 @@ public enum YogaAlign {
   STRETCH(4),
   BASELINE(5),
   SPACE_BETWEEN(6),
-  SPACE_AROUND(7);
+  SPACE_AROUND(7),
+  SPACE_EVENLY(8);
 
   private final int mIntValue;
 
@@ -39,6 +40,7 @@ public enum YogaAlign {
       case 5: return BASELINE;
       case 6: return SPACE_BETWEEN;
       case 7: return SPACE_AROUND;
+      case 8: return SPACE_EVENLY;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);
     }
   }

--- a/java/tests/com/facebook/yoga/YGAlignContentTest.java
+++ b/java/tests/com/facebook/yoga/YGAlignContentTest.java
@@ -26,15 +26,71 @@ public class YGAlignContentTest {
   @Parameterized.Parameter public TestParametrization.NodeFactory mNodeFactory;
 
   @Test
-  public void test_align_content_flex_start() {
+  public void test_align_content_flex_start_nowrap() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setWidth(140f);
+    root.setHeight(120f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_flex_start_wrap() {
     YogaConfig config = YogaConfigFactory.create();
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
 
     final YogaNode root = createNode(config);
     root.setFlexDirection(YogaFlexDirection.ROW);
     root.setWrap(YogaWrap.WRAP);
-    root.setWidth(130f);
-    root.setHeight(100f);
+    root.setWidth(140f);
+    root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setWidth(50f);
@@ -65,8 +121,8 @@ public class YGAlignContentTest {
 
     assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
-    assertEquals(130f, root.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
@@ -98,33 +154,274 @@ public class YGAlignContentTest {
 
     assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
-    assertEquals(130f, root.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
     assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(30f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
     assertEquals(0f, root_child1.getLayoutY(), 0.0f);
     assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child2.getLayoutX(), 0.0f);
     assertEquals(10f, root_child2.getLayoutY(), 0.0f);
     assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
 
-    assertEquals(30f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutX(), 0.0f);
     assertEquals(10f, root_child3.getLayoutY(), 0.0f);
     assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child3.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child4.getLayoutX(), 0.0f);
     assertEquals(20f, root_child4.getLayoutY(), 0.0f);
     assertEquals(50f, root_child4.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child4.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_flex_start_wrap_singleline() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setWrap(YogaWrap.WRAP);
+    root.setWidth(140f);
+    root.setHeight(120f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_flex_start_wrapped_negative_space() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setBorder(YogaEdge.LEFT, 60f);
+    root.setBorder(YogaEdge.TOP, 60f);
+    root.setBorder(YogaEdge.RIGHT, 60f);
+    root.setBorder(YogaEdge.BOTTOM, 60f);
+    root.setWidth(320f);
+    root.setHeight(320f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW);
+    root_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0.setWrap(YogaWrap.WRAP);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidthPercent(80f);
+    root_child0_child0.setHeight(20f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidthPercent(80f);
+    root_child0_child1.setHeight(20f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidthPercent(80f);
+    root_child0_child2.setHeight(20f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_flex_start_wrapped_negative_space_gap() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setBorder(YogaEdge.LEFT, 60f);
+    root.setBorder(YogaEdge.TOP, 60f);
+    root.setBorder(YogaEdge.RIGHT, 60f);
+    root.setBorder(YogaEdge.BOTTOM, 60f);
+    root.setWidth(320f);
+    root.setHeight(320f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW);
+    root_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0.setWrap(YogaWrap.WRAP);
+    root_child0.setHeight(10f);
+    root_child0.setGap(YogaGutter.COLUMN, 10f);
+    root_child0.setGap(YogaGutter.ROW, 10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidthPercent(80f);
+    root_child0_child0.setHeight(20f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidthPercent(80f);
+    root_child0_child1.setHeight(20f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidthPercent(80f);
+    root_child0_child2.setHeight(20f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
   }
 
   @Test
@@ -330,15 +627,73 @@ public class YGAlignContentTest {
   }
 
   @Test
-  public void test_align_content_flex_end() {
+  public void test_align_content_flex_end_nowrap() {
     YogaConfig config = YogaConfigFactory.create();
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
 
     final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.FLEX_END);
+    root.setWidth(140f);
+    root.setHeight(120f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_flex_end_wrap() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
     root.setAlignContent(YogaAlign.FLEX_END);
     root.setWrap(YogaWrap.WRAP);
-    root.setWidth(100f);
-    root.setHeight(100f);
+    root.setWidth(140f);
+    root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setWidth(50f);
@@ -369,31 +724,31 @@ public class YGAlignContentTest {
 
     assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
-    assertEquals(100f, root.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(50f, root_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutY(), 0.0f);
     assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
 
     assertEquals(50f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(90f, root_child1.getLayoutY(), 0.0f);
     assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
 
-    assertEquals(50f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(20f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child2.getLayoutY(), 0.0f);
     assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
 
     assertEquals(50f, root_child3.getLayoutX(), 0.0f);
-    assertEquals(30f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child3.getLayoutY(), 0.0f);
     assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child3.getLayoutHeight(), 0.0f);
 
-    assertEquals(50f, root_child4.getLayoutX(), 0.0f);
-    assertEquals(40f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(110f, root_child4.getLayoutY(), 0.0f);
     assertEquals(50f, root_child4.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child4.getLayoutHeight(), 0.0f);
 
@@ -402,134 +757,742 @@ public class YGAlignContentTest {
 
     assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
-    assertEquals(100f, root.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(110f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child4.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_flex_end_wrap_singleline() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.FLEX_END);
+    root.setWrap(YogaWrap.WRAP);
+    root.setWidth(140f);
+    root.setHeight(120f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(110f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(110f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(110f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(110f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_flex_end_wrapped_negative_space() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setBorder(YogaEdge.LEFT, 60f);
+    root.setBorder(YogaEdge.TOP, 60f);
+    root.setBorder(YogaEdge.RIGHT, 60f);
+    root.setBorder(YogaEdge.BOTTOM, 60f);
+    root.setWidth(320f);
+    root.setHeight(320f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW);
+    root_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0.setAlignContent(YogaAlign.FLEX_END);
+    root_child0.setWrap(YogaWrap.WRAP);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidthPercent(80f);
+    root_child0_child0.setHeight(20f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidthPercent(80f);
+    root_child0_child1.setHeight(20f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidthPercent(80f);
+    root_child0_child2.setHeight(20f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-50f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-30f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-50f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-30f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_flex_end_wrapped_negative_space_gap() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setBorder(YogaEdge.LEFT, 60f);
+    root.setBorder(YogaEdge.TOP, 60f);
+    root.setBorder(YogaEdge.RIGHT, 60f);
+    root.setBorder(YogaEdge.BOTTOM, 60f);
+    root.setWidth(320f);
+    root.setHeight(320f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW);
+    root_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0.setAlignContent(YogaAlign.FLEX_END);
+    root_child0.setWrap(YogaWrap.WRAP);
+    root_child0.setHeight(10f);
+    root_child0.setGap(YogaGutter.COLUMN, 10f);
+    root_child0.setGap(YogaGutter.ROW, 10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidthPercent(80f);
+    root_child0_child0.setHeight(20f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidthPercent(80f);
+    root_child0_child1.setHeight(20f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidthPercent(80f);
+    root_child0_child2.setHeight(20f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-70f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-40f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-70f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-40f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(-10f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_center_nowrap() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.CENTER);
+    root.setWidth(140f);
+    root.setHeight(120f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
     assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
     assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(20f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
-    assertEquals(0f, root_child3.getLayoutX(), 0.0f);
-    assertEquals(30f, root_child3.getLayoutY(), 0.0f);
-    assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
-    assertEquals(10f, root_child3.getLayoutHeight(), 0.0f);
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child4.getLayoutX(), 0.0f);
-    assertEquals(40f, root_child4.getLayoutY(), 0.0f);
-    assertEquals(50f, root_child4.getLayoutWidth(), 0.0f);
-    assertEquals(10f, root_child4.getLayoutHeight(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
   }
 
   @Test
-  public void test_align_content_stretch() {
+  public void test_align_content_center_wrap() {
     YogaConfig config = YogaConfigFactory.create();
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
 
     final YogaNode root = createNode(config);
-    root.setAlignContent(YogaAlign.STRETCH);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.CENTER);
     root.setWrap(YogaWrap.WRAP);
-    root.setWidth(150f);
-    root.setHeight(100f);
+    root.setWidth(140f);
+    root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
     root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
     root_child2.setWidth(50f);
+    root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
     root_child3.setWidth(50f);
+    root_child3.setHeight(10f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
     root_child4.setWidth(50f);
+    root_child4.setHeight(10f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
     assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
-    assertEquals(150f, root.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(45f, root_child0.getLayoutY(), 0.0f);
     assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(45f, root_child1.getLayoutY(), 0.0f);
     assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(55f, root_child2.getLayoutY(), 0.0f);
     assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child3.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child3.getLayoutY(), 0.0f);
     assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child3.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child4.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(65f, root_child4.getLayoutY(), 0.0f);
     assertEquals(50f, root_child4.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child4.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child4.getLayoutHeight(), 0.0f);
 
     root.setDirection(YogaDirection.RTL);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
     assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
-    assertEquals(150f, root.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(100f, root_child0.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(45f, root_child0.getLayoutY(), 0.0f);
     assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(100f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(45f, root_child1.getLayoutY(), 0.0f);
     assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
 
-    assertEquals(100f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(90f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child2.getLayoutY(), 0.0f);
     assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
 
-    assertEquals(100f, root_child3.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child3.getLayoutY(), 0.0f);
     assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child3.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutHeight(), 0.0f);
 
-    assertEquals(100f, root_child4.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(90f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(65f, root_child4.getLayoutY(), 0.0f);
     assertEquals(50f, root_child4.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child4.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child4.getLayoutHeight(), 0.0f);
   }
 
   @Test
-  public void test_align_content_spacebetween() {
+  public void test_align_content_center_wrap_singleline() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.CENTER);
+    root.setWrap(YogaWrap.WRAP);
+    root.setWidth(140f);
+    root.setHeight(120f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_center_wrapped_negative_space() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setBorder(YogaEdge.LEFT, 60f);
+    root.setBorder(YogaEdge.TOP, 60f);
+    root.setBorder(YogaEdge.RIGHT, 60f);
+    root.setBorder(YogaEdge.BOTTOM, 60f);
+    root.setWidth(320f);
+    root.setHeight(320f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW);
+    root_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0.setAlignContent(YogaAlign.CENTER);
+    root_child0.setWrap(YogaWrap.WRAP);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidthPercent(80f);
+    root_child0_child0.setHeight(20f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidthPercent(80f);
+    root_child0_child1.setHeight(20f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidthPercent(80f);
+    root_child0_child2.setHeight(20f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-25f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-5f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(15f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-25f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-5f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(15f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_center_wrapped_negative_space_gap() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setBorder(YogaEdge.LEFT, 60f);
+    root.setBorder(YogaEdge.TOP, 60f);
+    root.setBorder(YogaEdge.RIGHT, 60f);
+    root.setBorder(YogaEdge.BOTTOM, 60f);
+    root.setWidth(320f);
+    root.setHeight(320f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW);
+    root_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0.setAlignContent(YogaAlign.CENTER);
+    root_child0.setWrap(YogaWrap.WRAP);
+    root_child0.setHeight(10f);
+    root_child0.setGap(YogaGutter.COLUMN, 10f);
+    root_child0.setGap(YogaGutter.ROW, 10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidthPercent(80f);
+    root_child0_child0.setHeight(20f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidthPercent(80f);
+    root_child0_child1.setHeight(20f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidthPercent(80f);
+    root_child0_child2.setHeight(20f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-35f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-5f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(25f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-35f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-5f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(25f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_between_nowrap() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.SPACE_BETWEEN);
+    root.setWidth(140f);
+    root.setHeight(120f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_between_wrap() {
     YogaConfig config = YogaConfigFactory.create();
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
 
@@ -537,8 +1500,8 @@ public class YGAlignContentTest {
     root.setFlexDirection(YogaFlexDirection.ROW);
     root.setAlignContent(YogaAlign.SPACE_BETWEEN);
     root.setWrap(YogaWrap.WRAP);
-    root.setWidth(130f);
-    root.setHeight(100f);
+    root.setWidth(140f);
+    root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setWidth(50f);
@@ -569,8 +1532,8 @@ public class YGAlignContentTest {
 
     assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
-    assertEquals(130f, root.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
@@ -583,17 +1546,17 @@ public class YGAlignContentTest {
     assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(45f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(55f, root_child2.getLayoutY(), 0.0f);
     assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
 
     assertEquals(50f, root_child3.getLayoutX(), 0.0f);
-    assertEquals(45f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(55f, root_child3.getLayoutY(), 0.0f);
     assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child3.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child4.getLayoutX(), 0.0f);
-    assertEquals(90f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(110f, root_child4.getLayoutY(), 0.0f);
     assertEquals(50f, root_child4.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child4.getLayoutHeight(), 0.0f);
 
@@ -602,37 +1565,338 @@ public class YGAlignContentTest {
 
     assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
-    assertEquals(130f, root.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
     assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(30f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
     assertEquals(0f, root_child1.getLayoutY(), 0.0f);
     assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(45f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(90f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child2.getLayoutY(), 0.0f);
     assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
 
-    assertEquals(30f, root_child3.getLayoutX(), 0.0f);
-    assertEquals(45f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(40f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child3.getLayoutY(), 0.0f);
     assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child3.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child4.getLayoutX(), 0.0f);
-    assertEquals(90f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(90f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(110f, root_child4.getLayoutY(), 0.0f);
     assertEquals(50f, root_child4.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child4.getLayoutHeight(), 0.0f);
   }
 
   @Test
-  public void test_align_content_spacearound() {
+  public void test_align_content_space_between_wrap_singleline() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.SPACE_BETWEEN);
+    root.setWrap(YogaWrap.WRAP);
+    root.setWidth(140f);
+    root.setHeight(120f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_between_wrapped_negative_space() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setBorder(YogaEdge.LEFT, 60f);
+    root.setBorder(YogaEdge.TOP, 60f);
+    root.setBorder(YogaEdge.RIGHT, 60f);
+    root.setBorder(YogaEdge.BOTTOM, 60f);
+    root.setWidth(320f);
+    root.setHeight(320f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW);
+    root_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0.setAlignContent(YogaAlign.SPACE_BETWEEN);
+    root_child0.setWrap(YogaWrap.WRAP);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidthPercent(80f);
+    root_child0_child0.setHeight(20f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidthPercent(80f);
+    root_child0_child1.setHeight(20f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidthPercent(80f);
+    root_child0_child2.setHeight(20f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(40f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_between_wrapped_negative_space_gap() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setBorder(YogaEdge.LEFT, 60f);
+    root.setBorder(YogaEdge.TOP, 60f);
+    root.setBorder(YogaEdge.RIGHT, 60f);
+    root.setBorder(YogaEdge.BOTTOM, 60f);
+    root.setWidth(320f);
+    root.setHeight(320f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW);
+    root_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0.setAlignContent(YogaAlign.SPACE_BETWEEN);
+    root_child0.setWrap(YogaWrap.WRAP);
+    root_child0.setHeight(10f);
+    root_child0.setGap(YogaGutter.COLUMN, 10f);
+    root_child0.setGap(YogaGutter.ROW, 10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidthPercent(80f);
+    root_child0_child0.setHeight(20f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidthPercent(80f);
+    root_child0_child1.setHeight(20f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidthPercent(80f);
+    root_child0_child2.setHeight(20f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_around_nowrap() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.SPACE_AROUND);
+    root.setWidth(140f);
+    root.setHeight(120f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_around_wrap() {
     YogaConfig config = YogaConfigFactory.create();
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
 
@@ -732,6 +1996,751 @@ public class YGAlignContentTest {
     assertEquals(95f, root_child4.getLayoutY(), 0.0f);
     assertEquals(50f, root_child4.getLayoutWidth(), 0.0f);
     assertEquals(10f, root_child4.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_around_wrap_singleline() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.SPACE_AROUND);
+    root.setWrap(YogaWrap.WRAP);
+    root.setWidth(140f);
+    root.setHeight(120f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_around_wrapped_negative_space() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setBorder(YogaEdge.LEFT, 60f);
+    root.setBorder(YogaEdge.TOP, 60f);
+    root.setBorder(YogaEdge.RIGHT, 60f);
+    root.setBorder(YogaEdge.BOTTOM, 60f);
+    root.setWidth(320f);
+    root.setHeight(320f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW);
+    root_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0.setAlignContent(YogaAlign.SPACE_AROUND);
+    root_child0.setWrap(YogaWrap.WRAP);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidthPercent(80f);
+    root_child0_child0.setHeight(20f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidthPercent(80f);
+    root_child0_child1.setHeight(20f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidthPercent(80f);
+    root_child0_child2.setHeight(20f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-25f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-5f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(15f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-25f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-5f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(15f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_around_wrapped_negative_space_gap() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setBorder(YogaEdge.LEFT, 60f);
+    root.setBorder(YogaEdge.TOP, 60f);
+    root.setBorder(YogaEdge.RIGHT, 60f);
+    root.setBorder(YogaEdge.BOTTOM, 60f);
+    root.setWidth(320f);
+    root.setHeight(320f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW);
+    root_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0.setAlignContent(YogaAlign.SPACE_AROUND);
+    root_child0.setWrap(YogaWrap.WRAP);
+    root_child0.setHeight(10f);
+    root_child0.setGap(YogaGutter.COLUMN, 10f);
+    root_child0.setGap(YogaGutter.ROW, 10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidthPercent(80f);
+    root_child0_child0.setHeight(20f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidthPercent(80f);
+    root_child0_child1.setHeight(20f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidthPercent(80f);
+    root_child0_child2.setHeight(20f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-35f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-5f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(25f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-35f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-5f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(25f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_evenly_nowrap() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.SPACE_EVENLY);
+    root.setWidth(140f);
+    root.setHeight(120f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_evenly_wrap() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.SPACE_EVENLY);
+    root.setWrap(YogaWrap.WRAP);
+    root.setWidth(140f);
+    root.setHeight(120f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = createNode(config);
+    root_child2.setWidth(50f);
+    root_child2.setHeight(10f);
+    root.addChildAt(root_child2, 2);
+
+    final YogaNode root_child3 = createNode(config);
+    root_child3.setWidth(50f);
+    root_child3.setHeight(10f);
+    root.addChildAt(root_child3, 3);
+
+    final YogaNode root_child4 = createNode(config);
+    root_child4.setWidth(50f);
+    root_child4.setHeight(10f);
+    root.addChildAt(root_child4, 4);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(23f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(23f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(88f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child4.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(23f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(23f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(88f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child4.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_evenly_wrap_singleline() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.SPACE_EVENLY);
+    root.setWrap(YogaWrap.WRAP);
+    root.setWidth(140f);
+    root.setHeight(120f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root_child1.setHeight(10f);
+    root.addChildAt(root_child1, 1);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(140f, root.getLayoutWidth(), 0.0f);
+    assertEquals(120f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(40f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(55f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child1.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_evenly_wrapped_negative_space() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setBorder(YogaEdge.LEFT, 60f);
+    root.setBorder(YogaEdge.TOP, 60f);
+    root.setBorder(YogaEdge.RIGHT, 60f);
+    root.setBorder(YogaEdge.BOTTOM, 60f);
+    root.setWidth(320f);
+    root.setHeight(320f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW);
+    root_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0.setAlignContent(YogaAlign.SPACE_EVENLY);
+    root_child0.setWrap(YogaWrap.WRAP);
+    root_child0.setHeight(10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidthPercent(80f);
+    root_child0_child0.setHeight(20f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidthPercent(80f);
+    root_child0_child1.setHeight(20f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidthPercent(80f);
+    root_child0_child2.setHeight(20f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-25f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-5f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(15f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-25f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-5f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(15f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_space_evenly_wrapped_negative_space_gap() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setBorder(YogaEdge.LEFT, 60f);
+    root.setBorder(YogaEdge.TOP, 60f);
+    root.setBorder(YogaEdge.RIGHT, 60f);
+    root.setBorder(YogaEdge.BOTTOM, 60f);
+    root.setWidth(320f);
+    root.setHeight(320f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW);
+    root_child0.setJustifyContent(YogaJustify.CENTER);
+    root_child0.setAlignContent(YogaAlign.SPACE_EVENLY);
+    root_child0.setWrap(YogaWrap.WRAP);
+    root_child0.setHeight(10f);
+    root_child0.setGap(YogaGutter.COLUMN, 10f);
+    root_child0.setGap(YogaGutter.ROW, 10f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidthPercent(80f);
+    root_child0_child0.setHeight(20f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidthPercent(80f);
+    root_child0_child1.setHeight(20f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidthPercent(80f);
+    root_child0_child2.setHeight(20f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-35f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-5f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(25f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(320f, root.getLayoutWidth(), 0.0f);
+    assertEquals(320f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(60f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(200f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(-35f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(-5f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(25f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(160f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(20f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_align_content_stretch() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setAlignContent(YogaAlign.STRETCH);
+    root.setWrap(YogaWrap.WRAP);
+    root.setWidth(150f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(50f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(50f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = createNode(config);
+    root_child2.setWidth(50f);
+    root.addChildAt(root_child2, 2);
+
+    final YogaNode root_child3 = createNode(config);
+    root_child3.setWidth(50f);
+    root.addChildAt(root_child3, 3);
+
+    final YogaNode root_child4 = createNode(config);
+    root_child4.setWidth(50f);
+    root.addChildAt(root_child4, 4);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(150f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(150f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(100f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(100f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(100f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(100f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(100f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(50f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutHeight(), 0.0f);
   }
 
   @Test

--- a/java/tests/com/facebook/yoga/YGAspectRatioTest.java
+++ b/java/tests/com/facebook/yoga/YGAspectRatioTest.java
@@ -95,28 +95,28 @@ public class YGAspectRatioTest {
 
     assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
-    assertEquals(300f, root_child0_child0.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0.getLayoutHeight(), 0.0f);
+    assertEquals(285f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0_child0_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child0.getLayoutY(), 0.0f);
-    assertEquals(197f, root_child0_child0_child0.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child0.getLayoutHeight(), 0.0f);
+    assertEquals(187f, root_child0_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(197f, root_child0_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(187f, root_child0_child0_child1.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child1.getLayoutY(), 0.0f);
     assertEquals(5f, root_child0_child0_child1.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child1.getLayoutHeight(), 0.0f);
+    assertEquals(187f, root_child0_child0_child1.getLayoutHeight(), 0.0f);
 
-    assertEquals(202f, root_child0_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(192f, root_child0_child0_child2.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2.getLayoutY(), 0.0f);
-    assertEquals(98f, root_child0_child0_child2.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child2.getLayoutHeight(), 0.0f);
+    assertEquals(93f, root_child0_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child2.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0_child0_child2_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0.getLayoutY(), 0.0f);
-    assertEquals(98f, root_child0_child0_child2_child0.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child2_child0.getLayoutHeight(), 0.0f);
+    assertEquals(93f, root_child0_child0_child2_child0.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child2_child0.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0_child0_child2_child0_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0_child0.getLayoutY(), 0.0f);
@@ -125,8 +125,8 @@ public class YGAspectRatioTest {
 
     assertEquals(0f, root_child0_child0_child2_child0_child1.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0_child1.getLayoutY(), 0.0f);
-    assertEquals(98f, root_child0_child0_child2_child0_child1.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child2_child0_child1.getLayoutHeight(), 0.0f);
+    assertEquals(93f, root_child0_child0_child2_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child2_child0_child1.getLayoutHeight(), 0.0f);
 
     root.setDirection(YogaDirection.RTL);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
@@ -141,40 +141,40 @@ public class YGAspectRatioTest {
     assertEquals(300f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(300f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
-    assertEquals(300f, root_child0_child0.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0.getLayoutHeight(), 0.0f);
+    assertEquals(285f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(103f, root_child0_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(98f, root_child0_child0_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child0.getLayoutY(), 0.0f);
-    assertEquals(197f, root_child0_child0_child0.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child0.getLayoutHeight(), 0.0f);
+    assertEquals(187f, root_child0_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(98f, root_child0_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(93f, root_child0_child0_child1.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child1.getLayoutY(), 0.0f);
     assertEquals(5f, root_child0_child0_child1.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child1.getLayoutHeight(), 0.0f);
+    assertEquals(187f, root_child0_child0_child1.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0_child0_child2.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2.getLayoutY(), 0.0f);
-    assertEquals(98f, root_child0_child0_child2.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child2.getLayoutHeight(), 0.0f);
+    assertEquals(93f, root_child0_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child2.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0_child0_child2_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0.getLayoutY(), 0.0f);
-    assertEquals(98f, root_child0_child0_child2_child0.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child2_child0.getLayoutHeight(), 0.0f);
+    assertEquals(93f, root_child0_child0_child2_child0.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child2_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(93f, root_child0_child0_child2_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(88f, root_child0_child0_child2_child0_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0_child0.getLayoutY(), 0.0f);
     assertEquals(5f, root_child0_child0_child2_child0_child0.getLayoutWidth(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0_child0.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0_child0_child2_child0_child1.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0_child1.getLayoutY(), 0.0f);
-    assertEquals(98f, root_child0_child0_child2_child0_child1.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child2_child0_child1.getLayoutHeight(), 0.0f);
+    assertEquals(93f, root_child0_child0_child2_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child2_child0_child1.getLayoutHeight(), 0.0f);
   }
 
   private YogaNode createNode(YogaConfig config) {

--- a/javascript/src/generated/YGEnums.ts
+++ b/javascript/src/generated/YGEnums.ts
@@ -16,6 +16,7 @@ export enum Align {
   Baseline = 5,
   SpaceBetween = 6,
   SpaceAround = 7,
+  SpaceEvenly = 8,
 }
 
 export enum Dimension {
@@ -141,6 +142,7 @@ const constants = {
   ALIGN_BASELINE: Align.Baseline,
   ALIGN_SPACE_BETWEEN: Align.SpaceBetween,
   ALIGN_SPACE_AROUND: Align.SpaceAround,
+  ALIGN_SPACE_EVENLY: Align.SpaceEvenly,
   DIMENSION_WIDTH: Dimension.Width,
   DIMENSION_HEIGHT: Dimension.Height,
   DIRECTION_INHERIT: Direction.Inherit,

--- a/javascript/tests/generated/YGAlignContentTest.test.ts
+++ b/javascript/tests/generated/YGAlignContentTest.test.ts
@@ -25,7 +25,69 @@ import {
   Wrap,
 } from 'yoga-layout';
 
-test('align_content_flex_start', () => {
+test('align_content_flex_start_nowrap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_flex_start_wrap', () => {
   const config = Yoga.Config.create();
   let root;
 
@@ -35,8 +97,8 @@ test('align_content_flex_start', () => {
     root = Yoga.Node.create(config);
     root.setFlexDirection(FlexDirection.Row);
     root.setFlexWrap(Wrap.Wrap);
-    root.setWidth(130);
-    root.setHeight(100);
+    root.setWidth(140);
+    root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setWidth(50);
@@ -66,8 +128,8 @@ test('align_content_flex_start', () => {
 
     expect(root.getComputedLeft()).toBe(0);
     expect(root.getComputedTop()).toBe(0);
-    expect(root.getComputedWidth()).toBe(130);
-    expect(root.getComputedHeight()).toBe(100);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
 
     expect(root_child0.getComputedLeft()).toBe(0);
     expect(root_child0.getComputedTop()).toBe(0);
@@ -98,33 +160,292 @@ test('align_content_flex_start', () => {
 
     expect(root.getComputedLeft()).toBe(0);
     expect(root.getComputedTop()).toBe(0);
-    expect(root.getComputedWidth()).toBe(130);
-    expect(root.getComputedHeight()).toBe(100);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
 
-    expect(root_child0.getComputedLeft()).toBe(80);
+    expect(root_child0.getComputedLeft()).toBe(90);
     expect(root_child0.getComputedTop()).toBe(0);
     expect(root_child0.getComputedWidth()).toBe(50);
     expect(root_child0.getComputedHeight()).toBe(10);
 
-    expect(root_child1.getComputedLeft()).toBe(30);
+    expect(root_child1.getComputedLeft()).toBe(40);
     expect(root_child1.getComputedTop()).toBe(0);
     expect(root_child1.getComputedWidth()).toBe(50);
     expect(root_child1.getComputedHeight()).toBe(10);
 
-    expect(root_child2.getComputedLeft()).toBe(80);
+    expect(root_child2.getComputedLeft()).toBe(90);
     expect(root_child2.getComputedTop()).toBe(10);
     expect(root_child2.getComputedWidth()).toBe(50);
     expect(root_child2.getComputedHeight()).toBe(10);
 
-    expect(root_child3.getComputedLeft()).toBe(30);
+    expect(root_child3.getComputedLeft()).toBe(40);
     expect(root_child3.getComputedTop()).toBe(10);
     expect(root_child3.getComputedWidth()).toBe(50);
     expect(root_child3.getComputedHeight()).toBe(10);
 
-    expect(root_child4.getComputedLeft()).toBe(80);
+    expect(root_child4.getComputedLeft()).toBe(90);
     expect(root_child4.getComputedTop()).toBe(20);
     expect(root_child4.getComputedWidth()).toBe(50);
     expect(root_child4.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_flex_start_wrap_singleline', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setFlexWrap(Wrap.Wrap);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_flex_start_wrapped_negative_space', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setBorder(Edge.Left, 60);
+    root.setBorder(Edge.Top, 60);
+    root.setBorder(Edge.Right, 60);
+    root.setBorder(Edge.Bottom, 60);
+    root.setWidth(320);
+    root.setHeight(320);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.Row);
+    root_child0.setJustifyContent(Justify.Center);
+    root_child0.setFlexWrap(Wrap.Wrap);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth("80%");
+    root_child0_child0.setHeight(20);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth("80%");
+    root_child0_child1.setHeight(20);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth("80%");
+    root_child0_child2.setHeight(20);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(20);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(40);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(20);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(40);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_flex_start_wrapped_negative_space_gap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setBorder(Edge.Left, 60);
+    root.setBorder(Edge.Top, 60);
+    root.setBorder(Edge.Right, 60);
+    root.setBorder(Edge.Bottom, 60);
+    root.setWidth(320);
+    root.setHeight(320);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.Row);
+    root_child0.setJustifyContent(Justify.Center);
+    root_child0.setFlexWrap(Wrap.Wrap);
+    root_child0.setHeight(10);
+    root_child0.setGap(Gutter.Column, 10);
+    root_child0.setGap(Gutter.Row, 10);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth("80%");
+    root_child0_child0.setHeight(20);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth("80%");
+    root_child0_child1.setHeight(20);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth("80%");
+    root_child0_child2.setHeight(20);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(30);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(60);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(30);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(60);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
   } finally {
     if (typeof root !== 'undefined') {
       root.freeRecursive();
@@ -347,7 +668,7 @@ test('align_content_flex_start_with_flex', () => {
     config.free();
   }
 });
-test('align_content_flex_end', () => {
+test('align_content_flex_end_nowrap', () => {
   const config = Yoga.Config.create();
   let root;
 
@@ -355,10 +676,74 @@ test('align_content_flex_end', () => {
 
   try {
     root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.FlexEnd);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_flex_end_wrap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
     root.setAlignContent(Align.FlexEnd);
     root.setFlexWrap(Wrap.Wrap);
-    root.setWidth(100);
-    root.setHeight(100);
+    root.setWidth(140);
+    root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setWidth(50);
@@ -388,31 +773,31 @@ test('align_content_flex_end', () => {
 
     expect(root.getComputedLeft()).toBe(0);
     expect(root.getComputedTop()).toBe(0);
-    expect(root.getComputedWidth()).toBe(100);
-    expect(root.getComputedHeight()).toBe(100);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
 
-    expect(root_child0.getComputedLeft()).toBe(50);
-    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(90);
     expect(root_child0.getComputedWidth()).toBe(50);
     expect(root_child0.getComputedHeight()).toBe(10);
 
     expect(root_child1.getComputedLeft()).toBe(50);
-    expect(root_child1.getComputedTop()).toBe(10);
+    expect(root_child1.getComputedTop()).toBe(90);
     expect(root_child1.getComputedWidth()).toBe(50);
     expect(root_child1.getComputedHeight()).toBe(10);
 
-    expect(root_child2.getComputedLeft()).toBe(50);
-    expect(root_child2.getComputedTop()).toBe(20);
+    expect(root_child2.getComputedLeft()).toBe(0);
+    expect(root_child2.getComputedTop()).toBe(100);
     expect(root_child2.getComputedWidth()).toBe(50);
     expect(root_child2.getComputedHeight()).toBe(10);
 
     expect(root_child3.getComputedLeft()).toBe(50);
-    expect(root_child3.getComputedTop()).toBe(30);
+    expect(root_child3.getComputedTop()).toBe(100);
     expect(root_child3.getComputedWidth()).toBe(50);
     expect(root_child3.getComputedHeight()).toBe(10);
 
-    expect(root_child4.getComputedLeft()).toBe(50);
-    expect(root_child4.getComputedTop()).toBe(40);
+    expect(root_child4.getComputedLeft()).toBe(0);
+    expect(root_child4.getComputedTop()).toBe(110);
     expect(root_child4.getComputedWidth()).toBe(50);
     expect(root_child4.getComputedHeight()).toBe(10);
 
@@ -420,33 +805,2031 @@ test('align_content_flex_end', () => {
 
     expect(root.getComputedLeft()).toBe(0);
     expect(root.getComputedTop()).toBe(0);
-    expect(root.getComputedWidth()).toBe(100);
-    expect(root.getComputedHeight()).toBe(100);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(90);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(90);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    expect(root_child2.getComputedLeft()).toBe(90);
+    expect(root_child2.getComputedTop()).toBe(100);
+    expect(root_child2.getComputedWidth()).toBe(50);
+    expect(root_child2.getComputedHeight()).toBe(10);
+
+    expect(root_child3.getComputedLeft()).toBe(40);
+    expect(root_child3.getComputedTop()).toBe(100);
+    expect(root_child3.getComputedWidth()).toBe(50);
+    expect(root_child3.getComputedHeight()).toBe(10);
+
+    expect(root_child4.getComputedLeft()).toBe(90);
+    expect(root_child4.getComputedTop()).toBe(110);
+    expect(root_child4.getComputedWidth()).toBe(50);
+    expect(root_child4.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_flex_end_wrap_singleline', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.FlexEnd);
+    root.setFlexWrap(Wrap.Wrap);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(110);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(110);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(110);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(110);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_flex_end_wrapped_negative_space', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setBorder(Edge.Left, 60);
+    root.setBorder(Edge.Top, 60);
+    root.setBorder(Edge.Right, 60);
+    root.setBorder(Edge.Bottom, 60);
+    root.setWidth(320);
+    root.setHeight(320);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.Row);
+    root_child0.setJustifyContent(Justify.Center);
+    root_child0.setAlignContent(Align.FlexEnd);
+    root_child0.setFlexWrap(Wrap.Wrap);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth("80%");
+    root_child0_child0.setHeight(20);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth("80%");
+    root_child0_child1.setHeight(20);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth("80%");
+    root_child0_child2.setHeight(20);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-50);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-30);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(-10);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-50);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-30);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(-10);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_flex_end_wrapped_negative_space_gap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setBorder(Edge.Left, 60);
+    root.setBorder(Edge.Top, 60);
+    root.setBorder(Edge.Right, 60);
+    root.setBorder(Edge.Bottom, 60);
+    root.setWidth(320);
+    root.setHeight(320);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.Row);
+    root_child0.setJustifyContent(Justify.Center);
+    root_child0.setAlignContent(Align.FlexEnd);
+    root_child0.setFlexWrap(Wrap.Wrap);
+    root_child0.setHeight(10);
+    root_child0.setGap(Gutter.Column, 10);
+    root_child0.setGap(Gutter.Row, 10);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth("80%");
+    root_child0_child0.setHeight(20);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth("80%");
+    root_child0_child1.setHeight(20);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth("80%");
+    root_child0_child2.setHeight(20);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-70);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-40);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(-10);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-70);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-40);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(-10);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_center_nowrap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.Center);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
 
     expect(root_child0.getComputedLeft()).toBe(0);
     expect(root_child0.getComputedTop()).toBe(0);
     expect(root_child0.getComputedWidth()).toBe(50);
     expect(root_child0.getComputedHeight()).toBe(10);
 
-    expect(root_child1.getComputedLeft()).toBe(0);
-    expect(root_child1.getComputedTop()).toBe(10);
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_center_wrap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.Center);
+    root.setFlexWrap(Wrap.Wrap);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+
+    const root_child2 = Yoga.Node.create(config);
+    root_child2.setWidth(50);
+    root_child2.setHeight(10);
+    root.insertChild(root_child2, 2);
+
+    const root_child3 = Yoga.Node.create(config);
+    root_child3.setWidth(50);
+    root_child3.setHeight(10);
+    root.insertChild(root_child3, 3);
+
+    const root_child4 = Yoga.Node.create(config);
+    root_child4.setWidth(50);
+    root_child4.setHeight(10);
+    root.insertChild(root_child4, 4);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(45);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(45);
     expect(root_child1.getComputedWidth()).toBe(50);
     expect(root_child1.getComputedHeight()).toBe(10);
 
     expect(root_child2.getComputedLeft()).toBe(0);
-    expect(root_child2.getComputedTop()).toBe(20);
+    expect(root_child2.getComputedTop()).toBe(55);
     expect(root_child2.getComputedWidth()).toBe(50);
     expect(root_child2.getComputedHeight()).toBe(10);
 
-    expect(root_child3.getComputedLeft()).toBe(0);
-    expect(root_child3.getComputedTop()).toBe(30);
+    expect(root_child3.getComputedLeft()).toBe(50);
+    expect(root_child3.getComputedTop()).toBe(55);
     expect(root_child3.getComputedWidth()).toBe(50);
     expect(root_child3.getComputedHeight()).toBe(10);
 
     expect(root_child4.getComputedLeft()).toBe(0);
-    expect(root_child4.getComputedTop()).toBe(40);
+    expect(root_child4.getComputedTop()).toBe(65);
     expect(root_child4.getComputedWidth()).toBe(50);
     expect(root_child4.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(45);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(45);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    expect(root_child2.getComputedLeft()).toBe(90);
+    expect(root_child2.getComputedTop()).toBe(55);
+    expect(root_child2.getComputedWidth()).toBe(50);
+    expect(root_child2.getComputedHeight()).toBe(10);
+
+    expect(root_child3.getComputedLeft()).toBe(40);
+    expect(root_child3.getComputedTop()).toBe(55);
+    expect(root_child3.getComputedWidth()).toBe(50);
+    expect(root_child3.getComputedHeight()).toBe(10);
+
+    expect(root_child4.getComputedLeft()).toBe(90);
+    expect(root_child4.getComputedTop()).toBe(65);
+    expect(root_child4.getComputedWidth()).toBe(50);
+    expect(root_child4.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_center_wrap_singleline', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.Center);
+    root.setFlexWrap(Wrap.Wrap);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(55);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(55);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(55);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(55);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_center_wrapped_negative_space', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setBorder(Edge.Left, 60);
+    root.setBorder(Edge.Top, 60);
+    root.setBorder(Edge.Right, 60);
+    root.setBorder(Edge.Bottom, 60);
+    root.setWidth(320);
+    root.setHeight(320);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.Row);
+    root_child0.setJustifyContent(Justify.Center);
+    root_child0.setAlignContent(Align.Center);
+    root_child0.setFlexWrap(Wrap.Wrap);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth("80%");
+    root_child0_child0.setHeight(20);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth("80%");
+    root_child0_child1.setHeight(20);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth("80%");
+    root_child0_child2.setHeight(20);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-25);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-5);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(15);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-25);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-5);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(15);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_center_wrapped_negative_space_gap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setBorder(Edge.Left, 60);
+    root.setBorder(Edge.Top, 60);
+    root.setBorder(Edge.Right, 60);
+    root.setBorder(Edge.Bottom, 60);
+    root.setWidth(320);
+    root.setHeight(320);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.Row);
+    root_child0.setJustifyContent(Justify.Center);
+    root_child0.setAlignContent(Align.Center);
+    root_child0.setFlexWrap(Wrap.Wrap);
+    root_child0.setHeight(10);
+    root_child0.setGap(Gutter.Column, 10);
+    root_child0.setGap(Gutter.Row, 10);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth("80%");
+    root_child0_child0.setHeight(20);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth("80%");
+    root_child0_child1.setHeight(20);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth("80%");
+    root_child0_child2.setHeight(20);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-35);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-5);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(25);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-35);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-5);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(25);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_between_nowrap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.SpaceBetween);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_between_wrap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.SpaceBetween);
+    root.setFlexWrap(Wrap.Wrap);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+
+    const root_child2 = Yoga.Node.create(config);
+    root_child2.setWidth(50);
+    root_child2.setHeight(10);
+    root.insertChild(root_child2, 2);
+
+    const root_child3 = Yoga.Node.create(config);
+    root_child3.setWidth(50);
+    root_child3.setHeight(10);
+    root.insertChild(root_child3, 3);
+
+    const root_child4 = Yoga.Node.create(config);
+    root_child4.setWidth(50);
+    root_child4.setHeight(10);
+    root.insertChild(root_child4, 4);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    expect(root_child2.getComputedLeft()).toBe(0);
+    expect(root_child2.getComputedTop()).toBe(55);
+    expect(root_child2.getComputedWidth()).toBe(50);
+    expect(root_child2.getComputedHeight()).toBe(10);
+
+    expect(root_child3.getComputedLeft()).toBe(50);
+    expect(root_child3.getComputedTop()).toBe(55);
+    expect(root_child3.getComputedWidth()).toBe(50);
+    expect(root_child3.getComputedHeight()).toBe(10);
+
+    expect(root_child4.getComputedLeft()).toBe(0);
+    expect(root_child4.getComputedTop()).toBe(110);
+    expect(root_child4.getComputedWidth()).toBe(50);
+    expect(root_child4.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    expect(root_child2.getComputedLeft()).toBe(90);
+    expect(root_child2.getComputedTop()).toBe(55);
+    expect(root_child2.getComputedWidth()).toBe(50);
+    expect(root_child2.getComputedHeight()).toBe(10);
+
+    expect(root_child3.getComputedLeft()).toBe(40);
+    expect(root_child3.getComputedTop()).toBe(55);
+    expect(root_child3.getComputedWidth()).toBe(50);
+    expect(root_child3.getComputedHeight()).toBe(10);
+
+    expect(root_child4.getComputedLeft()).toBe(90);
+    expect(root_child4.getComputedTop()).toBe(110);
+    expect(root_child4.getComputedWidth()).toBe(50);
+    expect(root_child4.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_between_wrap_singleline', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.SpaceBetween);
+    root.setFlexWrap(Wrap.Wrap);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_between_wrapped_negative_space', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setBorder(Edge.Left, 60);
+    root.setBorder(Edge.Top, 60);
+    root.setBorder(Edge.Right, 60);
+    root.setBorder(Edge.Bottom, 60);
+    root.setWidth(320);
+    root.setHeight(320);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.Row);
+    root_child0.setJustifyContent(Justify.Center);
+    root_child0.setAlignContent(Align.SpaceBetween);
+    root_child0.setFlexWrap(Wrap.Wrap);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth("80%");
+    root_child0_child0.setHeight(20);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth("80%");
+    root_child0_child1.setHeight(20);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth("80%");
+    root_child0_child2.setHeight(20);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(20);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(40);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(20);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(40);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_between_wrapped_negative_space_gap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setBorder(Edge.Left, 60);
+    root.setBorder(Edge.Top, 60);
+    root.setBorder(Edge.Right, 60);
+    root.setBorder(Edge.Bottom, 60);
+    root.setWidth(320);
+    root.setHeight(320);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.Row);
+    root_child0.setJustifyContent(Justify.Center);
+    root_child0.setAlignContent(Align.SpaceBetween);
+    root_child0.setFlexWrap(Wrap.Wrap);
+    root_child0.setHeight(10);
+    root_child0.setGap(Gutter.Column, 10);
+    root_child0.setGap(Gutter.Row, 10);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth("80%");
+    root_child0_child0.setHeight(20);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth("80%");
+    root_child0_child1.setHeight(20);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth("80%");
+    root_child0_child2.setHeight(20);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(30);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(60);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(30);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(60);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_around_nowrap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.SpaceAround);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_around_wrap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.SpaceAround);
+    root.setFlexWrap(Wrap.Wrap);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+
+    const root_child2 = Yoga.Node.create(config);
+    root_child2.setWidth(50);
+    root_child2.setHeight(10);
+    root.insertChild(root_child2, 2);
+
+    const root_child3 = Yoga.Node.create(config);
+    root_child3.setWidth(50);
+    root_child3.setHeight(10);
+    root.insertChild(root_child3, 3);
+
+    const root_child4 = Yoga.Node.create(config);
+    root_child4.setWidth(50);
+    root_child4.setHeight(10);
+    root.insertChild(root_child4, 4);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(15);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(15);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    expect(root_child2.getComputedLeft()).toBe(0);
+    expect(root_child2.getComputedTop()).toBe(55);
+    expect(root_child2.getComputedWidth()).toBe(50);
+    expect(root_child2.getComputedHeight()).toBe(10);
+
+    expect(root_child3.getComputedLeft()).toBe(50);
+    expect(root_child3.getComputedTop()).toBe(55);
+    expect(root_child3.getComputedWidth()).toBe(50);
+    expect(root_child3.getComputedHeight()).toBe(10);
+
+    expect(root_child4.getComputedLeft()).toBe(0);
+    expect(root_child4.getComputedTop()).toBe(95);
+    expect(root_child4.getComputedWidth()).toBe(50);
+    expect(root_child4.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(15);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(15);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    expect(root_child2.getComputedLeft()).toBe(90);
+    expect(root_child2.getComputedTop()).toBe(55);
+    expect(root_child2.getComputedWidth()).toBe(50);
+    expect(root_child2.getComputedHeight()).toBe(10);
+
+    expect(root_child3.getComputedLeft()).toBe(40);
+    expect(root_child3.getComputedTop()).toBe(55);
+    expect(root_child3.getComputedWidth()).toBe(50);
+    expect(root_child3.getComputedHeight()).toBe(10);
+
+    expect(root_child4.getComputedLeft()).toBe(90);
+    expect(root_child4.getComputedTop()).toBe(95);
+    expect(root_child4.getComputedWidth()).toBe(50);
+    expect(root_child4.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_around_wrap_singleline', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.SpaceAround);
+    root.setFlexWrap(Wrap.Wrap);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(55);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(55);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(55);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(55);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_around_wrapped_negative_space', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setBorder(Edge.Left, 60);
+    root.setBorder(Edge.Top, 60);
+    root.setBorder(Edge.Right, 60);
+    root.setBorder(Edge.Bottom, 60);
+    root.setWidth(320);
+    root.setHeight(320);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.Row);
+    root_child0.setJustifyContent(Justify.Center);
+    root_child0.setAlignContent(Align.SpaceAround);
+    root_child0.setFlexWrap(Wrap.Wrap);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth("80%");
+    root_child0_child0.setHeight(20);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth("80%");
+    root_child0_child1.setHeight(20);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth("80%");
+    root_child0_child2.setHeight(20);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-25);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-5);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(15);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-25);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-5);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(15);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_around_wrapped_negative_space_gap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setBorder(Edge.Left, 60);
+    root.setBorder(Edge.Top, 60);
+    root.setBorder(Edge.Right, 60);
+    root.setBorder(Edge.Bottom, 60);
+    root.setWidth(320);
+    root.setHeight(320);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.Row);
+    root_child0.setJustifyContent(Justify.Center);
+    root_child0.setAlignContent(Align.SpaceAround);
+    root_child0.setFlexWrap(Wrap.Wrap);
+    root_child0.setHeight(10);
+    root_child0.setGap(Gutter.Column, 10);
+    root_child0.setGap(Gutter.Row, 10);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth("80%");
+    root_child0_child0.setHeight(20);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth("80%");
+    root_child0_child1.setHeight(20);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth("80%");
+    root_child0_child2.setHeight(20);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-35);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-5);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(25);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-35);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-5);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(25);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_evenly_nowrap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.SpaceEvenly);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(0);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_evenly_wrap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.SpaceEvenly);
+    root.setFlexWrap(Wrap.Wrap);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+
+    const root_child2 = Yoga.Node.create(config);
+    root_child2.setWidth(50);
+    root_child2.setHeight(10);
+    root.insertChild(root_child2, 2);
+
+    const root_child3 = Yoga.Node.create(config);
+    root_child3.setWidth(50);
+    root_child3.setHeight(10);
+    root.insertChild(root_child3, 3);
+
+    const root_child4 = Yoga.Node.create(config);
+    root_child4.setWidth(50);
+    root_child4.setHeight(10);
+    root.insertChild(root_child4, 4);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(23);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(23);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    expect(root_child2.getComputedLeft()).toBe(0);
+    expect(root_child2.getComputedTop()).toBe(55);
+    expect(root_child2.getComputedWidth()).toBe(50);
+    expect(root_child2.getComputedHeight()).toBe(10);
+
+    expect(root_child3.getComputedLeft()).toBe(50);
+    expect(root_child3.getComputedTop()).toBe(55);
+    expect(root_child3.getComputedWidth()).toBe(50);
+    expect(root_child3.getComputedHeight()).toBe(10);
+
+    expect(root_child4.getComputedLeft()).toBe(0);
+    expect(root_child4.getComputedTop()).toBe(88);
+    expect(root_child4.getComputedWidth()).toBe(50);
+    expect(root_child4.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(23);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(23);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    expect(root_child2.getComputedLeft()).toBe(90);
+    expect(root_child2.getComputedTop()).toBe(55);
+    expect(root_child2.getComputedWidth()).toBe(50);
+    expect(root_child2.getComputedHeight()).toBe(10);
+
+    expect(root_child3.getComputedLeft()).toBe(40);
+    expect(root_child3.getComputedTop()).toBe(55);
+    expect(root_child3.getComputedWidth()).toBe(50);
+    expect(root_child3.getComputedHeight()).toBe(10);
+
+    expect(root_child4.getComputedLeft()).toBe(90);
+    expect(root_child4.getComputedTop()).toBe(88);
+    expect(root_child4.getComputedWidth()).toBe(50);
+    expect(root_child4.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_evenly_wrap_singleline', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setFlexDirection(FlexDirection.Row);
+    root.setAlignContent(Align.SpaceEvenly);
+    root.setFlexWrap(Wrap.Wrap);
+    root.setWidth(140);
+    root.setHeight(120);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(50);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(50);
+    root_child1.setHeight(10);
+    root.insertChild(root_child1, 1);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(55);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(50);
+    expect(root_child1.getComputedTop()).toBe(55);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(140);
+    expect(root.getComputedHeight()).toBe(120);
+
+    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedTop()).toBe(55);
+    expect(root_child0.getComputedWidth()).toBe(50);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child1.getComputedLeft()).toBe(40);
+    expect(root_child1.getComputedTop()).toBe(55);
+    expect(root_child1.getComputedWidth()).toBe(50);
+    expect(root_child1.getComputedHeight()).toBe(10);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_evenly_wrapped_negative_space', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setBorder(Edge.Left, 60);
+    root.setBorder(Edge.Top, 60);
+    root.setBorder(Edge.Right, 60);
+    root.setBorder(Edge.Bottom, 60);
+    root.setWidth(320);
+    root.setHeight(320);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.Row);
+    root_child0.setJustifyContent(Justify.Center);
+    root_child0.setAlignContent(Align.SpaceEvenly);
+    root_child0.setFlexWrap(Wrap.Wrap);
+    root_child0.setHeight(10);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth("80%");
+    root_child0_child0.setHeight(20);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth("80%");
+    root_child0_child1.setHeight(20);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth("80%");
+    root_child0_child2.setHeight(20);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-25);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-5);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(15);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-25);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-5);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(15);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('align_content_space_evenly_wrapped_negative_space_gap', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setBorder(Edge.Left, 60);
+    root.setBorder(Edge.Top, 60);
+    root.setBorder(Edge.Right, 60);
+    root.setBorder(Edge.Bottom, 60);
+    root.setWidth(320);
+    root.setHeight(320);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.Row);
+    root_child0.setJustifyContent(Justify.Center);
+    root_child0.setAlignContent(Align.SpaceEvenly);
+    root_child0.setFlexWrap(Wrap.Wrap);
+    root_child0.setHeight(10);
+    root_child0.setGap(Gutter.Column, 10);
+    root_child0.setGap(Gutter.Row, 10);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth("80%");
+    root_child0_child0.setHeight(20);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth("80%");
+    root_child0_child1.setHeight(20);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth("80%");
+    root_child0_child2.setHeight(20);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-35);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-5);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(25);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(320);
+    expect(root.getComputedHeight()).toBe(320);
+
+    expect(root_child0.getComputedLeft()).toBe(60);
+    expect(root_child0.getComputedTop()).toBe(60);
+    expect(root_child0.getComputedWidth()).toBe(200);
+    expect(root_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(20);
+    expect(root_child0_child0.getComputedTop()).toBe(-35);
+    expect(root_child0_child0.getComputedWidth()).toBe(160);
+    expect(root_child0_child0.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(20);
+    expect(root_child0_child1.getComputedTop()).toBe(-5);
+    expect(root_child0_child1.getComputedWidth()).toBe(160);
+    expect(root_child0_child1.getComputedHeight()).toBe(20);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(25);
+    expect(root_child0_child2.getComputedWidth()).toBe(160);
+    expect(root_child0_child2.getComputedHeight()).toBe(20);
   } finally {
     if (typeof root !== 'undefined') {
       root.freeRecursive();
@@ -550,224 +2933,6 @@ test('align_content_stretch', () => {
     expect(root_child4.getComputedTop()).toBe(0);
     expect(root_child4.getComputedWidth()).toBe(50);
     expect(root_child4.getComputedHeight()).toBe(0);
-  } finally {
-    if (typeof root !== 'undefined') {
-      root.freeRecursive();
-    }
-
-    config.free();
-  }
-});
-test('align_content_spacebetween', () => {
-  const config = Yoga.Config.create();
-  let root;
-
-  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
-
-  try {
-    root = Yoga.Node.create(config);
-    root.setFlexDirection(FlexDirection.Row);
-    root.setAlignContent(Align.SpaceBetween);
-    root.setFlexWrap(Wrap.Wrap);
-    root.setWidth(130);
-    root.setHeight(100);
-
-    const root_child0 = Yoga.Node.create(config);
-    root_child0.setWidth(50);
-    root_child0.setHeight(10);
-    root.insertChild(root_child0, 0);
-
-    const root_child1 = Yoga.Node.create(config);
-    root_child1.setWidth(50);
-    root_child1.setHeight(10);
-    root.insertChild(root_child1, 1);
-
-    const root_child2 = Yoga.Node.create(config);
-    root_child2.setWidth(50);
-    root_child2.setHeight(10);
-    root.insertChild(root_child2, 2);
-
-    const root_child3 = Yoga.Node.create(config);
-    root_child3.setWidth(50);
-    root_child3.setHeight(10);
-    root.insertChild(root_child3, 3);
-
-    const root_child4 = Yoga.Node.create(config);
-    root_child4.setWidth(50);
-    root_child4.setHeight(10);
-    root.insertChild(root_child4, 4);
-    root.calculateLayout(undefined, undefined, Direction.LTR);
-
-    expect(root.getComputedLeft()).toBe(0);
-    expect(root.getComputedTop()).toBe(0);
-    expect(root.getComputedWidth()).toBe(130);
-    expect(root.getComputedHeight()).toBe(100);
-
-    expect(root_child0.getComputedLeft()).toBe(0);
-    expect(root_child0.getComputedTop()).toBe(0);
-    expect(root_child0.getComputedWidth()).toBe(50);
-    expect(root_child0.getComputedHeight()).toBe(10);
-
-    expect(root_child1.getComputedLeft()).toBe(50);
-    expect(root_child1.getComputedTop()).toBe(0);
-    expect(root_child1.getComputedWidth()).toBe(50);
-    expect(root_child1.getComputedHeight()).toBe(10);
-
-    expect(root_child2.getComputedLeft()).toBe(0);
-    expect(root_child2.getComputedTop()).toBe(45);
-    expect(root_child2.getComputedWidth()).toBe(50);
-    expect(root_child2.getComputedHeight()).toBe(10);
-
-    expect(root_child3.getComputedLeft()).toBe(50);
-    expect(root_child3.getComputedTop()).toBe(45);
-    expect(root_child3.getComputedWidth()).toBe(50);
-    expect(root_child3.getComputedHeight()).toBe(10);
-
-    expect(root_child4.getComputedLeft()).toBe(0);
-    expect(root_child4.getComputedTop()).toBe(90);
-    expect(root_child4.getComputedWidth()).toBe(50);
-    expect(root_child4.getComputedHeight()).toBe(10);
-
-    root.calculateLayout(undefined, undefined, Direction.RTL);
-
-    expect(root.getComputedLeft()).toBe(0);
-    expect(root.getComputedTop()).toBe(0);
-    expect(root.getComputedWidth()).toBe(130);
-    expect(root.getComputedHeight()).toBe(100);
-
-    expect(root_child0.getComputedLeft()).toBe(80);
-    expect(root_child0.getComputedTop()).toBe(0);
-    expect(root_child0.getComputedWidth()).toBe(50);
-    expect(root_child0.getComputedHeight()).toBe(10);
-
-    expect(root_child1.getComputedLeft()).toBe(30);
-    expect(root_child1.getComputedTop()).toBe(0);
-    expect(root_child1.getComputedWidth()).toBe(50);
-    expect(root_child1.getComputedHeight()).toBe(10);
-
-    expect(root_child2.getComputedLeft()).toBe(80);
-    expect(root_child2.getComputedTop()).toBe(45);
-    expect(root_child2.getComputedWidth()).toBe(50);
-    expect(root_child2.getComputedHeight()).toBe(10);
-
-    expect(root_child3.getComputedLeft()).toBe(30);
-    expect(root_child3.getComputedTop()).toBe(45);
-    expect(root_child3.getComputedWidth()).toBe(50);
-    expect(root_child3.getComputedHeight()).toBe(10);
-
-    expect(root_child4.getComputedLeft()).toBe(80);
-    expect(root_child4.getComputedTop()).toBe(90);
-    expect(root_child4.getComputedWidth()).toBe(50);
-    expect(root_child4.getComputedHeight()).toBe(10);
-  } finally {
-    if (typeof root !== 'undefined') {
-      root.freeRecursive();
-    }
-
-    config.free();
-  }
-});
-test('align_content_spacearound', () => {
-  const config = Yoga.Config.create();
-  let root;
-
-  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
-
-  try {
-    root = Yoga.Node.create(config);
-    root.setFlexDirection(FlexDirection.Row);
-    root.setAlignContent(Align.SpaceAround);
-    root.setFlexWrap(Wrap.Wrap);
-    root.setWidth(140);
-    root.setHeight(120);
-
-    const root_child0 = Yoga.Node.create(config);
-    root_child0.setWidth(50);
-    root_child0.setHeight(10);
-    root.insertChild(root_child0, 0);
-
-    const root_child1 = Yoga.Node.create(config);
-    root_child1.setWidth(50);
-    root_child1.setHeight(10);
-    root.insertChild(root_child1, 1);
-
-    const root_child2 = Yoga.Node.create(config);
-    root_child2.setWidth(50);
-    root_child2.setHeight(10);
-    root.insertChild(root_child2, 2);
-
-    const root_child3 = Yoga.Node.create(config);
-    root_child3.setWidth(50);
-    root_child3.setHeight(10);
-    root.insertChild(root_child3, 3);
-
-    const root_child4 = Yoga.Node.create(config);
-    root_child4.setWidth(50);
-    root_child4.setHeight(10);
-    root.insertChild(root_child4, 4);
-    root.calculateLayout(undefined, undefined, Direction.LTR);
-
-    expect(root.getComputedLeft()).toBe(0);
-    expect(root.getComputedTop()).toBe(0);
-    expect(root.getComputedWidth()).toBe(140);
-    expect(root.getComputedHeight()).toBe(120);
-
-    expect(root_child0.getComputedLeft()).toBe(0);
-    expect(root_child0.getComputedTop()).toBe(15);
-    expect(root_child0.getComputedWidth()).toBe(50);
-    expect(root_child0.getComputedHeight()).toBe(10);
-
-    expect(root_child1.getComputedLeft()).toBe(50);
-    expect(root_child1.getComputedTop()).toBe(15);
-    expect(root_child1.getComputedWidth()).toBe(50);
-    expect(root_child1.getComputedHeight()).toBe(10);
-
-    expect(root_child2.getComputedLeft()).toBe(0);
-    expect(root_child2.getComputedTop()).toBe(55);
-    expect(root_child2.getComputedWidth()).toBe(50);
-    expect(root_child2.getComputedHeight()).toBe(10);
-
-    expect(root_child3.getComputedLeft()).toBe(50);
-    expect(root_child3.getComputedTop()).toBe(55);
-    expect(root_child3.getComputedWidth()).toBe(50);
-    expect(root_child3.getComputedHeight()).toBe(10);
-
-    expect(root_child4.getComputedLeft()).toBe(0);
-    expect(root_child4.getComputedTop()).toBe(95);
-    expect(root_child4.getComputedWidth()).toBe(50);
-    expect(root_child4.getComputedHeight()).toBe(10);
-
-    root.calculateLayout(undefined, undefined, Direction.RTL);
-
-    expect(root.getComputedLeft()).toBe(0);
-    expect(root.getComputedTop()).toBe(0);
-    expect(root.getComputedWidth()).toBe(140);
-    expect(root.getComputedHeight()).toBe(120);
-
-    expect(root_child0.getComputedLeft()).toBe(90);
-    expect(root_child0.getComputedTop()).toBe(15);
-    expect(root_child0.getComputedWidth()).toBe(50);
-    expect(root_child0.getComputedHeight()).toBe(10);
-
-    expect(root_child1.getComputedLeft()).toBe(40);
-    expect(root_child1.getComputedTop()).toBe(15);
-    expect(root_child1.getComputedWidth()).toBe(50);
-    expect(root_child1.getComputedHeight()).toBe(10);
-
-    expect(root_child2.getComputedLeft()).toBe(90);
-    expect(root_child2.getComputedTop()).toBe(55);
-    expect(root_child2.getComputedWidth()).toBe(50);
-    expect(root_child2.getComputedHeight()).toBe(10);
-
-    expect(root_child3.getComputedLeft()).toBe(40);
-    expect(root_child3.getComputedTop()).toBe(55);
-    expect(root_child3.getComputedWidth()).toBe(50);
-    expect(root_child3.getComputedHeight()).toBe(10);
-
-    expect(root_child4.getComputedLeft()).toBe(90);
-    expect(root_child4.getComputedTop()).toBe(95);
-    expect(root_child4.getComputedWidth()).toBe(50);
-    expect(root_child4.getComputedHeight()).toBe(10);
   } finally {
     if (typeof root !== 'undefined') {
       root.freeRecursive();

--- a/javascript/tests/generated/YGAspectRatioTest.test.ts
+++ b/javascript/tests/generated/YGAspectRatioTest.test.ts
@@ -95,28 +95,28 @@ test.skip('aspect_ratio_does_not_stretch_cross_axis_dim', () => {
 
     expect(root_child0_child0.getComputedLeft()).toBe(0);
     expect(root_child0_child0.getComputedTop()).toBe(0);
-    expect(root_child0_child0.getComputedWidth()).toBe(300);
-    expect(root_child0_child0.getComputedHeight()).toBe(197);
+    expect(root_child0_child0.getComputedWidth()).toBe(285);
+    expect(root_child0_child0.getComputedHeight()).toBe(187);
 
     expect(root_child0_child0_child0.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child0.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child0.getComputedWidth()).toBe(197);
-    expect(root_child0_child0_child0.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child0.getComputedWidth()).toBe(187);
+    expect(root_child0_child0_child0.getComputedHeight()).toBe(187);
 
-    expect(root_child0_child0_child1.getComputedLeft()).toBe(197);
+    expect(root_child0_child0_child1.getComputedLeft()).toBe(187);
     expect(root_child0_child0_child1.getComputedTop()).toBe(0);
     expect(root_child0_child0_child1.getComputedWidth()).toBe(5);
-    expect(root_child0_child0_child1.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child1.getComputedHeight()).toBe(187);
 
-    expect(root_child0_child0_child2.getComputedLeft()).toBe(202);
+    expect(root_child0_child0_child2.getComputedLeft()).toBe(192);
     expect(root_child0_child0_child2.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child2.getComputedWidth()).toBe(98);
-    expect(root_child0_child0_child2.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child2.getComputedWidth()).toBe(93);
+    expect(root_child0_child0_child2.getComputedHeight()).toBe(187);
 
     expect(root_child0_child0_child2_child0.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child2_child0.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child2_child0.getComputedWidth()).toBe(98);
-    expect(root_child0_child0_child2_child0.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child2_child0.getComputedWidth()).toBe(93);
+    expect(root_child0_child0_child2_child0.getComputedHeight()).toBe(187);
 
     expect(root_child0_child0_child2_child0_child0.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child2_child0_child0.getComputedTop()).toBe(0);
@@ -125,8 +125,8 @@ test.skip('aspect_ratio_does_not_stretch_cross_axis_dim', () => {
 
     expect(root_child0_child0_child2_child0_child1.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child2_child0_child1.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child2_child0_child1.getComputedWidth()).toBe(98);
-    expect(root_child0_child0_child2_child0_child1.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child2_child0_child1.getComputedWidth()).toBe(93);
+    expect(root_child0_child0_child2_child0_child1.getComputedHeight()).toBe(187);
 
     root.calculateLayout(undefined, undefined, Direction.RTL);
 
@@ -140,40 +140,40 @@ test.skip('aspect_ratio_does_not_stretch_cross_axis_dim', () => {
     expect(root_child0.getComputedWidth()).toBe(300);
     expect(root_child0.getComputedHeight()).toBe(300);
 
-    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedLeft()).toBe(30);
     expect(root_child0_child0.getComputedTop()).toBe(0);
-    expect(root_child0_child0.getComputedWidth()).toBe(300);
-    expect(root_child0_child0.getComputedHeight()).toBe(197);
+    expect(root_child0_child0.getComputedWidth()).toBe(285);
+    expect(root_child0_child0.getComputedHeight()).toBe(187);
 
-    expect(root_child0_child0_child0.getComputedLeft()).toBe(103);
+    expect(root_child0_child0_child0.getComputedLeft()).toBe(98);
     expect(root_child0_child0_child0.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child0.getComputedWidth()).toBe(197);
-    expect(root_child0_child0_child0.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child0.getComputedWidth()).toBe(187);
+    expect(root_child0_child0_child0.getComputedHeight()).toBe(187);
 
-    expect(root_child0_child0_child1.getComputedLeft()).toBe(98);
+    expect(root_child0_child0_child1.getComputedLeft()).toBe(93);
     expect(root_child0_child0_child1.getComputedTop()).toBe(0);
     expect(root_child0_child0_child1.getComputedWidth()).toBe(5);
-    expect(root_child0_child0_child1.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child1.getComputedHeight()).toBe(187);
 
     expect(root_child0_child0_child2.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child2.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child2.getComputedWidth()).toBe(98);
-    expect(root_child0_child0_child2.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child2.getComputedWidth()).toBe(93);
+    expect(root_child0_child0_child2.getComputedHeight()).toBe(187);
 
     expect(root_child0_child0_child2_child0.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child2_child0.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child2_child0.getComputedWidth()).toBe(98);
-    expect(root_child0_child0_child2_child0.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child2_child0.getComputedWidth()).toBe(93);
+    expect(root_child0_child0_child2_child0.getComputedHeight()).toBe(187);
 
-    expect(root_child0_child0_child2_child0_child0.getComputedLeft()).toBe(93);
+    expect(root_child0_child0_child2_child0_child0.getComputedLeft()).toBe(88);
     expect(root_child0_child0_child2_child0_child0.getComputedTop()).toBe(0);
     expect(root_child0_child0_child2_child0_child0.getComputedWidth()).toBe(5);
     expect(root_child0_child0_child2_child0_child0.getComputedHeight()).toBe(0);
 
     expect(root_child0_child0_child2_child0_child1.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child2_child0_child1.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child2_child0_child1.getComputedWidth()).toBe(98);
-    expect(root_child0_child0_child2_child0_child1.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child2_child0_child1.getComputedWidth()).toBe(93);
+    expect(root_child0_child0_child2_child0_child1.getComputedHeight()).toBe(187);
   } finally {
     if (typeof root !== 'undefined') {
       root.freeRecursive();

--- a/tests/NumericBitfieldTest.cpp
+++ b/tests/NumericBitfieldTest.cpp
@@ -191,8 +191,8 @@ TEST(NumericBitfield, third_enum_can_be_set) {
 TEST(NumericBitfield, setting_values_does_not_spill_over) {
   uint32_t flags = 0;
   static constexpr size_t alignOffset = 0;
-  static constexpr size_t edgesOffset = 3;
-  static constexpr size_t boolOffset = 7;
+  static constexpr size_t edgesOffset = 4;
+  static constexpr size_t boolOffset = 8;
 
   uint32_t edge = 0xffffff;
   setEnumData<YGEdge>(flags, edgesOffset, (YGEdge)edge);

--- a/tests/generated/YGAlignContentTest.cpp
+++ b/tests/generated/YGAlignContentTest.cpp
@@ -11,15 +11,72 @@
 #include <gtest/gtest.h>
 #include <yoga/Yoga.h>
 
-TEST(YogaTest, align_content_flex_start) {
+TEST(YogaTest, align_content_flex_start_nowrap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_flex_start_wrap) {
   const YGConfigRef config = YGConfigNew();
   YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
   YGNodeStyleSetFlexWrap(root, YGWrapWrap);
-  YGNodeStyleSetWidth(root, 130);
-  YGNodeStyleSetHeight(root, 100);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetWidth(root_child0, 50);
@@ -49,8 +106,8 @@ TEST(YogaTest, align_content_flex_start) {
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
-  ASSERT_FLOAT_EQ(130, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
@@ -81,33 +138,277 @@ TEST(YogaTest, align_content_flex_start) {
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
-  ASSERT_FLOAT_EQ(130, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
 
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child2));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child2));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
 
-  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child3));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child3));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
 
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child4));
   ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child4));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_flex_start_wrap_singleline) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_flex_start_wrapped_negative_space) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetBorder(root, YGEdgeLeft, 60);
+  YGNodeStyleSetBorder(root, YGEdgeTop, 60);
+  YGNodeStyleSetBorder(root, YGEdgeRight, 60);
+  YGNodeStyleSetBorder(root, YGEdgeBottom, 60);
+  YGNodeStyleSetWidth(root, 320);
+  YGNodeStyleSetHeight(root, 320);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
+  YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
+  YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child0, 80);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child1, 80);
+  YGNodeStyleSetHeight(root_child0_child1, 20);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child2, 80);
+  YGNodeStyleSetHeight(root_child0_child2, 20);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_flex_start_wrapped_negative_space_gap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetBorder(root, YGEdgeLeft, 60);
+  YGNodeStyleSetBorder(root, YGEdgeTop, 60);
+  YGNodeStyleSetBorder(root, YGEdgeRight, 60);
+  YGNodeStyleSetBorder(root, YGEdgeBottom, 60);
+  YGNodeStyleSetWidth(root, 320);
+  YGNodeStyleSetHeight(root, 320);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
+  YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
+  YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeStyleSetGap(root_child0, YGGutterColumn, 10);
+  YGNodeStyleSetGap(root_child0, YGGutterRow, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child0, 80);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child1, 80);
+  YGNodeStyleSetHeight(root_child0_child1, 20);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child2, 80);
+  YGNodeStyleSetHeight(root_child0_child2, 20);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeFreeRecursive(root);
 
@@ -318,15 +619,74 @@ TEST(YogaTest, align_content_flex_start_with_flex) {
   YGConfigFree(config);
 }
 
-TEST(YogaTest, align_content_flex_end) {
+TEST(YogaTest, align_content_flex_end_nowrap) {
   const YGConfigRef config = YGConfigNew();
   YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignFlexEnd);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_flex_end_wrap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root, YGAlignFlexEnd);
   YGNodeStyleSetFlexWrap(root, YGWrapWrap);
-  YGNodeStyleSetWidth(root, 100);
-  YGNodeStyleSetHeight(root, 100);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetWidth(root_child0, 50);
@@ -356,31 +716,31 @@ TEST(YogaTest, align_content_flex_end) {
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
 
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child1));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
 
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child2));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
 
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child3));
-  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child3));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
 
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child4));
-  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child4));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
 
@@ -388,33 +748,1916 @@ TEST(YogaTest, align_content_flex_end) {
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_flex_end_wrap_singleline) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignFlexEnd);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_flex_end_wrapped_negative_space) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetBorder(root, YGEdgeLeft, 60);
+  YGNodeStyleSetBorder(root, YGEdgeTop, 60);
+  YGNodeStyleSetBorder(root, YGEdgeRight, 60);
+  YGNodeStyleSetBorder(root, YGEdgeBottom, 60);
+  YGNodeStyleSetWidth(root, 320);
+  YGNodeStyleSetHeight(root, 320);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
+  YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
+  YGNodeStyleSetAlignContent(root_child0, YGAlignFlexEnd);
+  YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child0, 80);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child1, 80);
+  YGNodeStyleSetHeight(root_child0_child1, 20);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child2, 80);
+  YGNodeStyleSetHeight(root_child0_child2, 20);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-50, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-30, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-50, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-30, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_flex_end_wrapped_negative_space_gap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetBorder(root, YGEdgeLeft, 60);
+  YGNodeStyleSetBorder(root, YGEdgeTop, 60);
+  YGNodeStyleSetBorder(root, YGEdgeRight, 60);
+  YGNodeStyleSetBorder(root, YGEdgeBottom, 60);
+  YGNodeStyleSetWidth(root, 320);
+  YGNodeStyleSetHeight(root, 320);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
+  YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
+  YGNodeStyleSetAlignContent(root_child0, YGAlignFlexEnd);
+  YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeStyleSetGap(root_child0, YGGutterColumn, 10);
+  YGNodeStyleSetGap(root_child0, YGGutterRow, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child0, 80);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child1, 80);
+  YGNodeStyleSetHeight(root_child0_child1, 20);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child2, 80);
+  YGNodeStyleSetHeight(root_child0_child2, 20);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-70, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-40, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-70, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-40, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_center_nowrap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignCenter);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_center_wrap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignCenter);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child2, 50);
+  YGNodeStyleSetHeight(root_child2, 10);
+  YGNodeInsertChild(root, root_child2, 2);
+
+  const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child3, 50);
+  YGNodeStyleSetHeight(root_child3, 10);
+  YGNodeInsertChild(root, root_child3, 3);
+
+  const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child4, 50);
+  YGNodeStyleSetHeight(root_child4, 10);
+  YGNodeInsertChild(root, root_child4, 4);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetTop(root_child1));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child2));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
 
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child3));
-  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child3));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child4));
-  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(65, YGNodeLayoutGetTop(root_child4));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
   ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(65, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_center_wrap_singleline) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignCenter);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_center_wrapped_negative_space) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetBorder(root, YGEdgeLeft, 60);
+  YGNodeStyleSetBorder(root, YGEdgeTop, 60);
+  YGNodeStyleSetBorder(root, YGEdgeRight, 60);
+  YGNodeStyleSetBorder(root, YGEdgeBottom, 60);
+  YGNodeStyleSetWidth(root, 320);
+  YGNodeStyleSetHeight(root, 320);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
+  YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
+  YGNodeStyleSetAlignContent(root_child0, YGAlignCenter);
+  YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child0, 80);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child1, 80);
+  YGNodeStyleSetHeight(root_child0_child1, 20);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child2, 80);
+  YGNodeStyleSetHeight(root_child0_child2, 20);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-25, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-25, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_center_wrapped_negative_space_gap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetBorder(root, YGEdgeLeft, 60);
+  YGNodeStyleSetBorder(root, YGEdgeTop, 60);
+  YGNodeStyleSetBorder(root, YGEdgeRight, 60);
+  YGNodeStyleSetBorder(root, YGEdgeBottom, 60);
+  YGNodeStyleSetWidth(root, 320);
+  YGNodeStyleSetHeight(root, 320);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
+  YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
+  YGNodeStyleSetAlignContent(root_child0, YGAlignCenter);
+  YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeStyleSetGap(root_child0, YGGutterColumn, 10);
+  YGNodeStyleSetGap(root_child0, YGGutterRow, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child0, 80);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child1, 80);
+  YGNodeStyleSetHeight(root_child0_child1, 20);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child2, 80);
+  YGNodeStyleSetHeight(root_child0_child2, 20);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-35, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-35, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_between_nowrap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignSpaceBetween);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_between_wrap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignSpaceBetween);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child2, 50);
+  YGNodeStyleSetHeight(root_child2, 10);
+  YGNodeInsertChild(root, root_child2, 2);
+
+  const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child3, 50);
+  YGNodeStyleSetHeight(root_child3, 10);
+  YGNodeInsertChild(root, root_child3, 3);
+
+  const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child4, 50);
+  YGNodeStyleSetHeight(root_child4, 10);
+  YGNodeInsertChild(root, root_child4, 4);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_between_wrap_singleline) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignSpaceBetween);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_between_wrapped_negative_space) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetBorder(root, YGEdgeLeft, 60);
+  YGNodeStyleSetBorder(root, YGEdgeTop, 60);
+  YGNodeStyleSetBorder(root, YGEdgeRight, 60);
+  YGNodeStyleSetBorder(root, YGEdgeBottom, 60);
+  YGNodeStyleSetWidth(root, 320);
+  YGNodeStyleSetHeight(root, 320);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
+  YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
+  YGNodeStyleSetAlignContent(root_child0, YGAlignSpaceBetween);
+  YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child0, 80);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child1, 80);
+  YGNodeStyleSetHeight(root_child0_child1, 20);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child2, 80);
+  YGNodeStyleSetHeight(root_child0_child2, 20);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_between_wrapped_negative_space_gap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetBorder(root, YGEdgeLeft, 60);
+  YGNodeStyleSetBorder(root, YGEdgeTop, 60);
+  YGNodeStyleSetBorder(root, YGEdgeRight, 60);
+  YGNodeStyleSetBorder(root, YGEdgeBottom, 60);
+  YGNodeStyleSetWidth(root, 320);
+  YGNodeStyleSetHeight(root, 320);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
+  YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
+  YGNodeStyleSetAlignContent(root_child0, YGAlignSpaceBetween);
+  YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeStyleSetGap(root_child0, YGGutterColumn, 10);
+  YGNodeStyleSetGap(root_child0, YGGutterRow, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child0, 80);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child1, 80);
+  YGNodeStyleSetHeight(root_child0_child1, 20);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child2, 80);
+  YGNodeStyleSetHeight(root_child0_child2, 20);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_around_nowrap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignSpaceAround);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_around_wrap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignSpaceAround);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child2, 50);
+  YGNodeStyleSetHeight(root_child2, 10);
+  YGNodeInsertChild(root, root_child2, 2);
+
+  const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child3, 50);
+  YGNodeStyleSetHeight(root_child3, 10);
+  YGNodeInsertChild(root, root_child3, 3);
+
+  const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child4, 50);
+  YGNodeStyleSetHeight(root_child4, 10);
+  YGNodeInsertChild(root, root_child4, 4);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(95, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(95, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_around_wrap_singleline) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignSpaceAround);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_around_wrapped_negative_space) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetBorder(root, YGEdgeLeft, 60);
+  YGNodeStyleSetBorder(root, YGEdgeTop, 60);
+  YGNodeStyleSetBorder(root, YGEdgeRight, 60);
+  YGNodeStyleSetBorder(root, YGEdgeBottom, 60);
+  YGNodeStyleSetWidth(root, 320);
+  YGNodeStyleSetHeight(root, 320);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
+  YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
+  YGNodeStyleSetAlignContent(root_child0, YGAlignSpaceAround);
+  YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child0, 80);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child1, 80);
+  YGNodeStyleSetHeight(root_child0_child1, 20);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child2, 80);
+  YGNodeStyleSetHeight(root_child0_child2, 20);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-25, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-25, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_around_wrapped_negative_space_gap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetBorder(root, YGEdgeLeft, 60);
+  YGNodeStyleSetBorder(root, YGEdgeTop, 60);
+  YGNodeStyleSetBorder(root, YGEdgeRight, 60);
+  YGNodeStyleSetBorder(root, YGEdgeBottom, 60);
+  YGNodeStyleSetWidth(root, 320);
+  YGNodeStyleSetHeight(root, 320);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
+  YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
+  YGNodeStyleSetAlignContent(root_child0, YGAlignSpaceAround);
+  YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeStyleSetGap(root_child0, YGGutterColumn, 10);
+  YGNodeStyleSetGap(root_child0, YGGutterRow, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child0, 80);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child1, 80);
+  YGNodeStyleSetHeight(root_child0_child1, 20);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child2, 80);
+  YGNodeStyleSetHeight(root_child0_child2, 20);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-35, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-35, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_evenly_nowrap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignSpaceEvenly);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_evenly_wrap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignSpaceEvenly);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child2, 50);
+  YGNodeStyleSetHeight(root_child2, 10);
+  YGNodeInsertChild(root, root_child2, 2);
+
+  const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child3, 50);
+  YGNodeStyleSetHeight(root_child3, 10);
+  YGNodeInsertChild(root, root_child3, 3);
+
+  const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child4, 50);
+  YGNodeStyleSetHeight(root_child4, 10);
+  YGNodeInsertChild(root, root_child4, 4);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(23, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(23, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(88, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(23, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(23, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(88, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_evenly_wrap_singleline) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignSpaceEvenly);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 140);
+  YGNodeStyleSetHeight(root, 120);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 50);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 50);
+  YGNodeStyleSetHeight(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_evenly_wrapped_negative_space) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetBorder(root, YGEdgeLeft, 60);
+  YGNodeStyleSetBorder(root, YGEdgeTop, 60);
+  YGNodeStyleSetBorder(root, YGEdgeRight, 60);
+  YGNodeStyleSetBorder(root, YGEdgeBottom, 60);
+  YGNodeStyleSetWidth(root, 320);
+  YGNodeStyleSetHeight(root, 320);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
+  YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
+  YGNodeStyleSetAlignContent(root_child0, YGAlignSpaceEvenly);
+  YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child0, 80);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child1, 80);
+  YGNodeStyleSetHeight(root_child0_child1, 20);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child2, 80);
+  YGNodeStyleSetHeight(root_child0_child2, 20);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-25, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-25, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, align_content_space_evenly_wrapped_negative_space_gap) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetBorder(root, YGEdgeLeft, 60);
+  YGNodeStyleSetBorder(root, YGEdgeTop, 60);
+  YGNodeStyleSetBorder(root, YGEdgeRight, 60);
+  YGNodeStyleSetBorder(root, YGEdgeBottom, 60);
+  YGNodeStyleSetWidth(root, 320);
+  YGNodeStyleSetHeight(root, 320);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
+  YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
+  YGNodeStyleSetAlignContent(root_child0, YGAlignSpaceEvenly);
+  YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
+  YGNodeStyleSetHeight(root_child0, 10);
+  YGNodeStyleSetGap(root_child0, YGGutterColumn, 10);
+  YGNodeStyleSetGap(root_child0, YGGutterRow, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child0, 80);
+  YGNodeStyleSetHeight(root_child0_child0, 20);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child1, 80);
+  YGNodeStyleSetHeight(root_child0_child1, 20);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidthPercent(root_child0_child2, 80);
+  YGNodeStyleSetHeight(root_child0_child2, 20);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-35, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(320, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(-35, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(-5, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(25, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(160, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeFreeRecursive(root);
 
@@ -513,214 +2756,6 @@ TEST(YogaTest, align_content_stretch) {
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child4));
   ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child4));
-
-  YGNodeFreeRecursive(root);
-
-  YGConfigFree(config);
-}
-
-TEST(YogaTest, align_content_spacebetween) {
-  const YGConfigRef config = YGConfigNew();
-  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
-
-  const YGNodeRef root = YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
-  YGNodeStyleSetAlignContent(root, YGAlignSpaceBetween);
-  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
-  YGNodeStyleSetWidth(root, 130);
-  YGNodeStyleSetHeight(root, 100);
-
-  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child0, 50);
-  YGNodeStyleSetHeight(root_child0, 10);
-  YGNodeInsertChild(root, root_child0, 0);
-
-  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child1, 50);
-  YGNodeStyleSetHeight(root_child1, 10);
-  YGNodeInsertChild(root, root_child1, 1);
-
-  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child2, 50);
-  YGNodeStyleSetHeight(root_child2, 10);
-  YGNodeInsertChild(root, root_child2, 2);
-
-  const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child3, 50);
-  YGNodeStyleSetHeight(root_child3, 10);
-  YGNodeInsertChild(root, root_child3, 3);
-
-  const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child4, 50);
-  YGNodeStyleSetHeight(root_child4, 10);
-  YGNodeInsertChild(root, root_child4, 4);
-  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
-  ASSERT_FLOAT_EQ(130, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
-
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
-
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child3));
-  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetTop(root_child3));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child4));
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child4));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
-
-  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
-  ASSERT_FLOAT_EQ(130, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
-
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
-
-  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
-
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
-
-  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child3));
-  ASSERT_FLOAT_EQ(45, YGNodeLayoutGetTop(root_child3));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
-
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child4));
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child4));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
-
-  YGNodeFreeRecursive(root);
-
-  YGConfigFree(config);
-}
-
-TEST(YogaTest, align_content_spacearound) {
-  const YGConfigRef config = YGConfigNew();
-  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
-
-  const YGNodeRef root = YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
-  YGNodeStyleSetAlignContent(root, YGAlignSpaceAround);
-  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
-  YGNodeStyleSetWidth(root, 140);
-  YGNodeStyleSetHeight(root, 120);
-
-  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child0, 50);
-  YGNodeStyleSetHeight(root_child0, 10);
-  YGNodeInsertChild(root, root_child0, 0);
-
-  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child1, 50);
-  YGNodeStyleSetHeight(root_child1, 10);
-  YGNodeInsertChild(root, root_child1, 1);
-
-  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child2, 50);
-  YGNodeStyleSetHeight(root_child2, 10);
-  YGNodeInsertChild(root, root_child2, 2);
-
-  const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child3, 50);
-  YGNodeStyleSetHeight(root_child3, 10);
-  YGNodeInsertChild(root, root_child3, 3);
-
-  const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child4, 50);
-  YGNodeStyleSetHeight(root_child4, 10);
-  YGNodeInsertChild(root, root_child4, 4);
-  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
-  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
-  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
-
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
-
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child3));
-  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child3));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child4));
-  ASSERT_FLOAT_EQ(95, YGNodeLayoutGetTop(root_child4));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
-
-  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
-
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
-  ASSERT_FLOAT_EQ(140, YGNodeLayoutGetWidth(root));
-  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetHeight(root));
-
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
-  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0));
-
-  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(15, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child1));
-
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child2));
-
-  ASSERT_FLOAT_EQ(40, YGNodeLayoutGetLeft(root_child3));
-  ASSERT_FLOAT_EQ(55, YGNodeLayoutGetTop(root_child3));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child3));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child3));
-
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child4));
-  ASSERT_FLOAT_EQ(95, YGNodeLayoutGetTop(root_child4));
-  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetWidth(root_child4));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child4));
 
   YGNodeFreeRecursive(root);
 

--- a/tests/generated/YGAspectRatioTest.cpp
+++ b/tests/generated/YGAspectRatioTest.cpp
@@ -80,28 +80,28 @@ TEST(YogaTest, aspect_ratio_does_not_stretch_cross_axis_dim) {
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
-  ASSERT_FLOAT_EQ(300, YGNodeLayoutGetWidth(root_child0_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0));
+  ASSERT_FLOAT_EQ(285, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetWidth(root_child0_child0_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetWidth(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child0));
 
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetLeft(root_child0_child0_child1));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetLeft(root_child0_child0_child1));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child1));
   ASSERT_FLOAT_EQ(5, YGNodeLayoutGetWidth(root_child0_child0_child1));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child1));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child1));
 
-  ASSERT_FLOAT_EQ(202, YGNodeLayoutGetLeft(root_child0_child0_child2));
+  ASSERT_FLOAT_EQ(192, YGNodeLayoutGetLeft(root_child0_child0_child2));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2));
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetWidth(root_child0_child0_child2));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child2));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetWidth(root_child0_child0_child2));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child2));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child2_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2_child0));
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetWidth(root_child0_child0_child2_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child2_child0));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetWidth(root_child0_child0_child2_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child2_child0));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child2_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2_child0_child0));
@@ -110,8 +110,8 @@ TEST(YogaTest, aspect_ratio_does_not_stretch_cross_axis_dim) {
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child2_child0_child1));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2_child0_child1));
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetWidth(root_child0_child0_child2_child0_child1));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child2_child0_child1));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetWidth(root_child0_child0_child2_child0_child1));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child2_child0_child1));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
 
@@ -125,40 +125,40 @@ TEST(YogaTest, aspect_ratio_does_not_stretch_cross_axis_dim) {
   ASSERT_FLOAT_EQ(300, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(300, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
-  ASSERT_FLOAT_EQ(300, YGNodeLayoutGetWidth(root_child0_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0));
+  ASSERT_FLOAT_EQ(285, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(103, YGNodeLayoutGetLeft(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetLeft(root_child0_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetWidth(root_child0_child0_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetWidth(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child0));
 
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetLeft(root_child0_child0_child1));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetLeft(root_child0_child0_child1));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child1));
   ASSERT_FLOAT_EQ(5, YGNodeLayoutGetWidth(root_child0_child0_child1));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child1));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child1));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child2));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2));
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetWidth(root_child0_child0_child2));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child2));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetWidth(root_child0_child0_child2));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child2));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child2_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2_child0));
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetWidth(root_child0_child0_child2_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child2_child0));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetWidth(root_child0_child0_child2_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child2_child0));
 
-  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetLeft(root_child0_child0_child2_child0_child0));
+  ASSERT_FLOAT_EQ(88, YGNodeLayoutGetLeft(root_child0_child0_child2_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2_child0_child0));
   ASSERT_FLOAT_EQ(5, YGNodeLayoutGetWidth(root_child0_child0_child2_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0_child2_child0_child0));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child2_child0_child1));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2_child0_child1));
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetWidth(root_child0_child0_child2_child0_child1));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child2_child0_child1));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetWidth(root_child0_child0_child2_child0_child1));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child2_child0_child1));
 
   YGNodeFreeRecursive(root);
 

--- a/yoga/YGEnums.cpp
+++ b/yoga/YGEnums.cpp
@@ -27,6 +27,8 @@ const char* YGAlignToString(const YGAlign value) {
       return "space-between";
     case YGAlignSpaceAround:
       return "space-around";
+    case YGAlignSpaceEvenly:
+      return "space-evenly";
   }
   return "unknown";
 }

--- a/yoga/YGEnums.h
+++ b/yoga/YGEnums.h
@@ -21,7 +21,8 @@ YG_ENUM_SEQ_DECL(
     YGAlignStretch,
     YGAlignBaseline,
     YGAlignSpaceBetween,
-    YGAlignSpaceAround)
+    YGAlignSpaceAround,
+    YGAlignSpaceEvenly)
 
 YG_ENUM_SEQ_DECL(
     YGDimension,

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -2021,6 +2021,18 @@ static void calculateLayoutImpl(
             currentLead += remainingAlignContentDim / 2;
           }
           break;
+        case Align::SpaceEvenly:
+          if (availableInnerCrossDim > totalLineCrossDim) {
+            currentLead +=
+                remainingAlignContentDim / static_cast<float>(lineCount + 1);
+            if (lineCount > 1) {
+              crossDimLead =
+                  remainingAlignContentDim / static_cast<float>(lineCount + 1);
+            }
+          } else {
+            currentLead += remainingAlignContentDim / 2;
+          }
+          break;
         case Align::SpaceBetween:
           if (availableInnerCrossDim > totalLineCrossDim && lineCount > 1) {
             crossDimLead =
@@ -2177,6 +2189,7 @@ static void calculateLayoutImpl(
               case Align::Auto:
               case Align::SpaceBetween:
               case Align::SpaceAround:
+              case Align::SpaceEvenly:
                 break;
             }
           }

--- a/yoga/enums/Align.h
+++ b/yoga/enums/Align.h
@@ -24,16 +24,17 @@ enum class Align : uint8_t {
   Baseline = YGAlignBaseline,
   SpaceBetween = YGAlignSpaceBetween,
   SpaceAround = YGAlignSpaceAround,
+  SpaceEvenly = YGAlignSpaceEvenly,
 };
 
 template <>
 constexpr inline int32_t ordinalCount<Align>() {
-  return 8;
+  return 9;
 } 
 
 template <>
 constexpr inline int32_t bitCount<Align>() {
-  return 3;
+  return 4;
 } 
 
 constexpr inline Align scopedEnum(YGAlign unscoped) {


### PR DESCRIPTION
### Changes made
- Regenerated tests (as some aspect ratio tests seem to be out of date compared to the fixtures)
- Added SpaceEvenly variant to the "Align" enums (via enums.py)
- Implemented `align-content: space-evenly` alignment in CalculateLayout.cpp
- Added generated tests `align-content: space-evenly`
- Updated NumericBitfield test to account for the fact that the Align enum now requires more bits (this bit could do with being reviewed as I am not 100% certain that it's valid to just update the test like this).

### Changes not made
- Any attempt to improve the spec-compliance of content alignment in general (e.g. I think https://github.com/facebook/yoga/pull/1013 probably still needs to happen)