### PR TITLE
Simplify getting padding + border for cross axis in algorithm

### DIFF
--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -1612,12 +1612,10 @@ static void calculateLayoutImpl(
 
   const float paddingAndBorderAxisMain =
       paddingAndBorderForAxis(node, mainAxis, ownerWidth);
+  const float paddingAndBorderAxisCross =
+      paddingAndBorderForAxis(node, crossAxis, ownerWidth);
   const float leadingPaddingAndBorderCross =
       node->getInlineStartPaddingAndBorder(crossAxis, direction, ownerWidth);
-  const float trailingPaddingAndBorderCross =
-      node->getInlineEndPaddingAndBorder(crossAxis, direction, ownerWidth);
-  const float paddingAndBorderAxisCross =
-      leadingPaddingAndBorderCross + trailingPaddingAndBorderCross;
 
   MeasureMode measureModeMainDim =
       isMainAxisRow ? widthMeasureMode : heightMeasureMode;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/react-native/pull/41208

Reading through the sizing logic and this seemed a bit redundant/confusing. Lets use the same function we just used for the main axis for the cross axis as well so people do not think its special. Also we will need one less variable. The reason this was done it seems is because we need the leading padding + border elsewhere so this is technically a few less steps but this is cleaner

Differential Revision: D50704177

