### PR TITLE
Pass '--hide-scrollbars' flag to chrome when generating tests

### DIFF
--- a/gentest/gentest.rb
+++ b/gentest/gentest.rb
@@ -14,7 +14,7 @@ browser = Watir::Browser.new(:chrome, options: {
     "browser" => "ALL",
     "performance" => "ALL"
   },
-  args: ['--force-device-scale-factor=1', '--window-position=0,0']
+  args: ['--force-device-scale-factor=1', '--hide-scrollbars', '--window-position=0,0']
 })
 
 Dir.chdir(File.dirname($0))


### PR DESCRIPTION
I have verified that this works (both that it doesn't crash, and that it causes me to generate the same assertions as everyone else, even with the "always show scrollbars" OS setting enabled).

@NickGerleman If I was following a "classic OSS workflow" I would rebase my space-evenly PR on top of this one and remove the commit updating the aspect ratio tests from this PR. Will Phabricator / the sync scripts deal with that properly, or would it be easier for me to just put this PR "on top" of the other one and just have a commit reverting the test changes? I can see you've already imported the other PR, and have been building work on top of it.