### PR TITLE
Fix issue where paddingStart and paddingEnd were swapped with row reverse

### DIFF
--- a/gentest/fixtures/YGFlexDirectionTest.html
+++ b/gentest/fixtures/YGFlexDirectionTest.html
@@ -113,7 +113,7 @@
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_border_start" data-disabled="true" style="height: 100px; width: 100px; flex-direction: row-reverse; border-start-width: 100px;">
+<div id="flex_direction_row_reverse_border_start" style="height: 100px; width: 100px; flex-direction: row-reverse; border-start-width: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
@@ -125,7 +125,7 @@
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_border_end" data-disabled="true" style="height: 100px; width: 100px; flex-direction: row-reverse; border-end-width: 100px;">
+<div id="flex_direction_row_reverse_border_end" style="height: 100px; width: 100px; flex-direction: row-reverse; border-end-width: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>

--- a/java/tests/com/facebook/yoga/YGAspectRatioTest.java
+++ b/java/tests/com/facebook/yoga/YGAspectRatioTest.java
@@ -95,28 +95,28 @@ public class YGAspectRatioTest {
 
     assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
-    assertEquals(300f, root_child0_child0.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0.getLayoutHeight(), 0.0f);
+    assertEquals(285f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0_child0_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child0.getLayoutY(), 0.0f);
-    assertEquals(197f, root_child0_child0_child0.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child0.getLayoutHeight(), 0.0f);
+    assertEquals(187f, root_child0_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(197f, root_child0_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(187f, root_child0_child0_child1.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child1.getLayoutY(), 0.0f);
     assertEquals(5f, root_child0_child0_child1.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child1.getLayoutHeight(), 0.0f);
+    assertEquals(187f, root_child0_child0_child1.getLayoutHeight(), 0.0f);
 
-    assertEquals(202f, root_child0_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(192f, root_child0_child0_child2.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2.getLayoutY(), 0.0f);
-    assertEquals(98f, root_child0_child0_child2.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child2.getLayoutHeight(), 0.0f);
+    assertEquals(93f, root_child0_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child2.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0_child0_child2_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0.getLayoutY(), 0.0f);
-    assertEquals(98f, root_child0_child0_child2_child0.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child2_child0.getLayoutHeight(), 0.0f);
+    assertEquals(93f, root_child0_child0_child2_child0.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child2_child0.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0_child0_child2_child0_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0_child0.getLayoutY(), 0.0f);
@@ -125,8 +125,8 @@ public class YGAspectRatioTest {
 
     assertEquals(0f, root_child0_child0_child2_child0_child1.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0_child1.getLayoutY(), 0.0f);
-    assertEquals(98f, root_child0_child0_child2_child0_child1.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child2_child0_child1.getLayoutHeight(), 0.0f);
+    assertEquals(93f, root_child0_child0_child2_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child2_child0_child1.getLayoutHeight(), 0.0f);
 
     root.setDirection(YogaDirection.RTL);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
@@ -141,40 +141,40 @@ public class YGAspectRatioTest {
     assertEquals(300f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(300f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(30f, root_child0_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
-    assertEquals(300f, root_child0_child0.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0.getLayoutHeight(), 0.0f);
+    assertEquals(285f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(103f, root_child0_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(98f, root_child0_child0_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child0.getLayoutY(), 0.0f);
-    assertEquals(197f, root_child0_child0_child0.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child0.getLayoutHeight(), 0.0f);
+    assertEquals(187f, root_child0_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(98f, root_child0_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(93f, root_child0_child0_child1.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child1.getLayoutY(), 0.0f);
     assertEquals(5f, root_child0_child0_child1.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child1.getLayoutHeight(), 0.0f);
+    assertEquals(187f, root_child0_child0_child1.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0_child0_child2.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2.getLayoutY(), 0.0f);
-    assertEquals(98f, root_child0_child0_child2.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child2.getLayoutHeight(), 0.0f);
+    assertEquals(93f, root_child0_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child2.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0_child0_child2_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0.getLayoutY(), 0.0f);
-    assertEquals(98f, root_child0_child0_child2_child0.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child2_child0.getLayoutHeight(), 0.0f);
+    assertEquals(93f, root_child0_child0_child2_child0.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child2_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(93f, root_child0_child0_child2_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(88f, root_child0_child0_child2_child0_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0_child0.getLayoutY(), 0.0f);
     assertEquals(5f, root_child0_child0_child2_child0_child0.getLayoutWidth(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0_child0.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0_child0_child2_child0_child1.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0_child0_child2_child0_child1.getLayoutY(), 0.0f);
-    assertEquals(98f, root_child0_child0_child2_child0_child1.getLayoutWidth(), 0.0f);
-    assertEquals(197f, root_child0_child0_child2_child0_child1.getLayoutHeight(), 0.0f);
+    assertEquals(93f, root_child0_child0_child2_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(187f, root_child0_child0_child2_child0_child1.getLayoutHeight(), 0.0f);
   }
 
   private YogaNode createNode(YogaConfig config) {

--- a/java/tests/com/facebook/yoga/YGFlexDirectionTest.java
+++ b/java/tests/com/facebook/yoga/YGFlexDirectionTest.java
@@ -1329,7 +1329,6 @@ public class YGFlexDirectionTest {
   }
 
   @Test
-  @Ignore
   public void test_flex_direction_row_reverse_border_start() {
     YogaConfig config = YogaConfigFactory.create();
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
@@ -1468,7 +1467,6 @@ public class YGFlexDirectionTest {
   }
 
   @Test
-  @Ignore
   public void test_flex_direction_row_reverse_border_end() {
     YogaConfig config = YogaConfigFactory.create();
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);

--- a/javascript/tests/generated/YGAspectRatioTest.test.ts
+++ b/javascript/tests/generated/YGAspectRatioTest.test.ts
@@ -95,28 +95,28 @@ test.skip('aspect_ratio_does_not_stretch_cross_axis_dim', () => {
 
     expect(root_child0_child0.getComputedLeft()).toBe(0);
     expect(root_child0_child0.getComputedTop()).toBe(0);
-    expect(root_child0_child0.getComputedWidth()).toBe(300);
-    expect(root_child0_child0.getComputedHeight()).toBe(197);
+    expect(root_child0_child0.getComputedWidth()).toBe(285);
+    expect(root_child0_child0.getComputedHeight()).toBe(187);
 
     expect(root_child0_child0_child0.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child0.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child0.getComputedWidth()).toBe(197);
-    expect(root_child0_child0_child0.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child0.getComputedWidth()).toBe(187);
+    expect(root_child0_child0_child0.getComputedHeight()).toBe(187);
 
-    expect(root_child0_child0_child1.getComputedLeft()).toBe(197);
+    expect(root_child0_child0_child1.getComputedLeft()).toBe(187);
     expect(root_child0_child0_child1.getComputedTop()).toBe(0);
     expect(root_child0_child0_child1.getComputedWidth()).toBe(5);
-    expect(root_child0_child0_child1.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child1.getComputedHeight()).toBe(187);
 
-    expect(root_child0_child0_child2.getComputedLeft()).toBe(202);
+    expect(root_child0_child0_child2.getComputedLeft()).toBe(192);
     expect(root_child0_child0_child2.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child2.getComputedWidth()).toBe(98);
-    expect(root_child0_child0_child2.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child2.getComputedWidth()).toBe(93);
+    expect(root_child0_child0_child2.getComputedHeight()).toBe(187);
 
     expect(root_child0_child0_child2_child0.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child2_child0.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child2_child0.getComputedWidth()).toBe(98);
-    expect(root_child0_child0_child2_child0.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child2_child0.getComputedWidth()).toBe(93);
+    expect(root_child0_child0_child2_child0.getComputedHeight()).toBe(187);
 
     expect(root_child0_child0_child2_child0_child0.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child2_child0_child0.getComputedTop()).toBe(0);
@@ -125,8 +125,8 @@ test.skip('aspect_ratio_does_not_stretch_cross_axis_dim', () => {
 
     expect(root_child0_child0_child2_child0_child1.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child2_child0_child1.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child2_child0_child1.getComputedWidth()).toBe(98);
-    expect(root_child0_child0_child2_child0_child1.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child2_child0_child1.getComputedWidth()).toBe(93);
+    expect(root_child0_child0_child2_child0_child1.getComputedHeight()).toBe(187);
 
     root.calculateLayout(undefined, undefined, Direction.RTL);
 
@@ -140,40 +140,40 @@ test.skip('aspect_ratio_does_not_stretch_cross_axis_dim', () => {
     expect(root_child0.getComputedWidth()).toBe(300);
     expect(root_child0.getComputedHeight()).toBe(300);
 
-    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedLeft()).toBe(30);
     expect(root_child0_child0.getComputedTop()).toBe(0);
-    expect(root_child0_child0.getComputedWidth()).toBe(300);
-    expect(root_child0_child0.getComputedHeight()).toBe(197);
+    expect(root_child0_child0.getComputedWidth()).toBe(285);
+    expect(root_child0_child0.getComputedHeight()).toBe(187);
 
-    expect(root_child0_child0_child0.getComputedLeft()).toBe(103);
+    expect(root_child0_child0_child0.getComputedLeft()).toBe(98);
     expect(root_child0_child0_child0.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child0.getComputedWidth()).toBe(197);
-    expect(root_child0_child0_child0.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child0.getComputedWidth()).toBe(187);
+    expect(root_child0_child0_child0.getComputedHeight()).toBe(187);
 
-    expect(root_child0_child0_child1.getComputedLeft()).toBe(98);
+    expect(root_child0_child0_child1.getComputedLeft()).toBe(93);
     expect(root_child0_child0_child1.getComputedTop()).toBe(0);
     expect(root_child0_child0_child1.getComputedWidth()).toBe(5);
-    expect(root_child0_child0_child1.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child1.getComputedHeight()).toBe(187);
 
     expect(root_child0_child0_child2.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child2.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child2.getComputedWidth()).toBe(98);
-    expect(root_child0_child0_child2.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child2.getComputedWidth()).toBe(93);
+    expect(root_child0_child0_child2.getComputedHeight()).toBe(187);
 
     expect(root_child0_child0_child2_child0.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child2_child0.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child2_child0.getComputedWidth()).toBe(98);
-    expect(root_child0_child0_child2_child0.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child2_child0.getComputedWidth()).toBe(93);
+    expect(root_child0_child0_child2_child0.getComputedHeight()).toBe(187);
 
-    expect(root_child0_child0_child2_child0_child0.getComputedLeft()).toBe(93);
+    expect(root_child0_child0_child2_child0_child0.getComputedLeft()).toBe(88);
     expect(root_child0_child0_child2_child0_child0.getComputedTop()).toBe(0);
     expect(root_child0_child0_child2_child0_child0.getComputedWidth()).toBe(5);
     expect(root_child0_child0_child2_child0_child0.getComputedHeight()).toBe(0);
 
     expect(root_child0_child0_child2_child0_child1.getComputedLeft()).toBe(0);
     expect(root_child0_child0_child2_child0_child1.getComputedTop()).toBe(0);
-    expect(root_child0_child0_child2_child0_child1.getComputedWidth()).toBe(98);
-    expect(root_child0_child0_child2_child0_child1.getComputedHeight()).toBe(197);
+    expect(root_child0_child0_child2_child0_child1.getComputedWidth()).toBe(93);
+    expect(root_child0_child0_child2_child0_child1.getComputedHeight()).toBe(187);
   } finally {
     if (typeof root !== 'undefined') {
       root.freeRecursive();

--- a/javascript/tests/generated/YGFlexDirectionTest.test.ts
+++ b/javascript/tests/generated/YGFlexDirectionTest.test.ts
@@ -1440,7 +1440,7 @@ test('flex_direction_row_reverse_border_left', () => {
     config.free();
   }
 });
-test.skip('flex_direction_row_reverse_border_start', () => {
+test('flex_direction_row_reverse_border_start', () => {
   const config = Yoga.Config.create();
   let root;
 
@@ -1590,7 +1590,7 @@ test('flex_direction_row_reverse_border_right', () => {
     config.free();
   }
 });
-test.skip('flex_direction_row_reverse_border_end', () => {
+test('flex_direction_row_reverse_border_end', () => {
   const config = Yoga.Config.create();
   let root;
 

--- a/tests/YGFlexDirectionErrataTest.cpp
+++ b/tests/YGFlexDirectionErrataTest.cpp
@@ -151,3 +151,145 @@ TEST(YogaTest, flex_direction_row_reverse_margin_end_errata) {
 
   YGConfigFree(config);
 }
+
+TEST(YogaTest, flex_direction_row_reverse_border_start_errata) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+  YGConfigSetErrata(config, YGErrata::YGErrataStartingEndingEdgeFromFlexDirection);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRowReverse);
+  YGNodeStyleSetBorder(root, YGEdgeStart, 100);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child2, 10);
+  YGNodeInsertChild(root, root_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(-10, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(-20, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(-30, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(120, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_border_end_errata) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+  YGConfigSetErrata(config, YGErrata::YGErrataStartingEndingEdgeFromFlexDirection);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRowReverse);
+  YGNodeStyleSetBorder(root, YGEdgeEnd, 100);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 10);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 10);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child2, 10);
+  YGNodeInsertChild(root, root_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}

--- a/tests/generated/YGAspectRatioTest.cpp
+++ b/tests/generated/YGAspectRatioTest.cpp
@@ -80,28 +80,28 @@ TEST(YogaTest, aspect_ratio_does_not_stretch_cross_axis_dim) {
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
-  ASSERT_FLOAT_EQ(300, YGNodeLayoutGetWidth(root_child0_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0));
+  ASSERT_FLOAT_EQ(285, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetWidth(root_child0_child0_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetWidth(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child0));
 
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetLeft(root_child0_child0_child1));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetLeft(root_child0_child0_child1));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child1));
   ASSERT_FLOAT_EQ(5, YGNodeLayoutGetWidth(root_child0_child0_child1));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child1));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child1));
 
-  ASSERT_FLOAT_EQ(202, YGNodeLayoutGetLeft(root_child0_child0_child2));
+  ASSERT_FLOAT_EQ(192, YGNodeLayoutGetLeft(root_child0_child0_child2));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2));
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetWidth(root_child0_child0_child2));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child2));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetWidth(root_child0_child0_child2));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child2));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child2_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2_child0));
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetWidth(root_child0_child0_child2_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child2_child0));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetWidth(root_child0_child0_child2_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child2_child0));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child2_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2_child0_child0));
@@ -110,8 +110,8 @@ TEST(YogaTest, aspect_ratio_does_not_stretch_cross_axis_dim) {
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child2_child0_child1));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2_child0_child1));
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetWidth(root_child0_child0_child2_child0_child1));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child2_child0_child1));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetWidth(root_child0_child0_child2_child0_child1));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child2_child0_child1));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
 
@@ -125,40 +125,40 @@ TEST(YogaTest, aspect_ratio_does_not_stretch_cross_axis_dim) {
   ASSERT_FLOAT_EQ(300, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(300, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
-  ASSERT_FLOAT_EQ(300, YGNodeLayoutGetWidth(root_child0_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0));
+  ASSERT_FLOAT_EQ(285, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(103, YGNodeLayoutGetLeft(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetLeft(root_child0_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetWidth(root_child0_child0_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetWidth(root_child0_child0_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child0));
 
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetLeft(root_child0_child0_child1));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetLeft(root_child0_child0_child1));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child1));
   ASSERT_FLOAT_EQ(5, YGNodeLayoutGetWidth(root_child0_child0_child1));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child1));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child1));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child2));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2));
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetWidth(root_child0_child0_child2));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child2));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetWidth(root_child0_child0_child2));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child2));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child2_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2_child0));
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetWidth(root_child0_child0_child2_child0));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child2_child0));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetWidth(root_child0_child0_child2_child0));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child2_child0));
 
-  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetLeft(root_child0_child0_child2_child0_child0));
+  ASSERT_FLOAT_EQ(88, YGNodeLayoutGetLeft(root_child0_child0_child2_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2_child0_child0));
   ASSERT_FLOAT_EQ(5, YGNodeLayoutGetWidth(root_child0_child0_child2_child0_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0_child2_child0_child0));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0_child2_child0_child1));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0_child2_child0_child1));
-  ASSERT_FLOAT_EQ(98, YGNodeLayoutGetWidth(root_child0_child0_child2_child0_child1));
-  ASSERT_FLOAT_EQ(197, YGNodeLayoutGetHeight(root_child0_child0_child2_child0_child1));
+  ASSERT_FLOAT_EQ(93, YGNodeLayoutGetWidth(root_child0_child0_child2_child0_child1));
+  ASSERT_FLOAT_EQ(187, YGNodeLayoutGetHeight(root_child0_child0_child2_child0_child1));
 
   YGNodeFreeRecursive(root);
 

--- a/tests/generated/YGFlexDirectionTest.cpp
+++ b/tests/generated/YGFlexDirectionTest.cpp
@@ -1336,8 +1336,6 @@ TEST(YogaTest, flex_direction_row_reverse_border_left) {
 }
 
 TEST(YogaTest, flex_direction_row_reverse_border_start) {
-  GTEST_SKIP();
-
   const YGConfigRef config = YGConfigNew();
   YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
 
@@ -1478,8 +1476,6 @@ TEST(YogaTest, flex_direction_row_reverse_border_right) {
 }
 
 TEST(YogaTest, flex_direction_row_reverse_border_end) {
-  GTEST_SKIP();
-
   const YGConfigRef config = YGConfigNew();
   YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
 

--- a/yoga/algorithm/BoundAxis.h
+++ b/yoga/algorithm/BoundAxis.h
@@ -21,8 +21,10 @@ inline float paddingAndBorderForAxis(
     const yoga::Node* const node,
     const FlexDirection axis,
     const float widthSize) {
-  return node->getFlexStartPaddingAndBorder(axis, widthSize) +
-      node->getFlexEndPaddingAndBorder(axis, widthSize);
+  // The total padding/border for a given axis does not depend on the direction
+  // so hardcoding LTR here to avoid piping direction to this function
+  return node->getInlineStartPaddingAndBorder(axis, Direction::LTR, widthSize) +
+      node->getInlineEndPaddingAndBorder(axis, Direction::LTR, widthSize);
 }
 
 inline FloatOptional boundAxisWithinMinAndMax(

--- a/yoga/algorithm/BoundAxis.h
+++ b/yoga/algorithm/BoundAxis.h
@@ -21,8 +21,8 @@ inline float paddingAndBorderForAxis(
     const yoga::Node* const node,
     const FlexDirection axis,
     const float widthSize) {
-  return node->getLeadingPaddingAndBorder(axis, widthSize) +
-      node->getTrailingPaddingAndBorder(axis, widthSize);
+  return node->getFlexStartPaddingAndBorder(axis, widthSize) +
+      node->getFlexEndPaddingAndBorder(axis, widthSize);
 }
 
 inline FloatOptional boundAxisWithinMinAndMax(

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -343,13 +343,13 @@ static void layoutAbsoluteChild(
   } else {
     // If the child doesn't have a specified width, compute the width based on
     // the left/right offsets if they're defined.
-    if (child->isLeadingPositionDefined(FlexDirection::Row) &&
-        child->isTrailingPosDefined(FlexDirection::Row)) {
+    if (child->isFlexStartPositionDefined(FlexDirection::Row) &&
+        child->isFlexEndPositionDefined(FlexDirection::Row)) {
       childWidth = node->getLayout().measuredDimension(Dimension::Width) -
-          (node->getLeadingBorder(FlexDirection::Row) +
-           node->getTrailingBorder(FlexDirection::Row)) -
-          (child->getLeadingPosition(FlexDirection::Row, width) +
-           child->getTrailingPosition(FlexDirection::Row, width));
+          (node->getFlexStartBorder(FlexDirection::Row) +
+           node->getFlexEndBorder(FlexDirection::Row)) -
+          (child->getFlexStartPosition(FlexDirection::Row, width) +
+           child->getFlexEndPosition(FlexDirection::Row, width));
       childWidth =
           boundAxis(child, FlexDirection::Row, childWidth, width, width);
     }
@@ -363,13 +363,13 @@ static void layoutAbsoluteChild(
   } else {
     // If the child doesn't have a specified height, compute the height based on
     // the top/bottom offsets if they're defined.
-    if (child->isLeadingPositionDefined(FlexDirection::Column) &&
-        child->isTrailingPosDefined(FlexDirection::Column)) {
+    if (child->isFlexStartPositionDefined(FlexDirection::Column) &&
+        child->isFlexEndPositionDefined(FlexDirection::Column)) {
       childHeight = node->getLayout().measuredDimension(Dimension::Height) -
-          (node->getLeadingBorder(FlexDirection::Column) +
-           node->getTrailingBorder(FlexDirection::Column)) -
-          (child->getLeadingPosition(FlexDirection::Column, height) +
-           child->getTrailingPosition(FlexDirection::Column, height));
+          (node->getFlexStartBorder(FlexDirection::Column) +
+           node->getFlexEndBorder(FlexDirection::Column)) -
+          (child->getFlexStartPosition(FlexDirection::Column, height) +
+           child->getFlexEndPosition(FlexDirection::Column, height));
       childHeight =
           boundAxis(child, FlexDirection::Column, childHeight, height, width);
     }
@@ -446,19 +446,18 @@ static void layoutAbsoluteChild(
       depth,
       generationCount);
 
-  if (child->isTrailingPosDefined(mainAxis) &&
-      !child->isLeadingPositionDefined(mainAxis)) {
+  if (child->isFlexEndPositionDefined(mainAxis) &&
+      !child->isFlexStartPositionDefined(mainAxis)) {
     child->setLayoutPosition(
         node->getLayout().measuredDimension(dimension(mainAxis)) -
             child->getLayout().measuredDimension(dimension(mainAxis)) -
-            node->getTrailingBorder(mainAxis) -
-            child->getTrailingMargin(
+            node->getFlexEndBorder(mainAxis) -
+            child->getInlineEndMargin(
                 mainAxis, direction, isMainAxisRow ? width : height) -
-            child->getTrailingPosition(
-                mainAxis, isMainAxisRow ? width : height),
+            child->getFlexEndPosition(mainAxis, isMainAxisRow ? width : height),
         flexStartEdge(mainAxis));
   } else if (
-      !child->isLeadingPositionDefined(mainAxis) &&
+      !child->isFlexStartPositionDefined(mainAxis) &&
       node->getStyle().justifyContent() == Justify::Center) {
     child->setLayoutPosition(
         (node->getLayout().measuredDimension(dimension(mainAxis)) -
@@ -466,7 +465,7 @@ static void layoutAbsoluteChild(
             2.0f,
         flexStartEdge(mainAxis));
   } else if (
-      !child->isLeadingPositionDefined(mainAxis) &&
+      !child->isFlexStartPositionDefined(mainAxis) &&
       node->getStyle().justifyContent() == Justify::FlexEnd) {
     child->setLayoutPosition(
         (node->getLayout().measuredDimension(dimension(mainAxis)) -
@@ -475,33 +474,33 @@ static void layoutAbsoluteChild(
   } else if (
       node->getConfig()->isExperimentalFeatureEnabled(
           ExperimentalFeature::AbsolutePercentageAgainstPaddingEdge) &&
-      child->isLeadingPositionDefined(mainAxis)) {
+      child->isFlexStartPositionDefined(mainAxis)) {
     child->setLayoutPosition(
-        child->getLeadingPosition(
+        child->getFlexStartPosition(
             mainAxis,
             node->getLayout().measuredDimension(dimension(mainAxis))) +
-            node->getLeadingBorder(mainAxis) +
-            child->getLeadingMargin(
+            node->getFlexStartBorder(mainAxis) +
+            child->getInlineStartMargin(
                 mainAxis,
                 direction,
                 node->getLayout().measuredDimension(dimension(mainAxis))),
         flexStartEdge(mainAxis));
   }
 
-  if (child->isTrailingPosDefined(crossAxis) &&
-      !child->isLeadingPositionDefined(crossAxis)) {
+  if (child->isFlexEndPositionDefined(crossAxis) &&
+      !child->isFlexStartPositionDefined(crossAxis)) {
     child->setLayoutPosition(
         node->getLayout().measuredDimension(dimension(crossAxis)) -
             child->getLayout().measuredDimension(dimension(crossAxis)) -
-            node->getTrailingBorder(crossAxis) -
-            child->getTrailingMargin(
+            node->getFlexEndBorder(crossAxis) -
+            child->getInlineEndMargin(
                 crossAxis, direction, isMainAxisRow ? height : width) -
-            child->getTrailingPosition(
+            child->getFlexEndPosition(
                 crossAxis, isMainAxisRow ? height : width),
         flexStartEdge(crossAxis));
 
   } else if (
-      !child->isLeadingPositionDefined(crossAxis) &&
+      !child->isFlexStartPositionDefined(crossAxis) &&
       resolveChildAlignment(node, child) == Align::Center) {
     child->setLayoutPosition(
         (node->getLayout().measuredDimension(dimension(crossAxis)) -
@@ -509,7 +508,7 @@ static void layoutAbsoluteChild(
             2.0f,
         flexStartEdge(crossAxis));
   } else if (
-      !child->isLeadingPositionDefined(crossAxis) &&
+      !child->isFlexStartPositionDefined(crossAxis) &&
       ((resolveChildAlignment(node, child) == Align::FlexEnd) ^
        (node->getStyle().flexWrap() == Wrap::WrapReverse))) {
     child->setLayoutPosition(
@@ -519,13 +518,13 @@ static void layoutAbsoluteChild(
   } else if (
       node->getConfig()->isExperimentalFeatureEnabled(
           ExperimentalFeature::AbsolutePercentageAgainstPaddingEdge) &&
-      child->isLeadingPositionDefined(crossAxis)) {
+      child->isFlexStartPositionDefined(crossAxis)) {
     child->setLayoutPosition(
-        child->getLeadingPosition(
+        child->getFlexStartPosition(
             crossAxis,
             node->getLayout().measuredDimension(dimension(crossAxis))) +
-            node->getLeadingBorder(crossAxis) +
-            child->getLeadingMargin(
+            node->getFlexStartBorder(crossAxis) +
+            child->getInlineStartMargin(
                 crossAxis,
                 direction,
                 node->getLayout().measuredDimension(dimension(crossAxis))),
@@ -946,7 +945,8 @@ static float distributeFreeSpaceSecondPass(
         measureModeCrossDim == MeasureMode::Exactly &&
         !(isNodeFlexWrap && mainAxisOverflows) &&
         resolveChildAlignment(node, currentLineChild) == Align::Stretch &&
-        currentLineChild->marginLeadingValue(crossAxis).unit != YGUnitAuto &&
+        currentLineChild->getFlexStartMarginValue(crossAxis).unit !=
+            YGUnitAuto &&
         currentLineChild->marginTrailingValue(crossAxis).unit != YGUnitAuto) {
       childCrossSize = availableInnerCrossDim;
       childCrossMeasureMode = MeasureMode::Exactly;
@@ -992,7 +992,8 @@ static float distributeFreeSpaceSecondPass(
         !styleDefinesDimension(
             currentLineChild, crossAxis, availableInnerCrossDim) &&
         resolveChildAlignment(node, currentLineChild) == Align::Stretch &&
-        currentLineChild->marginLeadingValue(crossAxis).unit != YGUnitAuto &&
+        currentLineChild->getFlexStartMarginValue(crossAxis).unit !=
+            YGUnitAuto &&
         currentLineChild->marginTrailingValue(crossAxis).unit != YGUnitAuto;
 
     const float childWidth = isMainAxisRow ? childMainSize : childCrossSize;
@@ -1199,9 +1200,9 @@ static void justifyMainAxis(
     const bool performLayout) {
   const auto& style = node->getStyle();
   const float leadingPaddingAndBorderMain =
-      node->getLeadingPaddingAndBorder(mainAxis, ownerWidth);
+      node->getFlexStartPaddingAndBorder(mainAxis, ownerWidth);
   const float trailingPaddingAndBorderMain =
-      node->getTrailingPaddingAndBorder(mainAxis, ownerWidth);
+      node->getFlexEndPaddingAndBorder(mainAxis, ownerWidth);
   const float gap = node->getGapForAxis(mainAxis);
   // If we are using "at most" rules in the main axis, make sure that
   // remainingFreeSpace is 0 when min main dimension is not given
@@ -1236,7 +1237,7 @@ static void justifyMainAxis(
   for (size_t i = startOfLineIndex; i < flexLine.endOfLineIndex; i++) {
     auto child = node->getChild(i);
     if (child->getStyle().positionType() != PositionType::Absolute) {
-      if (child->marginLeadingValue(mainAxis).unit == YGUnitAuto) {
+      if (child->getFlexStartMarginValue(mainAxis).unit == YGUnitAuto) {
         numberOfAutoMarginsOnCurrentLine++;
       }
       if (child->marginTrailingValue(mainAxis).unit == YGUnitAuto) {
@@ -1298,15 +1299,15 @@ static void justifyMainAxis(
       continue;
     }
     if (childStyle.positionType() == PositionType::Absolute &&
-        child->isLeadingPositionDefined(mainAxis)) {
+        child->isFlexStartPositionDefined(mainAxis)) {
       if (performLayout) {
         // In case the child is position absolute and has left/top being
         // defined, we override the position to whatever the user said (and
         // margin/border).
         child->setLayoutPosition(
-            child->getLeadingPosition(mainAxis, availableInnerMainDim) +
-                node->getLeadingBorder(mainAxis) +
-                child->getLeadingMargin(
+            child->getFlexStartPosition(mainAxis, availableInnerMainDim) +
+                node->getFlexStartBorder(mainAxis) +
+                child->getInlineStartMargin(
                     mainAxis, direction, availableInnerWidth),
             flexStartEdge(mainAxis));
       }
@@ -1315,7 +1316,7 @@ static void justifyMainAxis(
       // We need to do that only for relative elements. Absolute elements do not
       // take part in that phase.
       if (childStyle.positionType() != PositionType::Absolute) {
-        if (child->marginLeadingValue(mainAxis).unit == YGUnitAuto) {
+        if (child->getFlexStartMarginValue(mainAxis).unit == YGUnitAuto) {
           flexLine.layout.mainDim += flexLine.layout.remainingFreeSpace /
               static_cast<float>(numberOfAutoMarginsOnCurrentLine);
         }
@@ -1355,7 +1356,7 @@ static void justifyMainAxis(
             // If the child is baseline aligned then the cross dimension is
             // calculated by adding maxAscent and maxDescent from the baseline.
             const float ascent = calculateBaseline(child) +
-                child->getLeadingMargin(
+                child->getInlineStartMargin(
                     FlexDirection::Column, direction, availableInnerWidth);
             const float descent =
                 child->getLayout().measuredDimension(Dimension::Height) +
@@ -1379,7 +1380,7 @@ static void justifyMainAxis(
       } else if (performLayout) {
         child->setLayoutPosition(
             childLayout.position[flexStartEdge(mainAxis)] +
-                node->getLeadingBorder(mainAxis) + leadingMainDim,
+                node->getFlexStartBorder(mainAxis) + leadingMainDim,
             flexStartEdge(mainAxis));
       }
     }
@@ -1502,35 +1503,36 @@ static void calculateLayoutImpl(
   const YGEdge endEdge = direction == Direction::LTR ? YGEdgeRight : YGEdgeLeft;
 
   const float marginRowLeading =
-      node->getLeadingMargin(flexRowDirection, direction, ownerWidth);
+      node->getInlineStartMargin(flexRowDirection, direction, ownerWidth);
   node->setLayoutMargin(marginRowLeading, startEdge);
   const float marginRowTrailing =
-      node->getTrailingMargin(flexRowDirection, direction, ownerWidth);
+      node->getInlineEndMargin(flexRowDirection, direction, ownerWidth);
   node->setLayoutMargin(marginRowTrailing, endEdge);
   const float marginColumnLeading =
-      node->getLeadingMargin(flexColumnDirection, direction, ownerWidth);
+      node->getInlineStartMargin(flexColumnDirection, direction, ownerWidth);
   node->setLayoutMargin(marginColumnLeading, YGEdgeTop);
   const float marginColumnTrailing =
-      node->getTrailingMargin(flexColumnDirection, direction, ownerWidth);
+      node->getInlineEndMargin(flexColumnDirection, direction, ownerWidth);
   node->setLayoutMargin(marginColumnTrailing, YGEdgeBottom);
 
   const float marginAxisRow = marginRowLeading + marginRowTrailing;
   const float marginAxisColumn = marginColumnLeading + marginColumnTrailing;
 
-  node->setLayoutBorder(node->getLeadingBorder(flexRowDirection), startEdge);
-  node->setLayoutBorder(node->getTrailingBorder(flexRowDirection), endEdge);
-  node->setLayoutBorder(node->getLeadingBorder(flexColumnDirection), YGEdgeTop);
+  node->setLayoutBorder(node->getFlexStartBorder(flexRowDirection), startEdge);
+  node->setLayoutBorder(node->getFlexEndBorder(flexRowDirection), endEdge);
   node->setLayoutBorder(
-      node->getTrailingBorder(flexColumnDirection), YGEdgeBottom);
+      node->getFlexStartBorder(flexColumnDirection), YGEdgeTop);
+  node->setLayoutBorder(
+      node->getFlexEndBorder(flexColumnDirection), YGEdgeBottom);
 
   node->setLayoutPadding(
-      node->getLeadingPadding(flexRowDirection, ownerWidth), startEdge);
+      node->getFlexStartPadding(flexRowDirection, ownerWidth), startEdge);
   node->setLayoutPadding(
-      node->getTrailingPadding(flexRowDirection, ownerWidth), endEdge);
+      node->getFlexEndPadding(flexRowDirection, ownerWidth), endEdge);
   node->setLayoutPadding(
-      node->getLeadingPadding(flexColumnDirection, ownerWidth), YGEdgeTop);
+      node->getFlexStartPadding(flexColumnDirection, ownerWidth), YGEdgeTop);
   node->setLayoutPadding(
-      node->getTrailingPadding(flexColumnDirection, ownerWidth), YGEdgeBottom);
+      node->getFlexEndPadding(flexColumnDirection, ownerWidth), YGEdgeBottom);
 
   if (node->hasMeasureFunc()) {
     measureNodeWithMeasureFunc(
@@ -1592,9 +1594,9 @@ static void calculateLayoutImpl(
   const float paddingAndBorderAxisMain =
       paddingAndBorderForAxis(node, mainAxis, ownerWidth);
   const float leadingPaddingAndBorderCross =
-      node->getLeadingPaddingAndBorder(crossAxis, ownerWidth);
+      node->getFlexStartPaddingAndBorder(crossAxis, ownerWidth);
   const float trailingPaddingAndBorderCross =
-      node->getTrailingPaddingAndBorder(crossAxis, ownerWidth);
+      node->getFlexEndPaddingAndBorder(crossAxis, ownerWidth);
   const float paddingAndBorderAxisCross =
       leadingPaddingAndBorderCross + trailingPaddingAndBorderCross;
 
@@ -1849,12 +1851,12 @@ static void calculateLayoutImpl(
           // top/left/bottom/right set, override all the previously computed
           // positions to set it correctly.
           const bool isChildLeadingPosDefined =
-              child->isLeadingPositionDefined(crossAxis);
+              child->isFlexStartPositionDefined(crossAxis);
           if (isChildLeadingPosDefined) {
             child->setLayoutPosition(
-                child->getLeadingPosition(crossAxis, availableInnerCrossDim) +
-                    node->getLeadingBorder(crossAxis) +
-                    child->getLeadingMargin(
+                child->getFlexStartPosition(crossAxis, availableInnerCrossDim) +
+                    node->getFlexStartBorder(crossAxis) +
+                    child->getInlineStartMargin(
                         crossAxis, direction, availableInnerWidth),
                 flexStartEdge(crossAxis));
           }
@@ -1864,8 +1866,8 @@ static void calculateLayoutImpl(
               yoga::isUndefined(
                   child->getLayout().position[flexStartEdge(crossAxis)])) {
             child->setLayoutPosition(
-                node->getLeadingBorder(crossAxis) +
-                    child->getLeadingMargin(
+                node->getFlexStartBorder(crossAxis) +
+                    child->getInlineStartMargin(
                         crossAxis, direction, availableInnerWidth),
                 flexStartEdge(crossAxis));
           }
@@ -1881,7 +1883,7 @@ static void calculateLayoutImpl(
           // time, this time forcing the cross-axis size to be the computed
           // cross size for the current line.
           if (alignItem == Align::Stretch &&
-              child->marginLeadingValue(crossAxis).unit != YGUnitAuto &&
+              child->getFlexStartMarginValue(crossAxis).unit != YGUnitAuto &&
               child->marginTrailingValue(crossAxis).unit != YGUnitAuto) {
             // If the child defines a definite size for its cross axis, there's
             // no need to stretch.
@@ -1955,7 +1957,7 @@ static void calculateLayoutImpl(
             const float remainingCrossDim = containerCrossAxis -
                 dimensionWithMargin(child, crossAxis, availableInnerWidth);
 
-            if (child->marginLeadingValue(crossAxis).unit == YGUnitAuto &&
+            if (child->getFlexStartMarginValue(crossAxis).unit == YGUnitAuto &&
                 child->marginTrailingValue(crossAxis).unit == YGUnitAuto) {
               leadingCrossDim +=
                   yoga::maxOrDefined(0.0f, remainingCrossDim / 2);
@@ -1963,7 +1965,7 @@ static void calculateLayoutImpl(
                 child->marginTrailingValue(crossAxis).unit == YGUnitAuto) {
               // No-Op
             } else if (
-                child->marginLeadingValue(crossAxis).unit == YGUnitAuto) {
+                child->getFlexStartMarginValue(crossAxis).unit == YGUnitAuto) {
               leadingCrossDim += yoga::maxOrDefined(0.0f, remainingCrossDim);
             } else if (alignItem == Align::FlexStart) {
               // No-Op
@@ -2059,7 +2061,7 @@ static void calculateLayoutImpl(
           }
           if (resolveChildAlignment(node, child) == Align::Baseline) {
             const float ascent = calculateBaseline(child) +
-                child->getLeadingMargin(
+                child->getInlineStartMargin(
                     FlexDirection::Column, direction, availableInnerWidth);
             const float descent =
                 child->getLayout().measuredDimension(Dimension::Height) +
@@ -2090,7 +2092,7 @@ static void calculateLayoutImpl(
               case Align::FlexStart: {
                 child->setLayoutPosition(
                     currentLead +
-                        child->getLeadingMargin(
+                        child->getInlineStartMargin(
                             crossAxis, direction, availableInnerWidth),
                     flexStartEdge(crossAxis));
                 break;
@@ -2098,7 +2100,7 @@ static void calculateLayoutImpl(
               case Align::FlexEnd: {
                 child->setLayoutPosition(
                     currentLead + lineHeight -
-                        child->getTrailingMargin(
+                        child->getInlineEndMargin(
                             crossAxis, direction, availableInnerWidth) -
                         child->getLayout().measuredDimension(
                             dimension(crossAxis)),
@@ -2117,7 +2119,7 @@ static void calculateLayoutImpl(
               case Align::Stretch: {
                 child->setLayoutPosition(
                     currentLead +
-                        child->getLeadingMargin(
+                        child->getInlineStartMargin(
                             crossAxis, direction, availableInnerWidth),
                     flexStartEdge(crossAxis));
 
@@ -2168,7 +2170,7 @@ static void calculateLayoutImpl(
                 child->setLayoutPosition(
                     currentLead + maxAscentForCurrentLine -
                         calculateBaseline(child) +
-                        child->getLeadingPosition(
+                        child->getFlexStartPosition(
                             FlexDirection::Column, availableInnerCrossDim),
                     YGEdgeTop);
 

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -88,8 +88,8 @@ static void setChildTrailingPosition(
   const float size = child->getLayout().measuredDimension(dimension(axis));
   child->setLayoutPosition(
       node->getLayout().measuredDimension(dimension(axis)) - size -
-          child->getLayout().position[leadingEdge(axis)],
-      trailingEdge(axis));
+          child->getLayout().position[flexStartEdge(axis)],
+      flexEndEdge(axis));
 }
 
 static void constrainMaxSizeForMode(
@@ -456,7 +456,7 @@ static void layoutAbsoluteChild(
                 mainAxis, direction, isMainAxisRow ? width : height) -
             child->getTrailingPosition(
                 mainAxis, isMainAxisRow ? width : height),
-        leadingEdge(mainAxis));
+        flexStartEdge(mainAxis));
   } else if (
       !child->isLeadingPositionDefined(mainAxis) &&
       node->getStyle().justifyContent() == Justify::Center) {
@@ -464,14 +464,14 @@ static void layoutAbsoluteChild(
         (node->getLayout().measuredDimension(dimension(mainAxis)) -
          child->getLayout().measuredDimension(dimension(mainAxis))) /
             2.0f,
-        leadingEdge(mainAxis));
+        flexStartEdge(mainAxis));
   } else if (
       !child->isLeadingPositionDefined(mainAxis) &&
       node->getStyle().justifyContent() == Justify::FlexEnd) {
     child->setLayoutPosition(
         (node->getLayout().measuredDimension(dimension(mainAxis)) -
          child->getLayout().measuredDimension(dimension(mainAxis))),
-        leadingEdge(mainAxis));
+        flexStartEdge(mainAxis));
   } else if (
       node->getConfig()->isExperimentalFeatureEnabled(
           ExperimentalFeature::AbsolutePercentageAgainstPaddingEdge) &&
@@ -485,7 +485,7 @@ static void layoutAbsoluteChild(
                 mainAxis,
                 direction,
                 node->getLayout().measuredDimension(dimension(mainAxis))),
-        leadingEdge(mainAxis));
+        flexStartEdge(mainAxis));
   }
 
   if (child->isTrailingPosDefined(crossAxis) &&
@@ -498,7 +498,7 @@ static void layoutAbsoluteChild(
                 crossAxis, direction, isMainAxisRow ? height : width) -
             child->getTrailingPosition(
                 crossAxis, isMainAxisRow ? height : width),
-        leadingEdge(crossAxis));
+        flexStartEdge(crossAxis));
 
   } else if (
       !child->isLeadingPositionDefined(crossAxis) &&
@@ -507,7 +507,7 @@ static void layoutAbsoluteChild(
         (node->getLayout().measuredDimension(dimension(crossAxis)) -
          child->getLayout().measuredDimension(dimension(crossAxis))) /
             2.0f,
-        leadingEdge(crossAxis));
+        flexStartEdge(crossAxis));
   } else if (
       !child->isLeadingPositionDefined(crossAxis) &&
       ((resolveChildAlignment(node, child) == Align::FlexEnd) ^
@@ -515,7 +515,7 @@ static void layoutAbsoluteChild(
     child->setLayoutPosition(
         (node->getLayout().measuredDimension(dimension(crossAxis)) -
          child->getLayout().measuredDimension(dimension(crossAxis))),
-        leadingEdge(crossAxis));
+        flexStartEdge(crossAxis));
   } else if (
       node->getConfig()->isExperimentalFeatureEnabled(
           ExperimentalFeature::AbsolutePercentageAgainstPaddingEdge) &&
@@ -529,7 +529,7 @@ static void layoutAbsoluteChild(
                 crossAxis,
                 direction,
                 node->getLayout().measuredDimension(dimension(crossAxis))),
-        leadingEdge(crossAxis));
+        flexStartEdge(crossAxis));
   }
 }
 
@@ -1308,7 +1308,7 @@ static void justifyMainAxis(
                 node->getLeadingBorder(mainAxis) +
                 child->getLeadingMargin(
                     mainAxis, direction, availableInnerWidth),
-            leadingEdge(mainAxis));
+            flexStartEdge(mainAxis));
       }
     } else {
       // Now that we placed the element, we need to update the variables.
@@ -1322,9 +1322,9 @@ static void justifyMainAxis(
 
         if (performLayout) {
           child->setLayoutPosition(
-              childLayout.position[leadingEdge(mainAxis)] +
+              childLayout.position[flexStartEdge(mainAxis)] +
                   flexLine.layout.mainDim,
-              leadingEdge(mainAxis));
+              flexStartEdge(mainAxis));
         }
 
         if (child != flexLine.itemsInFlow.back()) {
@@ -1378,9 +1378,9 @@ static void justifyMainAxis(
         }
       } else if (performLayout) {
         child->setLayoutPosition(
-            childLayout.position[leadingEdge(mainAxis)] +
+            childLayout.position[flexStartEdge(mainAxis)] +
                 node->getLeadingBorder(mainAxis) + leadingMainDim,
-            leadingEdge(mainAxis));
+            flexStartEdge(mainAxis));
       }
     }
   }
@@ -1856,18 +1856,18 @@ static void calculateLayoutImpl(
                     node->getLeadingBorder(crossAxis) +
                     child->getLeadingMargin(
                         crossAxis, direction, availableInnerWidth),
-                leadingEdge(crossAxis));
+                flexStartEdge(crossAxis));
           }
           // If leading position is not defined or calculations result in Nan,
           // default to border + margin
           if (!isChildLeadingPosDefined ||
               yoga::isUndefined(
-                  child->getLayout().position[leadingEdge(crossAxis)])) {
+                  child->getLayout().position[flexStartEdge(crossAxis)])) {
             child->setLayoutPosition(
                 node->getLeadingBorder(crossAxis) +
                     child->getLeadingMargin(
                         crossAxis, direction, availableInnerWidth),
-                leadingEdge(crossAxis));
+                flexStartEdge(crossAxis));
           }
         } else {
           float leadingCrossDim = leadingPaddingAndBorderCross;
@@ -1975,9 +1975,9 @@ static void calculateLayoutImpl(
           }
           // And we apply the position
           child->setLayoutPosition(
-              child->getLayout().position[leadingEdge(crossAxis)] +
+              child->getLayout().position[flexStartEdge(crossAxis)] +
                   totalLineCrossDim + leadingCrossDim,
-              leadingEdge(crossAxis));
+              flexStartEdge(crossAxis));
         }
       }
     }
@@ -2092,7 +2092,7 @@ static void calculateLayoutImpl(
                     currentLead +
                         child->getLeadingMargin(
                             crossAxis, direction, availableInnerWidth),
-                    leadingEdge(crossAxis));
+                    flexStartEdge(crossAxis));
                 break;
               }
               case Align::FlexEnd: {
@@ -2102,7 +2102,7 @@ static void calculateLayoutImpl(
                             crossAxis, direction, availableInnerWidth) -
                         child->getLayout().measuredDimension(
                             dimension(crossAxis)),
-                    leadingEdge(crossAxis));
+                    flexStartEdge(crossAxis));
                 break;
               }
               case Align::Center: {
@@ -2111,7 +2111,7 @@ static void calculateLayoutImpl(
 
                 child->setLayoutPosition(
                     currentLead + (lineHeight - childHeight) / 2,
-                    leadingEdge(crossAxis));
+                    flexStartEdge(crossAxis));
                 break;
               }
               case Align::Stretch: {
@@ -2119,7 +2119,7 @@ static void calculateLayoutImpl(
                     currentLead +
                         child->getLeadingMargin(
                             crossAxis, direction, availableInnerWidth),
-                    leadingEdge(crossAxis));
+                    flexStartEdge(crossAxis));
 
                 // Remeasure child with the line height as it as been only
                 // measured with the owners height yet.
@@ -2275,9 +2275,9 @@ static void calculateLayoutImpl(
       if (child->getStyle().positionType() != PositionType::Absolute) {
         child->setLayoutPosition(
             node->getLayout().measuredDimension(dimension(crossAxis)) -
-                child->getLayout().position[leadingEdge(crossAxis)] -
+                child->getLayout().position[flexStartEdge(crossAxis)] -
                 child->getLayout().measuredDimension(dimension(crossAxis)),
-            leadingEdge(crossAxis));
+            flexStartEdge(crossAxis));
       }
     }
   }

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -1535,13 +1535,17 @@ static void calculateLayoutImpl(
       node->getInlineEndBorder(flexColumnDirection, direction), YGEdgeBottom);
 
   node->setLayoutPadding(
-      node->getFlexStartPadding(flexRowDirection, ownerWidth), startEdge);
+      node->getInlineStartPadding(flexRowDirection, direction, ownerWidth),
+      startEdge);
   node->setLayoutPadding(
-      node->getFlexEndPadding(flexRowDirection, ownerWidth), endEdge);
+      node->getInlineEndPadding(flexRowDirection, direction, ownerWidth),
+      endEdge);
   node->setLayoutPadding(
-      node->getFlexStartPadding(flexColumnDirection, ownerWidth), YGEdgeTop);
+      node->getInlineStartPadding(flexColumnDirection, direction, ownerWidth),
+      YGEdgeTop);
   node->setLayoutPadding(
-      node->getFlexEndPadding(flexColumnDirection, ownerWidth), YGEdgeBottom);
+      node->getInlineEndPadding(flexColumnDirection, direction, ownerWidth),
+      YGEdgeBottom);
 
   if (node->hasMeasureFunc()) {
     measureNodeWithMeasureFunc(

--- a/yoga/algorithm/FlexDirection.h
+++ b/yoga/algorithm/FlexDirection.h
@@ -97,6 +97,32 @@ inline YGEdge inlineEndEdge(
   return YGEdgeBottom;
 }
 
+/**
+ * The physical edges that YGEdgeStart and YGEdgeEnd correspond to (e.g.
+ * left/right) are soley dependent on the direction. However, there are cases
+ * where we want the flex start/end edge (i.e. which edge is the start/end
+ * for laying out flex items), which can be distinct from the corresponding
+ * inline edge. In these cases we need to know which "relative edge"
+ * (YGEdgeStart/YGEdgeEnd) corresponds to the said flex start/end edge as these
+ * relative edges can be used instead of physical ones when defining certain
+ * attributes like border or padding.
+ */
+inline YGEdge flexStartRelativeEdge(
+    FlexDirection flexDirection,
+    Direction direction) {
+  const YGEdge leadLayoutEdge = inlineStartEdge(flexDirection, direction);
+  const YGEdge leadFlexItemEdge = flexStartEdge(flexDirection);
+  return leadLayoutEdge == leadFlexItemEdge ? YGEdgeStart : YGEdgeEnd;
+}
+
+inline YGEdge flexEndRelativeEdge(
+    FlexDirection flexDirection,
+    Direction direction) {
+  const YGEdge trailLayoutEdge = inlineEndEdge(flexDirection, direction);
+  const YGEdge trailFlexItemEdge = flexEndEdge(flexDirection);
+  return trailLayoutEdge == trailFlexItemEdge ? YGEdgeEnd : YGEdgeStart;
+}
+
 inline Dimension dimension(const FlexDirection flexDirection) {
   switch (flexDirection) {
     case FlexDirection::Column:

--- a/yoga/algorithm/FlexDirection.h
+++ b/yoga/algorithm/FlexDirection.h
@@ -47,7 +47,7 @@ inline FlexDirection resolveCrossDirection(
       : FlexDirection::Column;
 }
 
-inline YGEdge leadingEdge(const FlexDirection flexDirection) {
+inline YGEdge flexStartEdge(const FlexDirection flexDirection) {
   switch (flexDirection) {
     case FlexDirection::Column:
       return YGEdgeTop;
@@ -62,7 +62,7 @@ inline YGEdge leadingEdge(const FlexDirection flexDirection) {
   fatalWithMessage("Invalid FlexDirection");
 }
 
-inline YGEdge trailingEdge(const FlexDirection flexDirection) {
+inline YGEdge flexEndEdge(const FlexDirection flexDirection) {
   switch (flexDirection) {
     case FlexDirection::Column:
       return YGEdgeBottom;
@@ -77,7 +77,7 @@ inline YGEdge trailingEdge(const FlexDirection flexDirection) {
   fatalWithMessage("Invalid FlexDirection");
 }
 
-inline YGEdge leadingLayoutEdge(
+inline YGEdge inlineStartEdge(
     const FlexDirection flexDirection,
     const Direction direction) {
   if (isRow(flexDirection)) {
@@ -87,7 +87,7 @@ inline YGEdge leadingLayoutEdge(
   return YGEdgeTop;
 }
 
-inline YGEdge trailingLayoutEdge(
+inline YGEdge inlineEndEdge(
     const FlexDirection flexDirection,
     const Direction direction) {
   if (isRow(flexDirection)) {

--- a/yoga/node/Node.cpp
+++ b/yoga/node/Node.cpp
@@ -157,18 +157,41 @@ float Node::getInlineEndMargin(
   return resolveValue(trailingMargin, widthSize).unwrapOrDefault(0.0f);
 }
 
-float Node::getFlexStartBorder(FlexDirection axis) const {
+float Node::getInlineStartBorder(FlexDirection axis, Direction direction)
+    const {
+  const YGEdge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
+  YGValue leadingBorder = isRow(axis)
+      ? computeEdgeValueForRow(style_.border(), YGEdgeStart, startEdge)
+      : computeEdgeValueForColumn(style_.border(), startEdge);
+
+  return maxOrDefined(leadingBorder.value, 0.0f);
+}
+
+float Node::getFlexStartBorder(FlexDirection axis, Direction direction) const {
+  const YGEdge leadRelativeFlexItemEdge =
+      flexStartRelativeEdge(axis, direction);
   YGValue leadingBorder = isRow(axis)
       ? computeEdgeValueForRow(
-            style_.border(), YGEdgeStart, flexStartEdge(axis))
+            style_.border(), leadRelativeFlexItemEdge, flexStartEdge(axis))
       : computeEdgeValueForColumn(style_.border(), flexStartEdge(axis));
 
   return maxOrDefined(leadingBorder.value, 0.0f);
 }
 
-float Node::getFlexEndBorder(FlexDirection axis) const {
+float Node::getInlineEndBorder(FlexDirection axis, Direction direction) const {
+  const YGEdge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
   YGValue trailingBorder = isRow(axis)
-      ? computeEdgeValueForRow(style_.border(), YGEdgeEnd, flexEndEdge(axis))
+      ? computeEdgeValueForRow(style_.border(), YGEdgeEnd, endEdge)
+      : computeEdgeValueForColumn(style_.border(), endEdge);
+
+  return maxOrDefined(trailingBorder.value, 0.0f);
+}
+
+float Node::getFlexEndBorder(FlexDirection axis, Direction direction) const {
+  const YGEdge trailRelativeFlexItemEdge = flexEndRelativeEdge(axis, direction);
+  YGValue trailingBorder = isRow(axis)
+      ? computeEdgeValueForRow(
+            style_.border(), trailRelativeFlexItemEdge, flexEndEdge(axis))
       : computeEdgeValueForColumn(style_.border(), flexEndEdge(axis));
 
   return maxOrDefined(trailingBorder.value, 0.0f);
@@ -191,14 +214,35 @@ float Node::getFlexEndPadding(FlexDirection axis, float widthSize) const {
   return maxOrDefined(resolveValue(trailingPadding, widthSize).unwrap(), 0.0f);
 }
 
-float Node::getFlexStartPaddingAndBorder(FlexDirection axis, float widthSize)
-    const {
-  return getFlexStartPadding(axis, widthSize) + getFlexStartBorder(axis);
+float Node::getInlineStartPaddingAndBorder(
+    FlexDirection axis,
+    Direction direction,
+    float widthSize) const {
+  return getFlexStartPadding(axis, widthSize) +
+      getInlineStartBorder(axis, direction);
 }
 
-float Node::getFlexEndPaddingAndBorder(FlexDirection axis, float widthSize)
-    const {
-  return getFlexEndPadding(axis, widthSize) + getFlexEndBorder(axis);
+float Node::getFlexStartPaddingAndBorder(
+    FlexDirection axis,
+    Direction direction,
+    float widthSize) const {
+  return getFlexStartPadding(axis, widthSize) +
+      getFlexStartBorder(axis, direction);
+}
+
+float Node::getInlineEndPaddingAndBorder(
+    FlexDirection axis,
+    Direction direction,
+    float widthSize) const {
+  return getFlexEndPadding(axis, widthSize) +
+      getInlineEndBorder(axis, direction);
+}
+
+float Node::getFlexEndPaddingAndBorder(
+    FlexDirection axis,
+    Direction direction,
+    float widthSize) const {
+  return getFlexEndPadding(axis, widthSize) + getFlexEndBorder(axis, direction);
 }
 
 float Node::getMarginForAxis(FlexDirection axis, float widthSize) const {

--- a/yoga/node/Node.cpp
+++ b/yoga/node/Node.cpp
@@ -83,7 +83,7 @@ CompactValue Node::computeEdgeValueForColumn(
   }
 }
 
-YGEdge Node::getLeadingLayoutEdgeUsingErrata(
+YGEdge Node::getInlineStartEdgeUsingErrata(
     FlexDirection flexDirection,
     Direction direction) const {
   return hasErrata(Errata::StartingEndingEdgeFromFlexDirection)
@@ -91,7 +91,7 @@ YGEdge Node::getLeadingLayoutEdgeUsingErrata(
       : inlineStartEdge(flexDirection, direction);
 }
 
-YGEdge Node::getTrailingLayoutEdgeUsingErrata(
+YGEdge Node::getInlineEndEdgeUsingErrata(
     FlexDirection flexDirection,
     Direction direction) const {
   return hasErrata(Errata::StartingEndingEdgeFromFlexDirection)
@@ -99,7 +99,7 @@ YGEdge Node::getTrailingLayoutEdgeUsingErrata(
       : inlineEndEdge(flexDirection, direction);
 }
 
-bool Node::isLeadingPositionDefined(FlexDirection axis) const {
+bool Node::isFlexStartPositionDefined(FlexDirection axis) const {
   auto leadingPosition = isRow(axis)
       ? computeEdgeValueForRow(
             style_.position(), YGEdgeStart, flexStartEdge(axis))
@@ -108,7 +108,7 @@ bool Node::isLeadingPositionDefined(FlexDirection axis) const {
   return !leadingPosition.isUndefined();
 }
 
-bool Node::isTrailingPosDefined(FlexDirection axis) const {
+bool Node::isFlexEndPositionDefined(FlexDirection axis) const {
   auto trailingPosition = isRow(axis)
       ? computeEdgeValueForRow(style_.position(), YGEdgeEnd, flexEndEdge(axis))
       : computeEdgeValueForColumn(style_.position(), flexEndEdge(axis));
@@ -116,7 +116,7 @@ bool Node::isTrailingPosDefined(FlexDirection axis) const {
   return !trailingPosition.isUndefined();
 }
 
-float Node::getLeadingPosition(FlexDirection axis, float axisSize) const {
+float Node::getFlexStartPosition(FlexDirection axis, float axisSize) const {
   auto leadingPosition = isRow(axis)
       ? computeEdgeValueForRow(
             style_.position(), YGEdgeStart, flexStartEdge(axis))
@@ -125,7 +125,7 @@ float Node::getLeadingPosition(FlexDirection axis, float axisSize) const {
   return resolveValue(leadingPosition, axisSize).unwrapOrDefault(0.0f);
 }
 
-float Node::getTrailingPosition(FlexDirection axis, float axisSize) const {
+float Node::getFlexEndPosition(FlexDirection axis, float axisSize) const {
   auto trailingPosition = isRow(axis)
       ? computeEdgeValueForRow(style_.position(), YGEdgeEnd, flexEndEdge(axis))
       : computeEdgeValueForColumn(style_.position(), flexEndEdge(axis));
@@ -133,11 +133,11 @@ float Node::getTrailingPosition(FlexDirection axis, float axisSize) const {
   return resolveValue(trailingPosition, axisSize).unwrapOrDefault(0.0f);
 }
 
-float Node::getLeadingMargin(
+float Node::getInlineStartMargin(
     FlexDirection axis,
     Direction direction,
     float widthSize) const {
-  const YGEdge startEdge = getLeadingLayoutEdgeUsingErrata(axis, direction);
+  const YGEdge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
   auto leadingMargin = isRow(axis)
       ? computeEdgeValueForRow(style_.margin(), YGEdgeStart, startEdge)
       : computeEdgeValueForColumn(style_.margin(), startEdge);
@@ -145,11 +145,11 @@ float Node::getLeadingMargin(
   return resolveValue(leadingMargin, widthSize).unwrapOrDefault(0.0f);
 }
 
-float Node::getTrailingMargin(
+float Node::getInlineEndMargin(
     FlexDirection axis,
     Direction direction,
     float widthSize) const {
-  const YGEdge endEdge = getTrailingLayoutEdgeUsingErrata(axis, direction);
+  const YGEdge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
   auto trailingMargin = isRow(axis)
       ? computeEdgeValueForRow(style_.margin(), YGEdgeEnd, endEdge)
       : computeEdgeValueForColumn(style_.margin(), endEdge);
@@ -157,7 +157,7 @@ float Node::getTrailingMargin(
   return resolveValue(trailingMargin, widthSize).unwrapOrDefault(0.0f);
 }
 
-float Node::getLeadingBorder(FlexDirection axis) const {
+float Node::getFlexStartBorder(FlexDirection axis) const {
   YGValue leadingBorder = isRow(axis)
       ? computeEdgeValueForRow(
             style_.border(), YGEdgeStart, flexStartEdge(axis))
@@ -166,7 +166,7 @@ float Node::getLeadingBorder(FlexDirection axis) const {
   return maxOrDefined(leadingBorder.value, 0.0f);
 }
 
-float Node::getTrailingBorder(FlexDirection axis) const {
+float Node::getFlexEndBorder(FlexDirection axis) const {
   YGValue trailingBorder = isRow(axis)
       ? computeEdgeValueForRow(style_.border(), YGEdgeEnd, flexEndEdge(axis))
       : computeEdgeValueForColumn(style_.border(), flexEndEdge(axis));
@@ -174,7 +174,7 @@ float Node::getTrailingBorder(FlexDirection axis) const {
   return maxOrDefined(trailingBorder.value, 0.0f);
 }
 
-float Node::getLeadingPadding(FlexDirection axis, float widthSize) const {
+float Node::getFlexStartPadding(FlexDirection axis, float widthSize) const {
   auto leadingPadding = isRow(axis)
       ? computeEdgeValueForRow(
             style_.padding(), YGEdgeStart, flexStartEdge(axis))
@@ -183,7 +183,7 @@ float Node::getLeadingPadding(FlexDirection axis, float widthSize) const {
   return maxOrDefined(resolveValue(leadingPadding, widthSize).unwrap(), 0.0f);
 }
 
-float Node::getTrailingPadding(FlexDirection axis, float widthSize) const {
+float Node::getFlexEndPadding(FlexDirection axis, float widthSize) const {
   auto trailingPadding = isRow(axis)
       ? computeEdgeValueForRow(style_.padding(), YGEdgeEnd, flexEndEdge(axis))
       : computeEdgeValueForColumn(style_.padding(), flexEndEdge(axis));
@@ -191,21 +191,21 @@ float Node::getTrailingPadding(FlexDirection axis, float widthSize) const {
   return maxOrDefined(resolveValue(trailingPadding, widthSize).unwrap(), 0.0f);
 }
 
-float Node::getLeadingPaddingAndBorder(FlexDirection axis, float widthSize)
+float Node::getFlexStartPaddingAndBorder(FlexDirection axis, float widthSize)
     const {
-  return getLeadingPadding(axis, widthSize) + getLeadingBorder(axis);
+  return getFlexStartPadding(axis, widthSize) + getFlexStartBorder(axis);
 }
 
-float Node::getTrailingPaddingAndBorder(FlexDirection axis, float widthSize)
+float Node::getFlexEndPaddingAndBorder(FlexDirection axis, float widthSize)
     const {
-  return getTrailingPadding(axis, widthSize) + getTrailingBorder(axis);
+  return getFlexEndPadding(axis, widthSize) + getFlexEndBorder(axis);
 }
 
 float Node::getMarginForAxis(FlexDirection axis, float widthSize) const {
   // The total margin for a given axis does not depend on the direction
   // so hardcoding LTR here to avoid piping direction to this function
-  return getLeadingMargin(axis, Direction::LTR, widthSize) +
-      getTrailingMargin(axis, Direction::LTR, widthSize);
+  return getInlineStartMargin(axis, Direction::LTR, widthSize) +
+      getInlineEndMargin(axis, Direction::LTR, widthSize);
 }
 
 float Node::getGapForAxis(FlexDirection axis) const {
@@ -362,11 +362,11 @@ void Node::setLayoutDimension(float dimensionValue, Dimension dimension) {
 // If both left and right are defined, then use left. Otherwise return +left or
 // -right depending on which is defined.
 float Node::relativePosition(FlexDirection axis, float axisSize) const {
-  if (isLeadingPositionDefined(axis)) {
-    return getLeadingPosition(axis, axisSize);
+  if (isFlexStartPositionDefined(axis)) {
+    return getFlexStartPosition(axis, axisSize);
   }
 
-  return -1 * getTrailingPosition(axis, axisSize);
+  return -1 * getFlexEndPosition(axis, axisSize);
 }
 
 void Node::setPosition(
@@ -390,33 +390,33 @@ void Node::setPosition(
   const float relativePositionCross = relativePosition(crossAxis, crossSize);
 
   const YGEdge mainAxisLeadingEdge =
-      getLeadingLayoutEdgeUsingErrata(mainAxis, direction);
+      getInlineStartEdgeUsingErrata(mainAxis, direction);
   const YGEdge mainAxisTrailingEdge =
-      getTrailingLayoutEdgeUsingErrata(mainAxis, direction);
+      getInlineEndEdgeUsingErrata(mainAxis, direction);
   const YGEdge crossAxisLeadingEdge =
-      getLeadingLayoutEdgeUsingErrata(crossAxis, direction);
+      getInlineStartEdgeUsingErrata(crossAxis, direction);
   const YGEdge crossAxisTrailingEdge =
-      getTrailingLayoutEdgeUsingErrata(crossAxis, direction);
+      getInlineEndEdgeUsingErrata(crossAxis, direction);
 
   setLayoutPosition(
-      (getLeadingMargin(mainAxis, direction, ownerWidth) +
+      (getInlineStartMargin(mainAxis, direction, ownerWidth) +
        relativePositionMain),
       mainAxisLeadingEdge);
   setLayoutPosition(
-      (getTrailingMargin(mainAxis, direction, ownerWidth) +
+      (getInlineEndMargin(mainAxis, direction, ownerWidth) +
        relativePositionMain),
       mainAxisTrailingEdge);
   setLayoutPosition(
-      (getLeadingMargin(crossAxis, direction, ownerWidth) +
+      (getInlineStartMargin(crossAxis, direction, ownerWidth) +
        relativePositionCross),
       crossAxisLeadingEdge);
   setLayoutPosition(
-      (getTrailingMargin(crossAxis, direction, ownerWidth) +
+      (getInlineEndMargin(crossAxis, direction, ownerWidth) +
        relativePositionCross),
       crossAxisTrailingEdge);
 }
 
-YGValue Node::marginLeadingValue(FlexDirection axis) const {
+YGValue Node::getFlexStartMarginValue(FlexDirection axis) const {
   if (isRow(axis) && !style_.margin()[YGEdgeStart].isUndefined()) {
     return style_.margin()[YGEdgeStart];
   } else {

--- a/yoga/node/Node.cpp
+++ b/yoga/node/Node.cpp
@@ -87,31 +87,31 @@ YGEdge Node::getLeadingLayoutEdgeUsingErrata(
     FlexDirection flexDirection,
     Direction direction) const {
   return hasErrata(Errata::StartingEndingEdgeFromFlexDirection)
-      ? leadingEdge(flexDirection)
-      : leadingLayoutEdge(flexDirection, direction);
+      ? flexStartEdge(flexDirection)
+      : inlineStartEdge(flexDirection, direction);
 }
 
 YGEdge Node::getTrailingLayoutEdgeUsingErrata(
     FlexDirection flexDirection,
     Direction direction) const {
   return hasErrata(Errata::StartingEndingEdgeFromFlexDirection)
-      ? trailingEdge(flexDirection)
-      : trailingLayoutEdge(flexDirection, direction);
+      ? flexEndEdge(flexDirection)
+      : inlineEndEdge(flexDirection, direction);
 }
 
 bool Node::isLeadingPositionDefined(FlexDirection axis) const {
   auto leadingPosition = isRow(axis)
       ? computeEdgeValueForRow(
-            style_.position(), YGEdgeStart, leadingEdge(axis))
-      : computeEdgeValueForColumn(style_.position(), leadingEdge(axis));
+            style_.position(), YGEdgeStart, flexStartEdge(axis))
+      : computeEdgeValueForColumn(style_.position(), flexStartEdge(axis));
 
   return !leadingPosition.isUndefined();
 }
 
 bool Node::isTrailingPosDefined(FlexDirection axis) const {
   auto trailingPosition = isRow(axis)
-      ? computeEdgeValueForRow(style_.position(), YGEdgeEnd, trailingEdge(axis))
-      : computeEdgeValueForColumn(style_.position(), trailingEdge(axis));
+      ? computeEdgeValueForRow(style_.position(), YGEdgeEnd, flexEndEdge(axis))
+      : computeEdgeValueForColumn(style_.position(), flexEndEdge(axis));
 
   return !trailingPosition.isUndefined();
 }
@@ -119,16 +119,16 @@ bool Node::isTrailingPosDefined(FlexDirection axis) const {
 float Node::getLeadingPosition(FlexDirection axis, float axisSize) const {
   auto leadingPosition = isRow(axis)
       ? computeEdgeValueForRow(
-            style_.position(), YGEdgeStart, leadingEdge(axis))
-      : computeEdgeValueForColumn(style_.position(), leadingEdge(axis));
+            style_.position(), YGEdgeStart, flexStartEdge(axis))
+      : computeEdgeValueForColumn(style_.position(), flexStartEdge(axis));
 
   return resolveValue(leadingPosition, axisSize).unwrapOrDefault(0.0f);
 }
 
 float Node::getTrailingPosition(FlexDirection axis, float axisSize) const {
   auto trailingPosition = isRow(axis)
-      ? computeEdgeValueForRow(style_.position(), YGEdgeEnd, trailingEdge(axis))
-      : computeEdgeValueForColumn(style_.position(), trailingEdge(axis));
+      ? computeEdgeValueForRow(style_.position(), YGEdgeEnd, flexEndEdge(axis))
+      : computeEdgeValueForColumn(style_.position(), flexEndEdge(axis));
 
   return resolveValue(trailingPosition, axisSize).unwrapOrDefault(0.0f);
 }
@@ -159,32 +159,34 @@ float Node::getTrailingMargin(
 
 float Node::getLeadingBorder(FlexDirection axis) const {
   YGValue leadingBorder = isRow(axis)
-      ? computeEdgeValueForRow(style_.border(), YGEdgeStart, leadingEdge(axis))
-      : computeEdgeValueForColumn(style_.border(), leadingEdge(axis));
+      ? computeEdgeValueForRow(
+            style_.border(), YGEdgeStart, flexStartEdge(axis))
+      : computeEdgeValueForColumn(style_.border(), flexStartEdge(axis));
 
   return maxOrDefined(leadingBorder.value, 0.0f);
 }
 
 float Node::getTrailingBorder(FlexDirection axis) const {
   YGValue trailingBorder = isRow(axis)
-      ? computeEdgeValueForRow(style_.border(), YGEdgeEnd, trailingEdge(axis))
-      : computeEdgeValueForColumn(style_.border(), trailingEdge(axis));
+      ? computeEdgeValueForRow(style_.border(), YGEdgeEnd, flexEndEdge(axis))
+      : computeEdgeValueForColumn(style_.border(), flexEndEdge(axis));
 
   return maxOrDefined(trailingBorder.value, 0.0f);
 }
 
 float Node::getLeadingPadding(FlexDirection axis, float widthSize) const {
   auto leadingPadding = isRow(axis)
-      ? computeEdgeValueForRow(style_.padding(), YGEdgeStart, leadingEdge(axis))
-      : computeEdgeValueForColumn(style_.padding(), leadingEdge(axis));
+      ? computeEdgeValueForRow(
+            style_.padding(), YGEdgeStart, flexStartEdge(axis))
+      : computeEdgeValueForColumn(style_.padding(), flexStartEdge(axis));
 
   return maxOrDefined(resolveValue(leadingPadding, widthSize).unwrap(), 0.0f);
 }
 
 float Node::getTrailingPadding(FlexDirection axis, float widthSize) const {
   auto trailingPadding = isRow(axis)
-      ? computeEdgeValueForRow(style_.padding(), YGEdgeEnd, trailingEdge(axis))
-      : computeEdgeValueForColumn(style_.padding(), trailingEdge(axis));
+      ? computeEdgeValueForRow(style_.padding(), YGEdgeEnd, flexEndEdge(axis))
+      : computeEdgeValueForColumn(style_.padding(), flexEndEdge(axis));
 
   return maxOrDefined(resolveValue(trailingPadding, widthSize).unwrap(), 0.0f);
 }
@@ -418,7 +420,7 @@ YGValue Node::marginLeadingValue(FlexDirection axis) const {
   if (isRow(axis) && !style_.margin()[YGEdgeStart].isUndefined()) {
     return style_.margin()[YGEdgeStart];
   } else {
-    return style_.margin()[leadingEdge(axis)];
+    return style_.margin()[flexStartEdge(axis)];
   }
 }
 
@@ -426,7 +428,7 @@ YGValue Node::marginTrailingValue(FlexDirection axis) const {
   if (isRow(axis) && !style_.margin()[YGEdgeEnd].isUndefined()) {
     return style_.margin()[YGEdgeEnd];
   } else {
-    return style_.margin()[trailingEdge(axis)];
+    return style_.margin()[flexEndEdge(axis)];
   }
 }
 

--- a/yoga/node/Node.cpp
+++ b/yoga/node/Node.cpp
@@ -197,18 +197,52 @@ float Node::getFlexEndBorder(FlexDirection axis, Direction direction) const {
   return maxOrDefined(trailingBorder.value, 0.0f);
 }
 
-float Node::getFlexStartPadding(FlexDirection axis, float widthSize) const {
+float Node::getInlineStartPadding(
+    FlexDirection axis,
+    Direction direction,
+    float widthSize) const {
+  const YGEdge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
+  auto leadingPadding = isRow(axis)
+      ? computeEdgeValueForRow(style_.padding(), YGEdgeStart, startEdge)
+      : computeEdgeValueForColumn(style_.padding(), startEdge);
+
+  return maxOrDefined(resolveValue(leadingPadding, widthSize).unwrap(), 0.0f);
+}
+
+float Node::getFlexStartPadding(
+    FlexDirection axis,
+    Direction direction,
+    float widthSize) const {
+  const YGEdge leadRelativeFlexItemEdge =
+      flexStartRelativeEdge(axis, direction);
   auto leadingPadding = isRow(axis)
       ? computeEdgeValueForRow(
-            style_.padding(), YGEdgeStart, flexStartEdge(axis))
+            style_.padding(), leadRelativeFlexItemEdge, flexStartEdge(axis))
       : computeEdgeValueForColumn(style_.padding(), flexStartEdge(axis));
 
   return maxOrDefined(resolveValue(leadingPadding, widthSize).unwrap(), 0.0f);
 }
 
-float Node::getFlexEndPadding(FlexDirection axis, float widthSize) const {
+float Node::getInlineEndPadding(
+    FlexDirection axis,
+    Direction direction,
+    float widthSize) const {
+  const YGEdge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
   auto trailingPadding = isRow(axis)
-      ? computeEdgeValueForRow(style_.padding(), YGEdgeEnd, flexEndEdge(axis))
+      ? computeEdgeValueForRow(style_.padding(), YGEdgeEnd, endEdge)
+      : computeEdgeValueForColumn(style_.padding(), endEdge);
+
+  return maxOrDefined(resolveValue(trailingPadding, widthSize).unwrap(), 0.0f);
+}
+
+float Node::getFlexEndPadding(
+    FlexDirection axis,
+    Direction direction,
+    float widthSize) const {
+  const YGEdge trailRelativeFlexItemEdge = flexEndRelativeEdge(axis, direction);
+  auto trailingPadding = isRow(axis)
+      ? computeEdgeValueForRow(
+            style_.padding(), trailRelativeFlexItemEdge, flexEndEdge(axis))
       : computeEdgeValueForColumn(style_.padding(), flexEndEdge(axis));
 
   return maxOrDefined(resolveValue(trailingPadding, widthSize).unwrap(), 0.0f);
@@ -218,7 +252,7 @@ float Node::getInlineStartPaddingAndBorder(
     FlexDirection axis,
     Direction direction,
     float widthSize) const {
-  return getFlexStartPadding(axis, widthSize) +
+  return getInlineStartPadding(axis, direction, widthSize) +
       getInlineStartBorder(axis, direction);
 }
 
@@ -226,7 +260,7 @@ float Node::getFlexStartPaddingAndBorder(
     FlexDirection axis,
     Direction direction,
     float widthSize) const {
-  return getFlexStartPadding(axis, widthSize) +
+  return getFlexStartPadding(axis, direction, widthSize) +
       getFlexStartBorder(axis, direction);
 }
 
@@ -234,7 +268,7 @@ float Node::getInlineEndPaddingAndBorder(
     FlexDirection axis,
     Direction direction,
     float widthSize) const {
-  return getFlexEndPadding(axis, widthSize) +
+  return getInlineEndPadding(axis, direction, widthSize) +
       getInlineEndBorder(axis, direction);
 }
 
@@ -242,7 +276,8 @@ float Node::getFlexEndPaddingAndBorder(
     FlexDirection axis,
     Direction direction,
     float widthSize) const {
-  return getFlexEndPadding(axis, widthSize) + getFlexEndBorder(axis, direction);
+  return getFlexEndPadding(axis, direction, widthSize) +
+      getFlexEndBorder(axis, direction);
 }
 
 float Node::getMarginForAxis(FlexDirection axis, float widthSize) const {

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -50,10 +50,10 @@ class YG_EXPORT Node : public ::YGNode {
 
   float relativePosition(FlexDirection axis, const float axisSize) const;
 
-  YGEdge getLeadingLayoutEdgeUsingErrata(
+  YGEdge getInlineStartEdgeUsingErrata(
       FlexDirection flexDirection,
       Direction direction) const;
-  YGEdge getTrailingLayoutEdgeUsingErrata(
+  YGEdge getInlineEndEdgeUsingErrata(
       FlexDirection flexDirection,
       Direction direction) const;
 
@@ -196,24 +196,24 @@ class YG_EXPORT Node : public ::YGNode {
       YGEdge edge);
 
   // Methods related to positions, margin, padding and border
-  bool isLeadingPositionDefined(FlexDirection axis) const;
-  bool isTrailingPosDefined(FlexDirection axis) const;
-  float getLeadingPosition(FlexDirection axis, float axisSize) const;
-  float getTrailingPosition(FlexDirection axis, float axisSize) const;
-  float getLeadingMargin(
+  bool isFlexStartPositionDefined(FlexDirection axis) const;
+  bool isFlexEndPositionDefined(FlexDirection axis) const;
+  float getFlexStartPosition(FlexDirection axis, float axisSize) const;
+  float getFlexEndPosition(FlexDirection axis, float axisSize) const;
+  float getInlineStartMargin(
       FlexDirection axis,
       Direction direction,
       float widthSize) const;
-  float getTrailingMargin(
+  float getInlineEndMargin(
       FlexDirection axis,
       Direction direction,
       float widthSize) const;
-  float getLeadingBorder(FlexDirection flexDirection) const;
-  float getTrailingBorder(FlexDirection flexDirection) const;
-  float getLeadingPadding(FlexDirection axis, float widthSize) const;
-  float getTrailingPadding(FlexDirection axis, float widthSize) const;
-  float getLeadingPaddingAndBorder(FlexDirection axis, float widthSize) const;
-  float getTrailingPaddingAndBorder(FlexDirection axis, float widthSize) const;
+  float getFlexStartBorder(FlexDirection flexDirection) const;
+  float getFlexEndBorder(FlexDirection flexDirection) const;
+  float getFlexStartPadding(FlexDirection axis, float widthSize) const;
+  float getFlexEndPadding(FlexDirection axis, float widthSize) const;
+  float getFlexStartPaddingAndBorder(FlexDirection axis, float widthSize) const;
+  float getFlexEndPaddingAndBorder(FlexDirection axis, float widthSize) const;
   float getMarginForAxis(FlexDirection axis, float widthSize) const;
   float getGapForAxis(FlexDirection axis) const;
   // Setters
@@ -293,7 +293,7 @@ class YG_EXPORT Node : public ::YGNode {
   void markDirtyAndPropagateDownwards();
 
   // Other methods
-  YGValue marginLeadingValue(FlexDirection axis) const;
+  YGValue getFlexStartMarginValue(FlexDirection axis) const;
   YGValue marginTrailingValue(FlexDirection axis) const;
   YGValue resolveFlexBasisPtr() const;
   void resolveDimension();

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -208,12 +208,32 @@ class YG_EXPORT Node : public ::YGNode {
       FlexDirection axis,
       Direction direction,
       float widthSize) const;
-  float getFlexStartBorder(FlexDirection flexDirection) const;
-  float getFlexEndBorder(FlexDirection flexDirection) const;
+  float getFlexStartBorder(FlexDirection flexDirection, Direction direction)
+      const;
+  float getInlineStartBorder(FlexDirection flexDirection, Direction direction)
+      const;
+  float getFlexEndBorder(FlexDirection flexDirection, Direction direction)
+      const;
+  float getInlineEndBorder(FlexDirection flexDirection, Direction direction)
+      const;
   float getFlexStartPadding(FlexDirection axis, float widthSize) const;
   float getFlexEndPadding(FlexDirection axis, float widthSize) const;
-  float getFlexStartPaddingAndBorder(FlexDirection axis, float widthSize) const;
-  float getFlexEndPaddingAndBorder(FlexDirection axis, float widthSize) const;
+  float getFlexStartPaddingAndBorder(
+      FlexDirection axis,
+      Direction direction,
+      float widthSize) const;
+  float getInlineStartPaddingAndBorder(
+      FlexDirection axis,
+      Direction direction,
+      float widthSize) const;
+  float getFlexEndPaddingAndBorder(
+      FlexDirection axis,
+      Direction direction,
+      float widthSize) const;
+  float getInlineEndPaddingAndBorder(
+      FlexDirection axis,
+      Direction direction,
+      float widthSize) const;
   float getMarginForAxis(FlexDirection axis, float widthSize) const;
   float getGapForAxis(FlexDirection axis) const;
   // Setters

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -216,8 +216,22 @@ class YG_EXPORT Node : public ::YGNode {
       const;
   float getInlineEndBorder(FlexDirection flexDirection, Direction direction)
       const;
-  float getFlexStartPadding(FlexDirection axis, float widthSize) const;
-  float getFlexEndPadding(FlexDirection axis, float widthSize) const;
+  float getFlexStartPadding(
+      FlexDirection axis,
+      Direction direction,
+      float widthSize) const;
+  float getInlineStartPadding(
+      FlexDirection axis,
+      Direction direction,
+      float widthSize) const;
+  float getFlexEndPadding(
+      FlexDirection axis,
+      Direction direction,
+      float widthSize) const;
+  float getInlineEndPadding(
+      FlexDirection axis,
+      Direction direction,
+      float widthSize) const;
   float getFlexStartPaddingAndBorder(
       FlexDirection axis,
       Direction direction,


### PR DESCRIPTION
Summary:
Just like D50140503 where marginStart and marginEnd were not working with row reverse, paddingStart and paddingEnd are not working either with row reverse either. The solution is similar - we were checking the flex item layout starting/ending edges and not the general layout starting/ending edges. This change makes it so that we look at the proper edge according to what direction is set.

One caveat is that in the case of padding (and also border) there is a callsite that actually wants to get the flex item layout's leading/trailing padding and not the one dictated by direction. So, I made a new function to accommodate this and just swapped that callsite out.

Differential Revision: D50348995

