### PR TITLE
Build with MSVC /W4

### DIFF
--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -17,7 +17,7 @@ add_compile_options(
     # "Standard C++ exception handling" (C++ stack unwinding including extern c)
     /EHsc
     # Enable warnings and warnings as errors
-    /W3
+    /W4
     /WX
     # Disable RTTI
     $<$<COMPILE_LANGUAGE:CXX>:/GR->

--- a/yoga/bits/NumericBitfield.h
+++ b/yoga/bits/NumericBitfield.h
@@ -34,7 +34,7 @@ template <
     typename Enum,
     std::enable_if_t<(ordinalCount<Enum>() > 0), bool> = true>
 constexpr uint8_t minimumBitCount() {
-  return details::log2ceilFn(ordinalCount<Enum>() - 1);
+  return details::log2ceilFn(static_cast<uint8_t>(ordinalCount<Enum>() - 1));
 }
 
 template <typename Enum>


### PR DESCRIPTION
The reference Clang/GCC build has a pretty strict set of warnings enabled. The reference MSVC build has less strict warnings, which can be a problem for MSVC users building at higher warning levels (e.g. React Native for Windows in OSS uses `/W4` as its baseline warning level).

This bumps up the MSVC warning level to `/W4`, since we are nearly clean already.

There are some limitations. E.g. we don't test binary with MSVC (some issues I didn't work out), and only test building statically linked. But but we do have a minimal C benchmark we compile with MSVC.