### PR TITLE
Fix issue where position insets were not working with row reverse

### DIFF
--- a/gentest/fixtures/YGFlexDirectionTest.html
+++ b/gentest/fixtures/YGFlexDirectionTest.html
@@ -34,147 +34,177 @@
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_margin_left" style="height: 100px; width: 100px; flex-direction: row-reverse; margin-left: 100px;">
+<div id="flex_direction_row_reverse_margin_left"
+  style="height: 100px; width: 100px; flex-direction: row-reverse; margin-left: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
 <!-- gentest.rb will swap margin-start to margin-left. This is needed to use YGEdgeStart instead of YGEdgeLeft in the generated tests -->
-<div id="flex_direction_row_reverse_margin_start" style="height: 100px; width: 100px; flex-direction: row-reverse; margin-start: 100px;">
+<div id="flex_direction_row_reverse_margin_start"
+  style="height: 100px; width: 100px; flex-direction: row-reverse; margin-start: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_margin_right" style="height: 100px; width: 100px; flex-direction: row-reverse; margin-right: 100px;">
+<div id="flex_direction_row_reverse_margin_right"
+  style="height: 100px; width: 100px; flex-direction: row-reverse; margin-right: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_margin_end" style="height: 100px; width: 100px; flex-direction: row-reverse; margin-end: 100px;">
+<div id="flex_direction_row_reverse_margin_end"
+  style="height: 100px; width: 100px; flex-direction: row-reverse; margin-end: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_column_reverse_margin_top" style="height: 100px; width: 100px; flex-direction: column-reverse; margin-top: 100px;">
+<div id="flex_direction_column_reverse_margin_top"
+  style="height: 100px; width: 100px; flex-direction: column-reverse; margin-top: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_column_reverse_margin_bottom" style="height: 100px; width: 100px; flex-direction: column-reverse; margin-bottom: 100px;">
+<div id="flex_direction_column_reverse_margin_bottom"
+  style="height: 100px; width: 100px; flex-direction: column-reverse; margin-bottom: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_padding_left" style="height: 100px; width: 100px; flex-direction: row-reverse; padding-left: 100px;">
+<div id="flex_direction_row_reverse_padding_left"
+  style="height: 100px; width: 100px; flex-direction: row-reverse; padding-left: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_padding_start" style="height: 100px; width: 100px; flex-direction: row-reverse; padding-start: 100px;">
+<div id="flex_direction_row_reverse_padding_start"
+  style="height: 100px; width: 100px; flex-direction: row-reverse; padding-start: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_padding_right" style="height: 100px; width: 100px; flex-direction: row-reverse; padding-right: 100px;">
+<div id="flex_direction_row_reverse_padding_right"
+  style="height: 100px; width: 100px; flex-direction: row-reverse; padding-right: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_padding_end" style="height: 100px; width: 100px; flex-direction: row-reverse; padding-end: 100px;">
+<div id="flex_direction_row_reverse_padding_end"
+  style="height: 100px; width: 100px; flex-direction: row-reverse; padding-end: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_column_reverse_padding_top" style="height: 100px; width: 100px; flex-direction: column-reverse; padding-top: 100px;">
+<div id="flex_direction_column_reverse_padding_top"
+  style="height: 100px; width: 100px; flex-direction: column-reverse; padding-top: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_column_reverse_padding_bottom" style="height: 100px; width: 100px; flex-direction: column-reverse; padding-bottom: 100px;">
+<div id="flex_direction_column_reverse_padding_bottom"
+  style="height: 100px; width: 100px; flex-direction: column-reverse; padding-bottom: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_border_left" style="height: 100px; width: 100px; flex-direction: row-reverse; border-left-width: 100px;">
+<div id="flex_direction_row_reverse_border_left"
+  style="height: 100px; width: 100px; flex-direction: row-reverse; border-left-width: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_border_start" style="height: 100px; width: 100px; flex-direction: row-reverse; border-start-width: 100px;">
+<div id="flex_direction_row_reverse_border_start"
+  style="height: 100px; width: 100px; flex-direction: row-reverse; border-start-width: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_border_right" style="height: 100px; width: 100px; flex-direction: row-reverse; border-right-width: 100px;">
+<div id="flex_direction_row_reverse_border_right"
+  style="height: 100px; width: 100px; flex-direction: row-reverse; border-right-width: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_border_end" style="height: 100px; width: 100px; flex-direction: row-reverse; border-end-width: 100px;">
+<div id="flex_direction_row_reverse_border_end"
+  style="height: 100px; width: 100px; flex-direction: row-reverse; border-end-width: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_column_reverse_border_top" style="height: 100px; width: 100px; flex-direction: column-reverse; border-top-width: 100px;">
+<div id="flex_direction_column_reverse_border_top"
+  style="height: 100px; width: 100px; flex-direction: column-reverse; border-top-width: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_column_reverse_border_bottom" style="height: 100px; width: 100px; flex-direction: column-reverse; border-bottom-width: 100px;">
+<div id="flex_direction_column_reverse_border_bottom"
+  style="height: 100px; width: 100px; flex-direction: column-reverse; border-bottom-width: 100px;">
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
   <div style="width: 10px;"></div>
 </div>
 
-<div id="flex_direction_row_reverse_pos_left" data-disabled="true" style="height: 100px; width: 100px; flex-direction: row-reverse; left: 100px;">
-  <div style="width: 10px;"></div>
-  <div style="width: 10px;"></div>
-  <div style="width: 10px;"></div>
+<div id="flex_direction_row_reverse_pos_left" data-disabled="true" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; left: 100px;">
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
 </div>
 
-<div id="flex_direction_row_reverse_pos_start" data-disabled="true" style="height: 100px; width: 100px; flex-direction: row-reverse; start: 100px;">
-  <div style="width: 10px;"></div>
-  <div style="width: 10px;"></div>
-  <div style="width: 10px;"></div>
+<div id="flex_direction_row_reverse_pos_start" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; start: 100px;">
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
 </div>
 
-<div id="flex_direction_row_reverse_pos_right" data-disabled="true" style="height: 100px; width: 100px; flex-direction: row-reverse; right: 100px;">
-  <div style="width: 10px;"></div>
-  <div style="width: 10px;"></div>
-  <div style="width: 10px;"></div>
+<div id="flex_direction_row_reverse_pos_right" data-disabled="true" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; right: 100px;">
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
 </div>
 
-<div id="flex_direction_row_reverse_pos_end" data-disabled="true" style="height: 100px; width: 100px; flex-direction: row-reverse; end: 100px;">
-  <div style="width: 10px;"></div>
-  <div style="width: 10px;"></div>
-  <div style="width: 10px;"></div>
+<div id="flex_direction_row_reverse_pos_end" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; end: 100px;">
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
 </div>
 
-<div id="flex_direction_column_reverse_pos_top" data-disabled="true" style="height: 100px; width: 100px; flex-direction: column-reverse; top: 100px;">
-  <div style="width: 10px;"></div>
-  <div style="width: 10px;"></div>
-  <div style="width: 10px;"></div>
+<div id="flex_direction_column_reverse_pos_top" data-disabled="true" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: column-reverse; top: 100px;">
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
 </div>
 
-<div id="flex_direction_column_reverse_pos_bottom" data-disabled="true" style="height: 100px; width: 100px; flex-direction: column-reverse; bottom: 100px;">
-  <div style="width: 10px;"></div>
-  <div style="width: 10px;"></div>
-  <div style="width: 10px;"></div>
+<div id="flex_direction_column_reverse_pos_bottom" data-disabled="true" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: column-reverse; bottom: 100px;">
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
 </div>

--- a/java/tests/com/facebook/yoga/YGFlexDirectionTest.java
+++ b/java/tests/com/facebook/yoga/YGFlexDirectionTest.java
@@ -1678,137 +1678,166 @@ public class YGFlexDirectionTest {
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
 
     final YogaNode root = createNode(config);
-    root.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root.setPosition(YogaEdge.LEFT, 100f);
     root.setWidth(100f);
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setWidth(10f);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPosition(YogaEdge.LEFT, 100f);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
-    final YogaNode root_child1 = createNode(config);
-    root_child1.setWidth(10f);
-    root.addChildAt(root_child1, 1);
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidth(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
 
-    final YogaNode root_child2 = createNode(config);
-    root_child2.setWidth(10f);
-    root.addChildAt(root_child2, 2);
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
-    assertEquals(100f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(70f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(80f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(70f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
 
     root.setDirection(YogaDirection.RTL);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
-    assertEquals(100f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(20f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
   }
 
   @Test
-  @Ignore
   public void test_flex_direction_row_reverse_pos_start() {
     YogaConfig config = YogaConfigFactory.create();
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
 
     final YogaNode root = createNode(config);
-    root.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root.setPosition(YogaEdge.START, 100f);
     root.setWidth(100f);
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setWidth(10f);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPosition(YogaEdge.START, 100f);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
-    final YogaNode root_child1 = createNode(config);
-    root_child1.setWidth(10f);
-    root.addChildAt(root_child1, 1);
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidth(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
 
-    final YogaNode root_child2 = createNode(config);
-    root_child2.setWidth(10f);
-    root.addChildAt(root_child2, 2);
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
-    assertEquals(100f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(70f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(80f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(70f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
 
     root.setDirection(YogaDirection.RTL);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
-    assertEquals(-200f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-100f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(20f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
   }
 
   @Test
@@ -1818,137 +1847,166 @@ public class YGFlexDirectionTest {
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
 
     final YogaNode root = createNode(config);
-    root.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root.setPosition(YogaEdge.RIGHT, 100f);
     root.setWidth(100f);
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setWidth(10f);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPosition(YogaEdge.RIGHT, 100f);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
-    final YogaNode root_child1 = createNode(config);
-    root_child1.setWidth(10f);
-    root.addChildAt(root_child1, 1);
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidth(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
 
-    final YogaNode root_child2 = createNode(config);
-    root_child2.setWidth(10f);
-    root.addChildAt(root_child2, 2);
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
-    assertEquals(-200f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-100f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(70f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(80f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(70f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
 
     root.setDirection(YogaDirection.RTL);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
-    assertEquals(-200f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-100f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(20f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
   }
 
   @Test
-  @Ignore
   public void test_flex_direction_row_reverse_pos_end() {
     YogaConfig config = YogaConfigFactory.create();
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
 
     final YogaNode root = createNode(config);
-    root.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root.setPosition(YogaEdge.END, 100f);
     root.setWidth(100f);
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setWidth(10f);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPosition(YogaEdge.END, 100f);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
-    final YogaNode root_child1 = createNode(config);
-    root_child1.setWidth(10f);
-    root.addChildAt(root_child1, 1);
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidth(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
 
-    final YogaNode root_child2 = createNode(config);
-    root_child2.setWidth(10f);
-    root.addChildAt(root_child2, 2);
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
-    assertEquals(-200f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-100f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(80f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(70f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(80f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(70f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
 
     root.setDirection(YogaDirection.RTL);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
-    assertEquals(100f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutX(), 0.0f);
     assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutX(), 0.0f);
     assertEquals(0f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
     assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(10f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(20f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(100f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
   }
 
   @Test
@@ -1958,67 +2016,82 @@ public class YGFlexDirectionTest {
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
 
     final YogaNode root = createNode(config);
-    root.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
-    root.setPosition(YogaEdge.TOP, 100f);
     root.setWidth(100f);
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setWidth(10f);
+    root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
+    root_child0.setPosition(YogaEdge.TOP, 100f);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
-    final YogaNode root_child1 = createNode(config);
-    root_child1.setWidth(10f);
-    root.addChildAt(root_child1, 1);
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidth(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
 
-    final YogaNode root_child2 = createNode(config);
-    root_child2.setWidth(10f);
-    root.addChildAt(root_child2, 2);
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
     assertEquals(0f, root.getLayoutX(), 0.0f);
-    assertEquals(100f, root.getLayoutY(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(100f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(100f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(100f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
 
     root.setDirection(YogaDirection.RTL);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
     assertEquals(0f, root.getLayoutX(), 0.0f);
-    assertEquals(100f, root.getLayoutY(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
     assertEquals(100f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(90f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(100f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(90f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(100f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
   }
 
   @Test
@@ -2028,67 +2101,82 @@ public class YGFlexDirectionTest {
     config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
 
     final YogaNode root = createNode(config);
-    root.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
-    root.setPosition(YogaEdge.BOTTOM, 100f);
     root.setWidth(100f);
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setWidth(10f);
+    root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
+    root_child0.setPosition(YogaEdge.BOTTOM, 100f);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
-    final YogaNode root_child1 = createNode(config);
-    root_child1.setWidth(10f);
-    root.addChildAt(root_child1, 1);
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setWidth(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
 
-    final YogaNode root_child2 = createNode(config);
-    root_child2.setWidth(10f);
-    root.addChildAt(root_child2, 2);
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
     assertEquals(0f, root.getLayoutX(), 0.0f);
-    assertEquals(-200f, root.getLayoutY(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
     assertEquals(0f, root_child0.getLayoutX(), 0.0f);
-    assertEquals(100f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+    assertEquals(-100f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(100f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(0f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(100f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
 
     root.setDirection(YogaDirection.RTL);
     root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
 
     assertEquals(0f, root.getLayoutX(), 0.0f);
-    assertEquals(-200f, root.getLayoutY(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
     assertEquals(100f, root.getLayoutWidth(), 0.0f);
     assertEquals(100f, root.getLayoutHeight(), 0.0f);
 
-    assertEquals(90f, root_child0.getLayoutX(), 0.0f);
-    assertEquals(100f, root_child0.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child0.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(-100f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(90f, root_child1.getLayoutX(), 0.0f);
-    assertEquals(100f, root_child1.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child1.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child1.getLayoutHeight(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutHeight(), 0.0f);
 
-    assertEquals(90f, root_child2.getLayoutX(), 0.0f);
-    assertEquals(100f, root_child2.getLayoutY(), 0.0f);
-    assertEquals(10f, root_child2.getLayoutWidth(), 0.0f);
-    assertEquals(0f, root_child2.getLayoutHeight(), 0.0f);
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
   }
 
   private YogaNode createNode(YogaConfig config) {

--- a/javascript/tests/generated/YGFlexDirectionTest.test.ts
+++ b/javascript/tests/generated/YGFlexDirectionTest.test.ts
@@ -1823,65 +1823,80 @@ test.skip('flex_direction_row_reverse_pos_left', () => {
 
   try {
     root = Yoga.Node.create(config);
-    root.setFlexDirection(FlexDirection.RowReverse);
-    root.setPosition(Edge.Left, 100);
     root.setWidth(100);
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setWidth(10);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPosition(Edge.Left, 100);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
-    const root_child1 = Yoga.Node.create(config);
-    root_child1.setWidth(10);
-    root.insertChild(root_child1, 1);
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth(10);
+    root_child0.insertChild(root_child0_child0, 0);
 
-    const root_child2 = Yoga.Node.create(config);
-    root_child2.setWidth(10);
-    root.insertChild(root_child2, 2);
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
 
-    expect(root.getComputedLeft()).toBe(100);
+    expect(root.getComputedLeft()).toBe(0);
     expect(root.getComputedTop()).toBe(0);
     expect(root.getComputedWidth()).toBe(100);
     expect(root.getComputedHeight()).toBe(100);
 
-    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedLeft()).toBe(100);
     expect(root_child0.getComputedTop()).toBe(0);
-    expect(root_child0.getComputedWidth()).toBe(10);
+    expect(root_child0.getComputedWidth()).toBe(100);
     expect(root_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child1.getComputedLeft()).toBe(80);
-    expect(root_child1.getComputedTop()).toBe(0);
-    expect(root_child1.getComputedWidth()).toBe(10);
-    expect(root_child1.getComputedHeight()).toBe(100);
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child2.getComputedLeft()).toBe(70);
-    expect(root_child2.getComputedTop()).toBe(0);
-    expect(root_child2.getComputedWidth()).toBe(10);
-    expect(root_child2.getComputedHeight()).toBe(100);
+    expect(root_child0_child1.getComputedLeft()).toBe(80);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(70);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
 
     root.calculateLayout(undefined, undefined, Direction.RTL);
 
-    expect(root.getComputedLeft()).toBe(100);
+    expect(root.getComputedLeft()).toBe(0);
     expect(root.getComputedTop()).toBe(0);
     expect(root.getComputedWidth()).toBe(100);
     expect(root.getComputedHeight()).toBe(100);
 
-    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedLeft()).toBe(100);
     expect(root_child0.getComputedTop()).toBe(0);
-    expect(root_child0.getComputedWidth()).toBe(10);
+    expect(root_child0.getComputedWidth()).toBe(100);
     expect(root_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child1.getComputedLeft()).toBe(10);
-    expect(root_child1.getComputedTop()).toBe(0);
-    expect(root_child1.getComputedWidth()).toBe(10);
-    expect(root_child1.getComputedHeight()).toBe(100);
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child2.getComputedLeft()).toBe(20);
-    expect(root_child2.getComputedTop()).toBe(0);
-    expect(root_child2.getComputedWidth()).toBe(10);
-    expect(root_child2.getComputedHeight()).toBe(100);
+    expect(root_child0_child1.getComputedLeft()).toBe(10);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
   } finally {
     if (typeof root !== 'undefined') {
       root.freeRecursive();
@@ -1890,7 +1905,7 @@ test.skip('flex_direction_row_reverse_pos_left', () => {
     config.free();
   }
 });
-test.skip('flex_direction_row_reverse_pos_start', () => {
+test('flex_direction_row_reverse_pos_start', () => {
   const config = Yoga.Config.create();
   let root;
 
@@ -1898,65 +1913,80 @@ test.skip('flex_direction_row_reverse_pos_start', () => {
 
   try {
     root = Yoga.Node.create(config);
-    root.setFlexDirection(FlexDirection.RowReverse);
-    root.setPosition(Edge.Start, 100);
     root.setWidth(100);
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setWidth(10);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPosition(Edge.Start, 100);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
-    const root_child1 = Yoga.Node.create(config);
-    root_child1.setWidth(10);
-    root.insertChild(root_child1, 1);
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth(10);
+    root_child0.insertChild(root_child0_child0, 0);
 
-    const root_child2 = Yoga.Node.create(config);
-    root_child2.setWidth(10);
-    root.insertChild(root_child2, 2);
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
 
-    expect(root.getComputedLeft()).toBe(100);
+    expect(root.getComputedLeft()).toBe(0);
     expect(root.getComputedTop()).toBe(0);
     expect(root.getComputedWidth()).toBe(100);
     expect(root.getComputedHeight()).toBe(100);
 
-    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedLeft()).toBe(100);
     expect(root_child0.getComputedTop()).toBe(0);
-    expect(root_child0.getComputedWidth()).toBe(10);
+    expect(root_child0.getComputedWidth()).toBe(100);
     expect(root_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child1.getComputedLeft()).toBe(80);
-    expect(root_child1.getComputedTop()).toBe(0);
-    expect(root_child1.getComputedWidth()).toBe(10);
-    expect(root_child1.getComputedHeight()).toBe(100);
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child2.getComputedLeft()).toBe(70);
-    expect(root_child2.getComputedTop()).toBe(0);
-    expect(root_child2.getComputedWidth()).toBe(10);
-    expect(root_child2.getComputedHeight()).toBe(100);
+    expect(root_child0_child1.getComputedLeft()).toBe(80);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(70);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
 
     root.calculateLayout(undefined, undefined, Direction.RTL);
 
-    expect(root.getComputedLeft()).toBe(-200);
+    expect(root.getComputedLeft()).toBe(0);
     expect(root.getComputedTop()).toBe(0);
     expect(root.getComputedWidth()).toBe(100);
     expect(root.getComputedHeight()).toBe(100);
 
-    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedLeft()).toBe(-100);
     expect(root_child0.getComputedTop()).toBe(0);
-    expect(root_child0.getComputedWidth()).toBe(10);
+    expect(root_child0.getComputedWidth()).toBe(100);
     expect(root_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child1.getComputedLeft()).toBe(10);
-    expect(root_child1.getComputedTop()).toBe(0);
-    expect(root_child1.getComputedWidth()).toBe(10);
-    expect(root_child1.getComputedHeight()).toBe(100);
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child2.getComputedLeft()).toBe(20);
-    expect(root_child2.getComputedTop()).toBe(0);
-    expect(root_child2.getComputedWidth()).toBe(10);
-    expect(root_child2.getComputedHeight()).toBe(100);
+    expect(root_child0_child1.getComputedLeft()).toBe(10);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
   } finally {
     if (typeof root !== 'undefined') {
       root.freeRecursive();
@@ -1973,65 +2003,80 @@ test.skip('flex_direction_row_reverse_pos_right', () => {
 
   try {
     root = Yoga.Node.create(config);
-    root.setFlexDirection(FlexDirection.RowReverse);
-    root.setPosition(Edge.Right, 100);
     root.setWidth(100);
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setWidth(10);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPosition(Edge.Right, 100);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
-    const root_child1 = Yoga.Node.create(config);
-    root_child1.setWidth(10);
-    root.insertChild(root_child1, 1);
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth(10);
+    root_child0.insertChild(root_child0_child0, 0);
 
-    const root_child2 = Yoga.Node.create(config);
-    root_child2.setWidth(10);
-    root.insertChild(root_child2, 2);
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
 
-    expect(root.getComputedLeft()).toBe(-200);
+    expect(root.getComputedLeft()).toBe(0);
     expect(root.getComputedTop()).toBe(0);
     expect(root.getComputedWidth()).toBe(100);
     expect(root.getComputedHeight()).toBe(100);
 
-    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedLeft()).toBe(-100);
     expect(root_child0.getComputedTop()).toBe(0);
-    expect(root_child0.getComputedWidth()).toBe(10);
+    expect(root_child0.getComputedWidth()).toBe(100);
     expect(root_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child1.getComputedLeft()).toBe(80);
-    expect(root_child1.getComputedTop()).toBe(0);
-    expect(root_child1.getComputedWidth()).toBe(10);
-    expect(root_child1.getComputedHeight()).toBe(100);
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child2.getComputedLeft()).toBe(70);
-    expect(root_child2.getComputedTop()).toBe(0);
-    expect(root_child2.getComputedWidth()).toBe(10);
-    expect(root_child2.getComputedHeight()).toBe(100);
+    expect(root_child0_child1.getComputedLeft()).toBe(80);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(70);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
 
     root.calculateLayout(undefined, undefined, Direction.RTL);
 
-    expect(root.getComputedLeft()).toBe(-200);
+    expect(root.getComputedLeft()).toBe(0);
     expect(root.getComputedTop()).toBe(0);
     expect(root.getComputedWidth()).toBe(100);
     expect(root.getComputedHeight()).toBe(100);
 
-    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedLeft()).toBe(-100);
     expect(root_child0.getComputedTop()).toBe(0);
-    expect(root_child0.getComputedWidth()).toBe(10);
+    expect(root_child0.getComputedWidth()).toBe(100);
     expect(root_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child1.getComputedLeft()).toBe(10);
-    expect(root_child1.getComputedTop()).toBe(0);
-    expect(root_child1.getComputedWidth()).toBe(10);
-    expect(root_child1.getComputedHeight()).toBe(100);
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child2.getComputedLeft()).toBe(20);
-    expect(root_child2.getComputedTop()).toBe(0);
-    expect(root_child2.getComputedWidth()).toBe(10);
-    expect(root_child2.getComputedHeight()).toBe(100);
+    expect(root_child0_child1.getComputedLeft()).toBe(10);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
   } finally {
     if (typeof root !== 'undefined') {
       root.freeRecursive();
@@ -2040,7 +2085,7 @@ test.skip('flex_direction_row_reverse_pos_right', () => {
     config.free();
   }
 });
-test.skip('flex_direction_row_reverse_pos_end', () => {
+test('flex_direction_row_reverse_pos_end', () => {
   const config = Yoga.Config.create();
   let root;
 
@@ -2048,65 +2093,80 @@ test.skip('flex_direction_row_reverse_pos_end', () => {
 
   try {
     root = Yoga.Node.create(config);
-    root.setFlexDirection(FlexDirection.RowReverse);
-    root.setPosition(Edge.End, 100);
     root.setWidth(100);
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setWidth(10);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPosition(Edge.End, 100);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
-    const root_child1 = Yoga.Node.create(config);
-    root_child1.setWidth(10);
-    root.insertChild(root_child1, 1);
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth(10);
+    root_child0.insertChild(root_child0_child0, 0);
 
-    const root_child2 = Yoga.Node.create(config);
-    root_child2.setWidth(10);
-    root.insertChild(root_child2, 2);
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
 
-    expect(root.getComputedLeft()).toBe(-200);
+    expect(root.getComputedLeft()).toBe(0);
     expect(root.getComputedTop()).toBe(0);
     expect(root.getComputedWidth()).toBe(100);
     expect(root.getComputedHeight()).toBe(100);
 
-    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedLeft()).toBe(-100);
     expect(root_child0.getComputedTop()).toBe(0);
-    expect(root_child0.getComputedWidth()).toBe(10);
+    expect(root_child0.getComputedWidth()).toBe(100);
     expect(root_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child1.getComputedLeft()).toBe(80);
-    expect(root_child1.getComputedTop()).toBe(0);
-    expect(root_child1.getComputedWidth()).toBe(10);
-    expect(root_child1.getComputedHeight()).toBe(100);
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child2.getComputedLeft()).toBe(70);
-    expect(root_child2.getComputedTop()).toBe(0);
-    expect(root_child2.getComputedWidth()).toBe(10);
-    expect(root_child2.getComputedHeight()).toBe(100);
+    expect(root_child0_child1.getComputedLeft()).toBe(80);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(70);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
 
     root.calculateLayout(undefined, undefined, Direction.RTL);
 
-    expect(root.getComputedLeft()).toBe(100);
+    expect(root.getComputedLeft()).toBe(0);
     expect(root.getComputedTop()).toBe(0);
     expect(root.getComputedWidth()).toBe(100);
     expect(root.getComputedHeight()).toBe(100);
 
-    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedLeft()).toBe(100);
     expect(root_child0.getComputedTop()).toBe(0);
-    expect(root_child0.getComputedWidth()).toBe(10);
+    expect(root_child0.getComputedWidth()).toBe(100);
     expect(root_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child1.getComputedLeft()).toBe(10);
-    expect(root_child1.getComputedTop()).toBe(0);
-    expect(root_child1.getComputedWidth()).toBe(10);
-    expect(root_child1.getComputedHeight()).toBe(100);
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child2.getComputedLeft()).toBe(20);
-    expect(root_child2.getComputedTop()).toBe(0);
-    expect(root_child2.getComputedWidth()).toBe(10);
-    expect(root_child2.getComputedHeight()).toBe(100);
+    expect(root_child0_child1.getComputedLeft()).toBe(10);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(20);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
   } finally {
     if (typeof root !== 'undefined') {
       root.freeRecursive();
@@ -2123,65 +2183,80 @@ test.skip('flex_direction_column_reverse_pos_top', () => {
 
   try {
     root = Yoga.Node.create(config);
-    root.setFlexDirection(FlexDirection.ColumnReverse);
-    root.setPosition(Edge.Top, 100);
     root.setWidth(100);
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setWidth(10);
+    root_child0.setFlexDirection(FlexDirection.ColumnReverse);
+    root_child0.setPosition(Edge.Top, 100);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
-    const root_child1 = Yoga.Node.create(config);
-    root_child1.setWidth(10);
-    root.insertChild(root_child1, 1);
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth(10);
+    root_child0.insertChild(root_child0_child0, 0);
 
-    const root_child2 = Yoga.Node.create(config);
-    root_child2.setWidth(10);
-    root.insertChild(root_child2, 2);
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
 
     expect(root.getComputedLeft()).toBe(0);
-    expect(root.getComputedTop()).toBe(100);
+    expect(root.getComputedTop()).toBe(0);
     expect(root.getComputedWidth()).toBe(100);
     expect(root.getComputedHeight()).toBe(100);
 
     expect(root_child0.getComputedLeft()).toBe(0);
     expect(root_child0.getComputedTop()).toBe(100);
-    expect(root_child0.getComputedWidth()).toBe(10);
-    expect(root_child0.getComputedHeight()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child1.getComputedLeft()).toBe(0);
-    expect(root_child1.getComputedTop()).toBe(100);
-    expect(root_child1.getComputedWidth()).toBe(10);
-    expect(root_child1.getComputedHeight()).toBe(0);
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(100);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(0);
 
-    expect(root_child2.getComputedLeft()).toBe(0);
-    expect(root_child2.getComputedTop()).toBe(100);
-    expect(root_child2.getComputedWidth()).toBe(10);
-    expect(root_child2.getComputedHeight()).toBe(0);
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(0);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
 
     root.calculateLayout(undefined, undefined, Direction.RTL);
 
     expect(root.getComputedLeft()).toBe(0);
-    expect(root.getComputedTop()).toBe(100);
+    expect(root.getComputedTop()).toBe(0);
     expect(root.getComputedWidth()).toBe(100);
     expect(root.getComputedHeight()).toBe(100);
 
-    expect(root_child0.getComputedLeft()).toBe(90);
+    expect(root_child0.getComputedLeft()).toBe(0);
     expect(root_child0.getComputedTop()).toBe(100);
-    expect(root_child0.getComputedWidth()).toBe(10);
-    expect(root_child0.getComputedHeight()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child1.getComputedLeft()).toBe(90);
-    expect(root_child1.getComputedTop()).toBe(100);
-    expect(root_child1.getComputedWidth()).toBe(10);
-    expect(root_child1.getComputedHeight()).toBe(0);
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(100);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(0);
 
-    expect(root_child2.getComputedLeft()).toBe(90);
-    expect(root_child2.getComputedTop()).toBe(100);
-    expect(root_child2.getComputedWidth()).toBe(10);
-    expect(root_child2.getComputedHeight()).toBe(0);
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(90);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
   } finally {
     if (typeof root !== 'undefined') {
       root.freeRecursive();
@@ -2198,65 +2273,80 @@ test.skip('flex_direction_column_reverse_pos_bottom', () => {
 
   try {
     root = Yoga.Node.create(config);
-    root.setFlexDirection(FlexDirection.ColumnReverse);
-    root.setPosition(Edge.Bottom, 100);
     root.setWidth(100);
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setWidth(10);
+    root_child0.setFlexDirection(FlexDirection.ColumnReverse);
+    root_child0.setPosition(Edge.Bottom, 100);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
-    const root_child1 = Yoga.Node.create(config);
-    root_child1.setWidth(10);
-    root.insertChild(root_child1, 1);
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setWidth(10);
+    root_child0.insertChild(root_child0_child0, 0);
 
-    const root_child2 = Yoga.Node.create(config);
-    root_child2.setWidth(10);
-    root.insertChild(root_child2, 2);
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
 
     expect(root.getComputedLeft()).toBe(0);
-    expect(root.getComputedTop()).toBe(-200);
+    expect(root.getComputedTop()).toBe(0);
     expect(root.getComputedWidth()).toBe(100);
     expect(root.getComputedHeight()).toBe(100);
 
     expect(root_child0.getComputedLeft()).toBe(0);
-    expect(root_child0.getComputedTop()).toBe(100);
-    expect(root_child0.getComputedWidth()).toBe(10);
-    expect(root_child0.getComputedHeight()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(-100);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child1.getComputedLeft()).toBe(0);
-    expect(root_child1.getComputedTop()).toBe(100);
-    expect(root_child1.getComputedWidth()).toBe(10);
-    expect(root_child1.getComputedHeight()).toBe(0);
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(100);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(0);
 
-    expect(root_child2.getComputedLeft()).toBe(0);
-    expect(root_child2.getComputedTop()).toBe(100);
-    expect(root_child2.getComputedWidth()).toBe(10);
-    expect(root_child2.getComputedHeight()).toBe(0);
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(0);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
 
     root.calculateLayout(undefined, undefined, Direction.RTL);
 
     expect(root.getComputedLeft()).toBe(0);
-    expect(root.getComputedTop()).toBe(-200);
+    expect(root.getComputedTop()).toBe(0);
     expect(root.getComputedWidth()).toBe(100);
     expect(root.getComputedHeight()).toBe(100);
 
-    expect(root_child0.getComputedLeft()).toBe(90);
-    expect(root_child0.getComputedTop()).toBe(100);
-    expect(root_child0.getComputedWidth()).toBe(10);
-    expect(root_child0.getComputedHeight()).toBe(0);
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(-100);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
 
-    expect(root_child1.getComputedLeft()).toBe(90);
-    expect(root_child1.getComputedTop()).toBe(100);
-    expect(root_child1.getComputedWidth()).toBe(10);
-    expect(root_child1.getComputedHeight()).toBe(0);
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(100);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(0);
 
-    expect(root_child2.getComputedLeft()).toBe(90);
-    expect(root_child2.getComputedTop()).toBe(100);
-    expect(root_child2.getComputedWidth()).toBe(10);
-    expect(root_child2.getComputedHeight()).toBe(0);
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(90);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
   } finally {
     if (typeof root !== 'undefined') {
       root.freeRecursive();

--- a/tests/generated/YGFlexDirectionTest.cpp
+++ b/tests/generated/YGFlexDirectionTest.cpp
@@ -1688,65 +1688,80 @@ TEST(YogaTest, flex_direction_row_reverse_pos_left) {
   YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPosition(root, YGEdgeLeft, 100);
   YGNodeStyleSetWidth(root, 100);
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child0, 10);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPosition(root_child0, YGEdgeLeft, 100);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
-  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child1, 10);
-  YGNodeInsertChild(root, root_child1, 1);
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
-  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child2, 10);
-  YGNodeInsertChild(root, root_child2, 2);
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child2));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
 
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeFreeRecursive(root);
 
@@ -1754,71 +1769,84 @@ TEST(YogaTest, flex_direction_row_reverse_pos_left) {
 }
 
 TEST(YogaTest, flex_direction_row_reverse_pos_start) {
-  GTEST_SKIP();
-
   const YGConfigRef config = YGConfigNew();
   YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPosition(root, YGEdgeStart, 100);
   YGNodeStyleSetWidth(root, 100);
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child0, 10);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPosition(root_child0, YGEdgeStart, 100);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
-  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child1, 10);
-  YGNodeInsertChild(root, root_child1, 1);
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
-  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child2, 10);
-  YGNodeInsertChild(root, root_child2, 2);
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child2));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
 
-  ASSERT_FLOAT_EQ(-200, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-100, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeFreeRecursive(root);
 
@@ -1832,65 +1860,80 @@ TEST(YogaTest, flex_direction_row_reverse_pos_right) {
   YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPosition(root, YGEdgeRight, 100);
   YGNodeStyleSetWidth(root, 100);
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child0, 10);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPosition(root_child0, YGEdgeRight, 100);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
-  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child1, 10);
-  YGNodeInsertChild(root, root_child1, 1);
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
-  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child2, 10);
-  YGNodeInsertChild(root, root_child2, 2);
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
-  ASSERT_FLOAT_EQ(-200, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-100, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child2));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
 
-  ASSERT_FLOAT_EQ(-200, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-100, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeFreeRecursive(root);
 
@@ -1898,71 +1941,84 @@ TEST(YogaTest, flex_direction_row_reverse_pos_right) {
 }
 
 TEST(YogaTest, flex_direction_row_reverse_pos_end) {
-  GTEST_SKIP();
-
   const YGConfigRef config = YGConfigNew();
   YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPosition(root, YGEdgeEnd, 100);
   YGNodeStyleSetWidth(root, 100);
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child0, 10);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPosition(root_child0, YGEdgeEnd, 100);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
-  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child1, 10);
-  YGNodeInsertChild(root, root_child1, 1);
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
-  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child2, 10);
-  YGNodeInsertChild(root, root_child2, 2);
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
-  ASSERT_FLOAT_EQ(-200, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-100, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child2));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(70, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
 
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeFreeRecursive(root);
 
@@ -1976,65 +2032,80 @@ TEST(YogaTest, flex_direction_column_reverse_pos_top) {
   YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(root, YGFlexDirectionColumnReverse);
-  YGNodeStyleSetPosition(root, YGEdgeTop, 100);
   YGNodeStyleSetWidth(root, 100);
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child0, 10);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
+  YGNodeStyleSetPosition(root_child0, YGEdgeTop, 100);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
-  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child1, 10);
-  YGNodeInsertChild(root, root_child1, 1);
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
-  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child2, 10);
-  YGNodeInsertChild(root, root_child2, 2);
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child2));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeFreeRecursive(root);
 
@@ -2048,65 +2119,80 @@ TEST(YogaTest, flex_direction_column_reverse_pos_bottom) {
   YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
 
   const YGNodeRef root = YGNodeNewWithConfig(config);
-  YGNodeStyleSetFlexDirection(root, YGFlexDirectionColumnReverse);
-  YGNodeStyleSetPosition(root, YGEdgeBottom, 100);
   YGNodeStyleSetWidth(root, 100);
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child0, 10);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
+  YGNodeStyleSetPosition(root_child0, YGEdgeBottom, 100);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
-  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child1, 10);
-  YGNodeInsertChild(root, root_child1, 1);
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
-  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetWidth(root_child2, 10);
-  YGNodeInsertChild(root, root_child2, 2);
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
-  ASSERT_FLOAT_EQ(-200, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+  ASSERT_FLOAT_EQ(-100, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
 
   ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
-  ASSERT_FLOAT_EQ(-200, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
   ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
 
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(-100, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
 
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child1));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child1));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child1));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child0));
 
-  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child2));
-  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child2));
-  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child2));
-  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child2));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
 
   YGNodeFreeRecursive(root);
 

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -343,13 +343,13 @@ static void layoutAbsoluteChild(
   } else {
     // If the child doesn't have a specified width, compute the width based on
     // the left/right offsets if they're defined.
-    if (child->isFlexStartPositionDefined(FlexDirection::Row) &&
-        child->isFlexEndPositionDefined(FlexDirection::Row)) {
+    if (child->isInlineStartPositionDefined(FlexDirection::Row, direction) &&
+        child->isInlineEndPositionDefined(FlexDirection::Row, direction)) {
       childWidth = node->getLayout().measuredDimension(Dimension::Width) -
           (node->getInlineStartBorder(FlexDirection::Row, direction) +
            node->getInlineEndBorder(FlexDirection::Row, direction)) -
-          (child->getFlexStartPosition(FlexDirection::Row, width) +
-           child->getFlexEndPosition(FlexDirection::Row, width));
+          (child->getInlineStartPosition(FlexDirection::Row, direction, width) +
+           child->getInlineEndPosition(FlexDirection::Row, direction, width));
       childWidth =
           boundAxis(child, FlexDirection::Row, childWidth, width, width);
     }
@@ -363,13 +363,15 @@ static void layoutAbsoluteChild(
   } else {
     // If the child doesn't have a specified height, compute the height based on
     // the top/bottom offsets if they're defined.
-    if (child->isFlexStartPositionDefined(FlexDirection::Column) &&
-        child->isFlexEndPositionDefined(FlexDirection::Column)) {
+    if (child->isInlineStartPositionDefined(FlexDirection::Column, direction) &&
+        child->isInlineEndPositionDefined(FlexDirection::Column, direction)) {
       childHeight = node->getLayout().measuredDimension(Dimension::Height) -
           (node->getInlineStartBorder(FlexDirection::Column, direction) +
            node->getInlineEndBorder(FlexDirection::Column, direction)) -
-          (child->getFlexStartPosition(FlexDirection::Column, height) +
-           child->getFlexEndPosition(FlexDirection::Column, height));
+          (child->getInlineStartPosition(
+               FlexDirection::Column, direction, height) +
+           child->getInlineEndPosition(
+               FlexDirection::Column, direction, height));
       childHeight =
           boundAxis(child, FlexDirection::Column, childHeight, height, width);
     }
@@ -446,18 +448,19 @@ static void layoutAbsoluteChild(
       depth,
       generationCount);
 
-  if (child->isFlexEndPositionDefined(mainAxis) &&
-      !child->isFlexStartPositionDefined(mainAxis)) {
+  if (child->isInlineEndPositionDefined(mainAxis, direction) &&
+      !child->isInlineStartPositionDefined(mainAxis, direction)) {
     child->setLayoutPosition(
         node->getLayout().measuredDimension(dimension(mainAxis)) -
             child->getLayout().measuredDimension(dimension(mainAxis)) -
             node->getInlineEndBorder(mainAxis, direction) -
             child->getInlineEndMargin(
                 mainAxis, direction, isMainAxisRow ? width : height) -
-            child->getFlexEndPosition(mainAxis, isMainAxisRow ? width : height),
+            child->getInlineEndPosition(
+                mainAxis, direction, isMainAxisRow ? width : height),
         flexStartEdge(mainAxis));
   } else if (
-      !child->isFlexStartPositionDefined(mainAxis) &&
+      !child->isInlineStartPositionDefined(mainAxis, direction) &&
       node->getStyle().justifyContent() == Justify::Center) {
     child->setLayoutPosition(
         (node->getLayout().measuredDimension(dimension(mainAxis)) -
@@ -465,7 +468,7 @@ static void layoutAbsoluteChild(
             2.0f,
         flexStartEdge(mainAxis));
   } else if (
-      !child->isFlexStartPositionDefined(mainAxis) &&
+      !child->isInlineStartPositionDefined(mainAxis, direction) &&
       node->getStyle().justifyContent() == Justify::FlexEnd) {
     child->setLayoutPosition(
         (node->getLayout().measuredDimension(dimension(mainAxis)) -
@@ -474,10 +477,11 @@ static void layoutAbsoluteChild(
   } else if (
       node->getConfig()->isExperimentalFeatureEnabled(
           ExperimentalFeature::AbsolutePercentageAgainstPaddingEdge) &&
-      child->isFlexStartPositionDefined(mainAxis)) {
+      child->isInlineStartPositionDefined(mainAxis, direction)) {
     child->setLayoutPosition(
-        child->getFlexStartPosition(
+        child->getInlineStartPosition(
             mainAxis,
+            direction,
             node->getLayout().measuredDimension(dimension(mainAxis))) +
             node->getInlineStartBorder(mainAxis, direction) +
             child->getInlineStartMargin(
@@ -487,20 +491,20 @@ static void layoutAbsoluteChild(
         flexStartEdge(mainAxis));
   }
 
-  if (child->isFlexEndPositionDefined(crossAxis) &&
-      !child->isFlexStartPositionDefined(crossAxis)) {
+  if (child->isInlineEndPositionDefined(crossAxis, direction) &&
+      !child->isInlineStartPositionDefined(crossAxis, direction)) {
     child->setLayoutPosition(
         node->getLayout().measuredDimension(dimension(crossAxis)) -
             child->getLayout().measuredDimension(dimension(crossAxis)) -
             node->getInlineEndBorder(crossAxis, direction) -
             child->getInlineEndMargin(
                 crossAxis, direction, isMainAxisRow ? height : width) -
-            child->getFlexEndPosition(
-                crossAxis, isMainAxisRow ? height : width),
+            child->getInlineEndPosition(
+                crossAxis, direction, isMainAxisRow ? height : width),
         flexStartEdge(crossAxis));
 
   } else if (
-      !child->isFlexStartPositionDefined(crossAxis) &&
+      !child->isInlineStartPositionDefined(crossAxis, direction) &&
       resolveChildAlignment(node, child) == Align::Center) {
     child->setLayoutPosition(
         (node->getLayout().measuredDimension(dimension(crossAxis)) -
@@ -508,7 +512,7 @@ static void layoutAbsoluteChild(
             2.0f,
         flexStartEdge(crossAxis));
   } else if (
-      !child->isFlexStartPositionDefined(crossAxis) &&
+      !child->isInlineStartPositionDefined(crossAxis, direction) &&
       ((resolveChildAlignment(node, child) == Align::FlexEnd) ^
        (node->getStyle().flexWrap() == Wrap::WrapReverse))) {
     child->setLayoutPosition(
@@ -518,10 +522,11 @@ static void layoutAbsoluteChild(
   } else if (
       node->getConfig()->isExperimentalFeatureEnabled(
           ExperimentalFeature::AbsolutePercentageAgainstPaddingEdge) &&
-      child->isFlexStartPositionDefined(crossAxis)) {
+      child->isInlineStartPositionDefined(crossAxis, direction)) {
     child->setLayoutPosition(
-        child->getFlexStartPosition(
+        child->getInlineStartPosition(
             crossAxis,
+            direction,
             node->getLayout().measuredDimension(dimension(crossAxis))) +
             node->getInlineStartBorder(crossAxis, direction) +
             child->getInlineStartMargin(
@@ -1305,13 +1310,14 @@ static void justifyMainAxis(
       continue;
     }
     if (childStyle.positionType() == PositionType::Absolute &&
-        child->isFlexStartPositionDefined(mainAxis)) {
+        child->isInlineStartPositionDefined(mainAxis, direction)) {
       if (performLayout) {
         // In case the child is position absolute and has left/top being
         // defined, we override the position to whatever the user said (and
         // margin/border).
         child->setLayoutPosition(
-            child->getFlexStartPosition(mainAxis, availableInnerMainDim) +
+            child->getInlineStartPosition(
+                mainAxis, direction, availableInnerMainDim) +
                 node->getInlineStartBorder(mainAxis, direction) +
                 child->getInlineStartMargin(
                     mainAxis, direction, availableInnerWidth),
@@ -1864,10 +1870,11 @@ static void calculateLayoutImpl(
           // top/left/bottom/right set, override all the previously computed
           // positions to set it correctly.
           const bool isChildLeadingPosDefined =
-              child->isFlexStartPositionDefined(crossAxis);
+              child->isInlineStartPositionDefined(crossAxis, direction);
           if (isChildLeadingPosDefined) {
             child->setLayoutPosition(
-                child->getFlexStartPosition(crossAxis, availableInnerCrossDim) +
+                child->getInlineStartPosition(
+                    crossAxis, direction, availableInnerCrossDim) +
                     node->getInlineStartBorder(crossAxis, direction) +
                     child->getInlineStartMargin(
                         crossAxis, direction, availableInnerWidth),
@@ -2195,8 +2202,10 @@ static void calculateLayoutImpl(
                 child->setLayoutPosition(
                     currentLead + maxAscentForCurrentLine -
                         calculateBaseline(child) +
-                        child->getFlexStartPosition(
-                            FlexDirection::Column, availableInnerCrossDim),
+                        child->getInlineStartPosition(
+                            FlexDirection::Column,
+                            direction,
+                            availableInnerCrossDim),
                     YGEdgeTop);
 
                 break;

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -48,7 +48,10 @@ class YG_EXPORT Node : public ::YGNode {
   std::array<YGValue, 2> resolvedDimensions_ = {
       {YGValueUndefined, YGValueUndefined}};
 
-  float relativePosition(FlexDirection axis, const float axisSize) const;
+  float relativePosition(
+      FlexDirection axis,
+      Direction direction,
+      const float axisSize) const;
 
   YGEdge getInlineStartEdgeUsingErrata(
       FlexDirection flexDirection,
@@ -196,10 +199,18 @@ class YG_EXPORT Node : public ::YGNode {
       YGEdge edge);
 
   // Methods related to positions, margin, padding and border
-  bool isFlexStartPositionDefined(FlexDirection axis) const;
-  bool isFlexEndPositionDefined(FlexDirection axis) const;
-  float getFlexStartPosition(FlexDirection axis, float axisSize) const;
-  float getFlexEndPosition(FlexDirection axis, float axisSize) const;
+  bool isInlineStartPositionDefined(FlexDirection axis, Direction direction)
+      const;
+  bool isInlineEndPositionDefined(FlexDirection axis, Direction direction)
+      const;
+  float getInlineStartPosition(
+      FlexDirection axis,
+      Direction direction,
+      float axisSize) const;
+  float getInlineEndPosition(
+      FlexDirection axis,
+      Direction direction,
+      float axisSize) const;
   float getInlineStartMargin(
       FlexDirection axis,
       Direction direction,


### PR DESCRIPTION
Summary:
The last of the row-reverse issues hurray!

The position insets were broken with row-reverse since we were using the main-start/main-end edges to inset from and NOT the inline-start/inline-end edges as we should. This made it so that inset in left and right were swapped and same with top and bottom (with column-reverse). The solution here is the same as the previous ones were we are migrating to using inline-start/end as the leading/trailing edge now.

Differential Revision: D50390543

