### PR TITLE
Use libc++ in Ubuntu Clang Build

### DIFF
--- a/.github/actions/setup-cpp/action.yml
+++ b/.github/actions/setup-cpp/action.yml
@@ -18,6 +18,8 @@ runs:
       run: |
         echo "CC=/usr/bin/clang" >> $GITHUB_ENV
         echo "CXX=/usr/bin/clang++" >> $GITHUB_ENV
+        echo "CXXFLAGS=-stdlib=libc++" >> $GITHUB_ENV
+        echo "LDFLAGS=-stdlib=libc++" >> $GITHUB_ENV
 
     - name: Set GCC as compiler
       if: ${{ inputs.toolchain == 'GCC' }}

--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -42,7 +42,7 @@ add_compile_options(
     $<$<CONFIG:RELEASE>:-O2>
     # Enable separate sections per function/data item
     $<$<CONFIG:RELEASE>:-ffunction-sections>
-    $<$<CONFIG:RELEASE>:-fdata-sections>>
+    $<$<CONFIG:RELEASE>:-fdata-sections>
     # Use libc++ when building with Clang on Linux
     $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>)
 

--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -42,7 +42,9 @@ add_compile_options(
     $<$<CONFIG:RELEASE>:-O2>
     # Enable separate sections per function/data item
     $<$<CONFIG:RELEASE>:-ffunction-sections>
-    $<$<CONFIG:RELEASE>:-fdata-sections>)
+    $<$<CONFIG:RELEASE>:-fdata-sections>
+    # Use libc++ when building with Clang on Linux
+    $<$<CXX_COMPILER_ID:Clang,GNU>:-stdlib=libc++>)
 
 add_link_options(
     # Discard unused sections

--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -42,7 +42,9 @@ add_compile_options(
     $<$<CONFIG:RELEASE>:-O2>
     # Enable separate sections per function/data item
     $<$<CONFIG:RELEASE>:-ffunction-sections>
-    $<$<CONFIG:RELEASE>:-fdata-sections>)
+    $<$<CONFIG:RELEASE>:-fdata-sections>>
+    # Use libc++ when building with Clang on Linux
+    $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>)
 
 add_link_options(
     # Discard unused sections

--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -44,7 +44,7 @@ add_compile_options(
     $<$<CONFIG:RELEASE>:-ffunction-sections>
     $<$<CONFIG:RELEASE>:-fdata-sections>
     # Use libc++ when building with Clang on Linux
-    $<$<CXX_COMPILER_ID:Clang,GNU>:-stdlib=libc++>)
+    $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>)
 
 add_link_options(
     # Discard unused sections

--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -51,6 +51,6 @@ add_link_options(
     $<$<CONFIG:RELEASE>:$<$<CXX_COMPILER_ID:Clang,GNU>:-Wl,--gc-sections>>
     $<$<CONFIG:RELEASE>:$<$<CXX_COMPILER_ID:AppleClang>:-Wl,-dead_strip>>
     # Use libc++ when building with Clang on Linux
-    $<$<COMPILE_LANGUAGE:CXX>$<$<CXX_COMPILER_ID:Clang>>:-stdlib=libc++>)
+    $<$<COMPILE_LANGUAGE:CXX>:$<$<CXX_COMPILER_ID:Clang>>:-stdlib=libc++>>)
 
 endif()

--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -42,13 +42,13 @@ add_compile_options(
     $<$<CONFIG:RELEASE>:-O2>
     # Enable separate sections per function/data item
     $<$<CONFIG:RELEASE>:-ffunction-sections>
-    $<$<CONFIG:RELEASE>:-fdata-sections>
-    # Use libc++ when building with Clang on Linux
-    $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>)
+    $<$<CONFIG:RELEASE>:-fdata-sections>)
 
 add_link_options(
     # Discard unused sections
     $<$<CONFIG:RELEASE>:$<$<CXX_COMPILER_ID:Clang,GNU>:-Wl,--gc-sections>>
-    $<$<CONFIG:RELEASE>:$<$<CXX_COMPILER_ID:AppleClang>:-Wl,-dead_strip>>)
+    $<$<CONFIG:RELEASE>:$<$<CXX_COMPILER_ID:AppleClang>:-Wl,-dead_strip>>
+    # Use libc++ when building with Clang on Linux
+    $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>)
 
 endif()

--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -42,15 +42,11 @@ add_compile_options(
     $<$<CONFIG:RELEASE>:-O2>
     # Enable separate sections per function/data item
     $<$<CONFIG:RELEASE>:-ffunction-sections>
-    $<$<CONFIG:RELEASE>:-fdata-sections>
-    # Use libc++ when building with Clang on Linux
-    $<$<COMPILE_LANGUAGE:CXX>:$<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>>)
+    $<$<CONFIG:RELEASE>:-fdata-sections>)
 
 add_link_options(
     # Discard unused sections
     $<$<CONFIG:RELEASE>:$<$<CXX_COMPILER_ID:Clang,GNU>:-Wl,--gc-sections>>
-    $<$<CONFIG:RELEASE>:$<$<CXX_COMPILER_ID:AppleClang>:-Wl,-dead_strip>>
-    # Use libc++ when building with Clang on Linux
-    $<$<COMPILE_LANGUAGE:CXX>:$<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>>)
+    $<$<CONFIG:RELEASE>:$<$<CXX_COMPILER_ID:AppleClang>:-Wl,-dead_strip>>)
 
 endif()

--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -51,6 +51,6 @@ add_link_options(
     $<$<CONFIG:RELEASE>:$<$<CXX_COMPILER_ID:Clang,GNU>:-Wl,--gc-sections>>
     $<$<CONFIG:RELEASE>:$<$<CXX_COMPILER_ID:AppleClang>:-Wl,-dead_strip>>
     # Use libc++ when building with Clang on Linux
-    $<$<COMPILE_LANGUAGE:CXX>:$<$<CXX_COMPILER_ID:Clang>>:-stdlib=libc++>>)
+    $<$<COMPILE_LANGUAGE:CXX>:$<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>>)
 
 endif()

--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -44,13 +44,13 @@ add_compile_options(
     $<$<CONFIG:RELEASE>:-ffunction-sections>
     $<$<CONFIG:RELEASE>:-fdata-sections>
     # Use libc++ when building with Clang on Linux
-    $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>)
+    $<$<COMPILE_LANGUAGE:CXX>:$<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>>)
 
 add_link_options(
     # Discard unused sections
     $<$<CONFIG:RELEASE>:$<$<CXX_COMPILER_ID:Clang,GNU>:-Wl,--gc-sections>>
     $<$<CONFIG:RELEASE>:$<$<CXX_COMPILER_ID:AppleClang>:-Wl,-dead_strip>>
     # Use libc++ when building with Clang on Linux
-    $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>)
+    $<$<COMPILE_LANGUAGE:CXX>$<$<CXX_COMPILER_ID:Clang>>:-stdlib=libc++>)
 
 endif()


### PR DESCRIPTION
An ubuntu-latest image update caused build failures, where GTest importing chrono headers caused an error inside of stdlib++ when being compiled by Clang. 

This switches to explicitly asking for libc++ (LLVM stdlib) in the reference Ubuntu Clang build instead of stdlibc++ (GCC stdlib).

We don’t force this in CMake logic, to not force a specific stdlib for users compiling Yoga alongside other libraries. E.g. https://github.com/facebookexperimental/libunifex/issues/86