### PR TITLE
Fix issue where absolute children of row-reverse containers would inset on the wrong side

### DIFF
--- a/gentest/fixtures/YGFlexDirectionTest.html
+++ b/gentest/fixtures/YGFlexDirectionTest.html
@@ -208,3 +208,195 @@
     <div style="width: 10px;"></div>
   </div>
 </div>
+
+<div id="flex_direction_row_reverse_inner_pos_left" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; left: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_pos_right" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; right: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_col_reverse_inner_pos_top" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: column-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; top: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_col_reverse_inner_pos_bottom" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: column-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; bottom: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_pos_start" data-disabled="true" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; start: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_pos_end" data-disabled="true" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; end: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_margin_left" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; margin-left: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_margin_right" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; margin-right: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_col_reverse_inner_margin_top" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: column-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; margin-top: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_col_reverse_inner_margin_bottom" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: column-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; margin-bottom: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_marign_start" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; margin-start: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_margin_end" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; margin-end: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_border_left" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; border-left: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_border_right" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; border-right: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_col_reverse_inner_border_top" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: column-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; border-top: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_col_reverse_inner_border_bottom" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: column-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; border-bottom: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_border_start" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; border-start: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_border_end" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; border-end: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_padding_left" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; padding-left: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_padding_right" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; padding-right: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_col_reverse_inner_padding_top" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: column-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; padding-top: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_col_reverse_inner_padding_bottom" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: column-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; padding-bottom: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_padding_start" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; padding-start: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>
+
+<div id="flex_direction_row_reverse_inner_padding_end" style="height: 100px; width: 100px;">
+  <div style="height: 100px; width: 100px; flex-direction: row-reverse; ">
+    <div style="width: 10px; height: 10px; position: absolute; padding-end: 10px"></div>
+    <div style="width: 10px;"></div>
+    <div style="width: 10px;"></div>
+  </div>
+</div>

--- a/java/tests/com/facebook/yoga/YGFlexDirectionTest.java
+++ b/java/tests/com/facebook/yoga/YGFlexDirectionTest.java
@@ -2301,6 +2301,2168 @@ public class YGFlexDirectionTest {
     assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
   }
 
+  @Test
+  public void test_flex_direction_row_reverse_inner_pos_left() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setPosition(YogaEdge.LEFT, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_row_reverse_inner_pos_right() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setPosition(YogaEdge.RIGHT, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_col_reverse_inner_pos_top() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setPosition(YogaEdge.TOP, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_col_reverse_inner_pos_bottom() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setPosition(YogaEdge.BOTTOM, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(80f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(80f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  @Ignore
+  public void test_flex_direction_row_reverse_inner_pos_start() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setPosition(YogaEdge.START, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  @Ignore
+  public void test_flex_direction_row_reverse_inner_pos_end() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setPosition(YogaEdge.END, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_row_reverse_inner_margin_left() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setMargin(YogaEdge.LEFT, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_row_reverse_inner_margin_right() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setMargin(YogaEdge.RIGHT, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_col_reverse_inner_margin_top() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setMargin(YogaEdge.TOP, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_col_reverse_inner_margin_bottom() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setMargin(YogaEdge.BOTTOM, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(80f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(80f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_row_reverse_inner_marign_start() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setMargin(YogaEdge.START, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_row_reverse_inner_margin_end() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setMargin(YogaEdge.END, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_row_reverse_inner_border_left() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setBorder(YogaEdge.LEFT, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_row_reverse_inner_border_right() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setBorder(YogaEdge.RIGHT, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_col_reverse_inner_border_top() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setBorder(YogaEdge.TOP, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_col_reverse_inner_border_bottom() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setBorder(YogaEdge.BOTTOM, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_row_reverse_inner_border_start() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setBorder(YogaEdge.LEFT, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_row_reverse_inner_border_end() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setBorder(YogaEdge.RIGHT, 10f);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_row_reverse_inner_padding_left() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setPadding(YogaEdge.LEFT, 10);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_row_reverse_inner_padding_right() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setPadding(YogaEdge.RIGHT, 10);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_col_reverse_inner_padding_top() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setPadding(YogaEdge.TOP, 10);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_col_reverse_inner_padding_bottom() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setPadding(YogaEdge.BOTTOM, 10);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(90f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_row_reverse_inner_padding_start() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setPadding(YogaEdge.START, 10);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_flex_direction_row_reverse_inner_padding_end() {
+    YogaConfig config = YogaConfigFactory.create();
+    config.setExperimentalFeatureEnabled(YogaExperimentalFeature.ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE, true);
+
+    final YogaNode root = createNode(config);
+    root.setPositionType(YogaPositionType.ABSOLUTE);
+    root.setWidth(100f);
+    root.setHeight(100f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
+    root_child0.setPositionType(YogaPositionType.RELATIVE);
+    root_child0.setWidth(100f);
+    root_child0.setHeight(100f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.ABSOLUTE);
+    root_child0_child0.setPadding(YogaEdge.END, 10);
+    root_child0_child0.setWidth(10f);
+    root_child0_child0.setHeight(10f);
+    root_child0.addChildAt(root_child0_child0, 0);
+
+    final YogaNode root_child0_child1 = createNode(config);
+    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child1.setWidth(10f);
+    root_child0.addChildAt(root_child0_child1, 1);
+
+    final YogaNode root_child0_child2 = createNode(config);
+    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
+    root_child0_child2.setWidth(10f);
+    root_child0.addChildAt(root_child0_child2, 2);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(90f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child0.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutWidth(), 0.0f);
+    assertEquals(10f, root_child0_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child1.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child1.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(10f, root_child0_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0_child2.getLayoutY(), 0.0f);
+    assertEquals(10f, root_child0_child2.getLayoutWidth(), 0.0f);
+    assertEquals(100f, root_child0_child2.getLayoutHeight(), 0.0f);
+  }
+
   private YogaNode createNode(YogaConfig config) {
     return mNodeFactory.create(config);
   }

--- a/javascript/tests/generated/YGFlexDirectionTest.test.ts
+++ b/javascript/tests/generated/YGFlexDirectionTest.test.ts
@@ -2481,3 +2481,2307 @@ test('flex_direction_column_reverse_pos_bottom', () => {
     config.free();
   }
 });
+test('flex_direction_row_reverse_inner_pos_left', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setPosition(Edge.Left, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(10);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(10);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_row_reverse_inner_pos_right', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setPosition(Edge.Right, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(80);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(80);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_col_reverse_inner_pos_top', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.ColumnReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setPosition(Edge.Top, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(10);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(0);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(10);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(90);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_col_reverse_inner_pos_bottom', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.ColumnReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setPosition(Edge.Bottom, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(80);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(0);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(80);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(90);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test.skip('flex_direction_row_reverse_inner_pos_start', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setPosition(Edge.Start, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(10);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(80);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test.skip('flex_direction_row_reverse_inner_pos_end', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setPosition(Edge.End, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(80);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(10);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_row_reverse_inner_margin_left', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setMargin(Edge.Left, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(10);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_row_reverse_inner_margin_right', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setMargin(Edge.Right, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(80);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_col_reverse_inner_margin_top', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.ColumnReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setMargin(Edge.Top, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(90);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(0);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(90);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(90);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_col_reverse_inner_margin_bottom', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.ColumnReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setMargin(Edge.Bottom, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(80);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(0);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(80);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(90);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_row_reverse_inner_marign_start', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setMargin(Edge.Start, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_row_reverse_inner_margin_end', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setMargin(Edge.End, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(80);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(10);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_row_reverse_inner_border_left', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setBorder(Edge.Left, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_row_reverse_inner_border_right', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setBorder(Edge.Right, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_col_reverse_inner_border_top', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.ColumnReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setBorder(Edge.Top, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(90);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(0);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(90);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(90);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_col_reverse_inner_border_bottom', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.ColumnReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setBorder(Edge.Bottom, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(90);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(0);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(90);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(90);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_row_reverse_inner_border_start', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setBorder(Edge.Left, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_row_reverse_inner_border_end', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setBorder(Edge.Right, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_row_reverse_inner_padding_left', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setPadding(Edge.Left, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_row_reverse_inner_padding_right', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setPadding(Edge.Right, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_col_reverse_inner_padding_top', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.ColumnReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setPadding(Edge.Top, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(90);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(0);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(90);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(90);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_col_reverse_inner_padding_bottom', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.ColumnReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setPadding(Edge.Bottom, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(90);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(0);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(90);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(100);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(0);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(90);
+    expect(root_child0_child2.getComputedTop()).toBe(100);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(0);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_row_reverse_inner_padding_start', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setPadding(Edge.Start, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+test('flex_direction_row_reverse_inner_padding_end', () => {
+  const config = Yoga.Config.create();
+  let root;
+
+  config.setExperimentalFeatureEnabled(ExperimentalFeature.AbsolutePercentageAgainstPaddingEdge, true);
+
+  try {
+    root = Yoga.Node.create(config);
+    root.setPositionType(PositionType.Absolute);
+    root.setWidth(100);
+    root.setHeight(100);
+
+    const root_child0 = Yoga.Node.create(config);
+    root_child0.setFlexDirection(FlexDirection.RowReverse);
+    root_child0.setPositionType(PositionType.Relative);
+    root_child0.setWidth(100);
+    root_child0.setHeight(100);
+    root.insertChild(root_child0, 0);
+
+    const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Absolute);
+    root_child0_child0.setPadding(Edge.End, 10);
+    root_child0_child0.setWidth(10);
+    root_child0_child0.setHeight(10);
+    root_child0.insertChild(root_child0_child0, 0);
+
+    const root_child0_child1 = Yoga.Node.create(config);
+    root_child0_child1.setPositionType(PositionType.Relative);
+    root_child0_child1.setWidth(10);
+    root_child0.insertChild(root_child0_child1, 1);
+
+    const root_child0_child2 = Yoga.Node.create(config);
+    root_child0_child2.setPositionType(PositionType.Relative);
+    root_child0_child2.setWidth(10);
+    root_child0.insertChild(root_child0_child2, 2);
+    root.calculateLayout(undefined, undefined, Direction.LTR);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(90);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(90);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(80);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+
+    root.calculateLayout(undefined, undefined, Direction.RTL);
+
+    expect(root.getComputedLeft()).toBe(0);
+    expect(root.getComputedTop()).toBe(0);
+    expect(root.getComputedWidth()).toBe(100);
+    expect(root.getComputedHeight()).toBe(100);
+
+    expect(root_child0.getComputedLeft()).toBe(0);
+    expect(root_child0.getComputedTop()).toBe(0);
+    expect(root_child0.getComputedWidth()).toBe(100);
+    expect(root_child0.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child0.getComputedLeft()).toBe(0);
+    expect(root_child0_child0.getComputedTop()).toBe(0);
+    expect(root_child0_child0.getComputedWidth()).toBe(10);
+    expect(root_child0_child0.getComputedHeight()).toBe(10);
+
+    expect(root_child0_child1.getComputedLeft()).toBe(0);
+    expect(root_child0_child1.getComputedTop()).toBe(0);
+    expect(root_child0_child1.getComputedWidth()).toBe(10);
+    expect(root_child0_child1.getComputedHeight()).toBe(100);
+
+    expect(root_child0_child2.getComputedLeft()).toBe(10);
+    expect(root_child0_child2.getComputedTop()).toBe(0);
+    expect(root_child0_child2.getComputedWidth()).toBe(10);
+    expect(root_child0_child2.getComputedHeight()).toBe(100);
+  } finally {
+    if (typeof root !== 'undefined') {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});

--- a/tests/generated/YGFlexDirectionTest.cpp
+++ b/tests/generated/YGFlexDirectionTest.cpp
@@ -2316,3 +2316,2191 @@ TEST(YogaTest, flex_direction_column_reverse_pos_bottom) {
 
   YGConfigFree(config);
 }
+
+TEST(YogaTest, flex_direction_row_reverse_inner_pos_left) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child0_child0, YGEdgeLeft, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_pos_right) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child0_child0, YGEdgeRight, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_col_reverse_inner_pos_top) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child0_child0, YGEdgeTop, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_col_reverse_inner_pos_bottom) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child0_child0, YGEdgeBottom, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_pos_start) {
+  GTEST_SKIP();
+
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child0_child0, YGEdgeStart, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_pos_end) {
+  GTEST_SKIP();
+
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPosition(root_child0_child0, YGEdgeEnd, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_margin_left) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetMargin(root_child0_child0, YGEdgeLeft, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_margin_right) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetMargin(root_child0_child0, YGEdgeRight, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_col_reverse_inner_margin_top) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetMargin(root_child0_child0, YGEdgeTop, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_col_reverse_inner_margin_bottom) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetMargin(root_child0_child0, YGEdgeBottom, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_marign_start) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetMargin(root_child0_child0, YGEdgeStart, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_margin_end) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetMargin(root_child0_child0, YGEdgeEnd, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_border_left) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetBorder(root_child0_child0, YGEdgeLeft, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_border_right) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetBorder(root_child0_child0, YGEdgeRight, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_col_reverse_inner_border_top) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetBorder(root_child0_child0, YGEdgeTop, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_col_reverse_inner_border_bottom) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetBorder(root_child0_child0, YGEdgeBottom, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_border_start) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetBorder(root_child0_child0, YGEdgeLeft, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_border_end) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetBorder(root_child0_child0, YGEdgeRight, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_padding_left) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPadding(root_child0_child0, YGEdgeLeft, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_padding_right) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPadding(root_child0_child0, YGEdgeRight, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_col_reverse_inner_padding_top) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPadding(root_child0_child0, YGEdgeTop, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_col_reverse_inner_padding_bottom) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPadding(root_child0_child0, YGEdgeBottom, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_padding_start) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPadding(root_child0_child0, YGEdgeStart, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, flex_direction_row_reverse_inner_padding_end) {
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetExperimentalFeatureEnabled(config, YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge, true);
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0, 100);
+  YGNodeStyleSetHeight(root_child0, 100);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeAbsolute);
+  YGNodeStyleSetPadding(root_child0_child0, YGEdgeEnd, 10);
+  YGNodeStyleSetWidth(root_child0_child0, 10);
+  YGNodeStyleSetHeight(root_child0_child0, 10);
+  YGNodeInsertChild(root_child0, root_child0_child0, 0);
+
+  const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child1, 10);
+  YGNodeInsertChild(root_child0, root_child0_child1, 1);
+
+  const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
+  YGNodeStyleSetWidth(root_child0_child2, 10);
+  YGNodeInsertChild(root_child0, root_child0_child2, 2);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child0));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetHeight(root_child0_child0));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child1));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child1));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child1));
+
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetLeft(root_child0_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0_child2));
+  ASSERT_FLOAT_EQ(10, YGNodeLayoutGetWidth(root_child0_child2));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetHeight(root_child0_child2));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -61,16 +61,16 @@ static inline bool styleDefinesDimension(
     const yoga::Node* const node,
     const FlexDirection axis,
     const float ownerSize) {
-  bool isUndefined =
-      yoga::isUndefined(node->getResolvedDimension(dimension(axis)).value);
+  bool isDefined =
+      yoga::isDefined(node->getResolvedDimension(dimension(axis)).value);
 
   auto resolvedDimension = node->getResolvedDimension(dimension(axis));
   return !(
       resolvedDimension.unit == YGUnitAuto ||
       resolvedDimension.unit == YGUnitUndefined ||
-      (resolvedDimension.unit == YGUnitPoint && !isUndefined &&
+      (resolvedDimension.unit == YGUnitPoint && isDefined &&
        resolvedDimension.value < 0.0f) ||
-      (resolvedDimension.unit == YGUnitPercent && !isUndefined &&
+      (resolvedDimension.unit == YGUnitPercent && isDefined &&
        (resolvedDimension.value < 0.0f || yoga::isUndefined(ownerSize))));
 }
 
@@ -78,7 +78,7 @@ static inline bool isLayoutDimensionDefined(
     const yoga::Node* const node,
     const FlexDirection axis) {
   const float value = node->getLayout().measuredDimension(dimension(axis));
-  return !yoga::isUndefined(value) && value >= 0.0f;
+  return yoga::isDefined(value) && value >= 0.0f;
 }
 
 static void setChildTrailingPosition(
@@ -111,7 +111,7 @@ static void constrainMaxSizeForMode(
           : maxSize.unwrap();
       break;
     case MeasureMode::Undefined:
-      if (!maxSize.isUndefined()) {
+      if (maxSize.isDefined()) {
         *mode = MeasureMode::AtMost;
         *size = maxSize.unwrap();
       }
@@ -150,7 +150,7 @@ static void computeFlexBasisForChild(
   const bool isColumnStyleDimDefined =
       styleDefinesDimension(child, FlexDirection::Column, ownerHeight);
 
-  if (!resolvedFlexBasis.isUndefined() && !yoga::isUndefined(mainAxisSize)) {
+  if (resolvedFlexBasis.isDefined() && yoga::isDefined(mainAxisSize)) {
     if (child->getLayout().computedFlexBasis.isUndefined() ||
         (child->getConfig()->isExperimentalFeatureEnabled(
              ExperimentalFeature::WebFlexBasis) &&
@@ -210,7 +210,7 @@ static void computeFlexBasisForChild(
     // major browsers appear to implement the following logic.
     if ((!isMainAxisRow && node->getStyle().overflow() == Overflow::Scroll) ||
         node->getStyle().overflow() != Overflow::Scroll) {
-      if (yoga::isUndefined(childWidth) && !yoga::isUndefined(width)) {
+      if (yoga::isUndefined(childWidth) && yoga::isDefined(width)) {
         childWidth = width;
         childWidthMeasureMode = MeasureMode::AtMost;
       }
@@ -218,14 +218,14 @@ static void computeFlexBasisForChild(
 
     if ((isMainAxisRow && node->getStyle().overflow() == Overflow::Scroll) ||
         node->getStyle().overflow() != Overflow::Scroll) {
-      if (yoga::isUndefined(childHeight) && !yoga::isUndefined(height)) {
+      if (yoga::isUndefined(childHeight) && yoga::isDefined(height)) {
         childHeight = height;
         childHeightMeasureMode = MeasureMode::AtMost;
       }
     }
 
     const auto& childStyle = child->getStyle();
-    if (!childStyle.aspectRatio().isUndefined()) {
+    if (childStyle.aspectRatio().isDefined()) {
       if (!isMainAxisRow && childWidthMeasureMode == MeasureMode::Exactly) {
         childHeight = marginColumn +
             (childWidth - marginRow) / childStyle.aspectRatio().unwrap();
@@ -242,7 +242,7 @@ static void computeFlexBasisForChild(
     // the cross axis to be measured exactly with the available inner width
 
     const bool hasExactWidth =
-        !yoga::isUndefined(width) && widthMode == MeasureMode::Exactly;
+        yoga::isDefined(width) && widthMode == MeasureMode::Exactly;
     const bool childWidthStretch =
         resolveChildAlignment(node, child) == Align::Stretch &&
         childWidthMeasureMode != MeasureMode::Exactly;
@@ -250,7 +250,7 @@ static void computeFlexBasisForChild(
         childWidthStretch) {
       childWidth = width;
       childWidthMeasureMode = MeasureMode::Exactly;
-      if (!childStyle.aspectRatio().isUndefined()) {
+      if (childStyle.aspectRatio().isDefined()) {
         childHeight =
             (childWidth - marginRow) / childStyle.aspectRatio().unwrap();
         childHeightMeasureMode = MeasureMode::Exactly;
@@ -258,7 +258,7 @@ static void computeFlexBasisForChild(
     }
 
     const bool hasExactHeight =
-        !yoga::isUndefined(height) && heightMode == MeasureMode::Exactly;
+        yoga::isDefined(height) && heightMode == MeasureMode::Exactly;
     const bool childHeightStretch =
         resolveChildAlignment(node, child) == Align::Stretch &&
         childHeightMeasureMode != MeasureMode::Exactly;
@@ -267,7 +267,7 @@ static void computeFlexBasisForChild(
       childHeight = height;
       childHeightMeasureMode = MeasureMode::Exactly;
 
-      if (!childStyle.aspectRatio().isUndefined()) {
+      if (childStyle.aspectRatio().isDefined()) {
         childWidth =
             (childHeight - marginColumn) * childStyle.aspectRatio().unwrap();
         childWidthMeasureMode = MeasureMode::Exactly;
@@ -382,7 +382,7 @@ static void layoutAbsoluteChild(
   // flexible.
   const auto& childStyle = child->getStyle();
   if (yoga::isUndefined(childWidth) ^ yoga::isUndefined(childHeight)) {
-    if (!childStyle.aspectRatio().isUndefined()) {
+    if (childStyle.aspectRatio().isDefined()) {
       if (yoga::isUndefined(childWidth)) {
         childWidth = marginRow +
             (childHeight - marginColumn) * childStyle.aspectRatio().unwrap();
@@ -407,7 +407,7 @@ static void layoutAbsoluteChild(
     // wrap to the size of its owner. This is the same behavior as many browsers
     // implement.
     if (!isMainAxisRow && yoga::isUndefined(childWidth) &&
-        widthMode != MeasureMode::Undefined && !yoga::isUndefined(width) &&
+        widthMode != MeasureMode::Undefined && yoga::isDefined(width) &&
         width > 0) {
       childWidth = width;
       childWidthMeasureMode = MeasureMode::AtMost;
@@ -678,9 +678,9 @@ static bool measureNodeWithFixedSize(
     const MeasureMode heightMeasureMode,
     const float ownerWidth,
     const float ownerHeight) {
-  if ((!yoga::isUndefined(availableWidth) &&
+  if ((yoga::isDefined(availableWidth) &&
        widthMeasureMode == MeasureMode::AtMost && availableWidth <= 0.0f) ||
-      (!yoga::isUndefined(availableHeight) &&
+      (yoga::isDefined(availableHeight) &&
        heightMeasureMode == MeasureMode::AtMost && availableHeight <= 0.0f) ||
       (widthMeasureMode == MeasureMode::Exactly &&
        heightMeasureMode == MeasureMode::Exactly)) {
@@ -736,7 +736,7 @@ static float calculateAvailableInnerDimension(
   float availableInnerDim = availableDim - paddingAndBorder;
   // Max dimension overrides predefined dimension value; Min dimension in turn
   // overrides both of the above
-  if (!yoga::isUndefined(availableInnerDim)) {
+  if (yoga::isDefined(availableInnerDim)) {
     // We want to make sure our available height does not violate min and max
     // constraints
     const FloatOptional minDimensionOptional =
@@ -880,7 +880,7 @@ static float distributeFreeSpaceSecondPass(
                          .unwrap();
     float updatedMainSize = childFlexBasis;
 
-    if (!yoga::isUndefined(flexLine.layout.remainingFreeSpace) &&
+    if (yoga::isDefined(flexLine.layout.remainingFreeSpace) &&
         flexLine.layout.remainingFreeSpace < 0) {
       flexShrinkScaledFactor =
           -currentLineChild->resolveFlexShrink() * childFlexBasis;
@@ -888,7 +888,7 @@ static float distributeFreeSpaceSecondPass(
       if (flexShrinkScaledFactor != 0) {
         float childSize;
 
-        if (!yoga::isUndefined(flexLine.layout.totalFlexShrinkScaledFactors) &&
+        if (yoga::isDefined(flexLine.layout.totalFlexShrinkScaledFactors) &&
             flexLine.layout.totalFlexShrinkScaledFactors == 0) {
           childSize = childFlexBasis + flexShrinkScaledFactor;
         } else {
@@ -906,7 +906,7 @@ static float distributeFreeSpaceSecondPass(
             availableInnerWidth);
       }
     } else if (
-        !yoga::isUndefined(flexLine.layout.remainingFreeSpace) &&
+        yoga::isDefined(flexLine.layout.remainingFreeSpace) &&
         flexLine.layout.remainingFreeSpace > 0) {
       flexGrowFactor = currentLineChild->resolveFlexGrow();
 
@@ -936,7 +936,7 @@ static float distributeFreeSpaceSecondPass(
     MeasureMode childMainMeasureMode = MeasureMode::Exactly;
 
     const auto& childStyle = currentLineChild->getStyle();
-    if (!childStyle.aspectRatio().isUndefined()) {
+    if (childStyle.aspectRatio().isDefined()) {
       childCrossSize = isMainAxisRow
           ? (childMainSize - marginMain) / childStyle.aspectRatio().unwrap()
           : (childMainSize - marginMain) * childStyle.aspectRatio().unwrap();
@@ -1062,7 +1062,7 @@ static void distributeFreeSpaceFirstPass(
           -currentLineChild->resolveFlexShrink() * childFlexBasis;
 
       // Is this child able to shrink?
-      if (!yoga::isUndefined(flexShrinkScaledFactor) &&
+      if (yoga::isDefined(flexShrinkScaledFactor) &&
           flexShrinkScaledFactor != 0) {
         baseMainSize = childFlexBasis +
             flexLine.layout.remainingFreeSpace /
@@ -1074,8 +1074,7 @@ static void distributeFreeSpaceFirstPass(
             baseMainSize,
             availableInnerMainDim,
             availableInnerWidth);
-        if (!yoga::isUndefined(baseMainSize) &&
-            !yoga::isUndefined(boundMainSize) &&
+        if (yoga::isDefined(baseMainSize) && yoga::isDefined(boundMainSize) &&
             baseMainSize != boundMainSize) {
           // By excluding this item's size and flex factor from remaining, this
           // item's min/max constraints should also trigger in the second pass
@@ -1088,12 +1087,12 @@ static void distributeFreeSpaceFirstPass(
         }
       }
     } else if (
-        !yoga::isUndefined(flexLine.layout.remainingFreeSpace) &&
+        yoga::isDefined(flexLine.layout.remainingFreeSpace) &&
         flexLine.layout.remainingFreeSpace > 0) {
       flexGrowFactor = currentLineChild->resolveFlexGrow();
 
       // Is this child able to grow?
-      if (!yoga::isUndefined(flexGrowFactor) && flexGrowFactor != 0) {
+      if (yoga::isDefined(flexGrowFactor) && flexGrowFactor != 0) {
         baseMainSize = childFlexBasis +
             flexLine.layout.remainingFreeSpace /
                 flexLine.layout.totalFlexGrowFactors * flexGrowFactor;
@@ -1104,8 +1103,7 @@ static void distributeFreeSpaceFirstPass(
             availableInnerMainDim,
             availableInnerWidth);
 
-        if (!yoga::isUndefined(baseMainSize) &&
-            !yoga::isUndefined(boundMainSize) &&
+        if (yoga::isDefined(baseMainSize) && yoga::isDefined(boundMainSize) &&
             baseMainSize != boundMainSize) {
           // By excluding this item's size and flex factor from remaining, this
           // item's min/max constraints should also trigger in the second pass
@@ -1219,10 +1217,10 @@ static void justifyMainAxis(
   // remainingFreeSpace is 0 when min main dimension is not given
   if (measureModeMainDim == MeasureMode::AtMost &&
       flexLine.layout.remainingFreeSpace > 0) {
-    if (!style.minDimension(dimension(mainAxis)).isUndefined() &&
-        !yoga::resolveValue(
-             style.minDimension(dimension(mainAxis)), mainAxisownerSize)
-             .isUndefined()) {
+    if (style.minDimension(dimension(mainAxis)).isDefined() &&
+        yoga::resolveValue(
+            style.minDimension(dimension(mainAxis)), mainAxisownerSize)
+            .isDefined()) {
       // This condition makes sure that if the size of main dimension(after
       // considering child nodes main dim, leading and trailing padding etc)
       // falls below min dimension, then the remainingFreeSpace is reassigned
@@ -1743,11 +1741,11 @@ static void calculateLayoutImpl(
       const float maxInnerMainDim =
           isMainAxisRow ? maxInnerWidth : maxInnerHeight;
 
-      if (!yoga::isUndefined(minInnerMainDim) &&
+      if (yoga::isDefined(minInnerMainDim) &&
           flexLine.sizeConsumed < minInnerMainDim) {
         availableInnerMainDim = minInnerMainDim;
       } else if (
-          !yoga::isUndefined(maxInnerMainDim) &&
+          yoga::isDefined(maxInnerMainDim) &&
           flexLine.sizeConsumed > maxInnerMainDim) {
         availableInnerMainDim = maxInnerMainDim;
       } else {
@@ -1755,9 +1753,9 @@ static void calculateLayoutImpl(
             node->hasErrata(Errata::StretchFlexBasis);
 
         if (!useLegacyStretchBehaviour &&
-            ((!yoga::isUndefined(flexLine.layout.totalFlexGrowFactors) &&
+            ((yoga::isDefined(flexLine.layout.totalFlexGrowFactors) &&
               flexLine.layout.totalFlexGrowFactors == 0) ||
-             (!yoga::isUndefined(node->resolveFlexGrow()) &&
+             (yoga::isDefined(node->resolveFlexGrow()) &&
               node->resolveFlexGrow() == 0))) {
           // If we don't have any children to flex or we can't flex the node
           // itself, space we've used is all space we need. Root node also
@@ -1769,7 +1767,7 @@ static void calculateLayoutImpl(
       }
     }
 
-    if (!sizeBasedOnContent && !yoga::isUndefined(availableInnerMainDim)) {
+    if (!sizeBasedOnContent && yoga::isDefined(availableInnerMainDim)) {
       flexLine.layout.remainingFreeSpace =
           availableInnerMainDim - flexLine.sizeConsumed;
     } else if (flexLine.sizeConsumed < 0) {
@@ -1910,7 +1908,7 @@ static void calculateLayoutImpl(
               float childMainSize =
                   child->getLayout().measuredDimension(dimension(mainAxis));
               const auto& childStyle = child->getStyle();
-              float childCrossSize = !childStyle.aspectRatio().isUndefined()
+              float childCrossSize = childStyle.aspectRatio().isDefined()
                   ? child->getMarginForAxis(crossAxis, availableInnerWidth) +
                       (isMainAxisRow
                            ? childMainSize / childStyle.aspectRatio().unwrap()
@@ -2013,7 +2011,7 @@ static void calculateLayoutImpl(
   if (performLayout && (isNodeFlexWrap || isBaselineLayout(node))) {
     float crossDimLead = 0;
     float currentLead = leadingPaddingAndBorderCross;
-    if (!yoga::isUndefined(availableInnerCrossDim)) {
+    if (yoga::isDefined(availableInnerCrossDim)) {
       const float remainingAlignContentDim =
           availableInnerCrossDim - totalLineCrossDim;
       switch (node->getStyle().alignContent()) {
@@ -2691,9 +2689,9 @@ void calculateLayout(
              .unwrap() +
          node->getMarginForAxis(FlexDirection::Row, ownerWidth));
     widthMeasureMode = MeasureMode::Exactly;
-  } else if (!yoga::resolveValue(
-                  style.maxDimension(Dimension::Width), ownerWidth)
-                  .isUndefined()) {
+  } else if (yoga::resolveValue(
+                 style.maxDimension(Dimension::Width), ownerWidth)
+                 .isDefined()) {
     width = yoga::resolveValue(style.maxDimension(Dimension::Width), ownerWidth)
                 .unwrap();
     widthMeasureMode = MeasureMode::AtMost;
@@ -2713,9 +2711,9 @@ void calculateLayout(
              .unwrap() +
          node->getMarginForAxis(FlexDirection::Column, ownerWidth));
     heightMeasureMode = MeasureMode::Exactly;
-  } else if (!yoga::resolveValue(
-                  style.maxDimension(Dimension::Height), ownerHeight)
-                  .isUndefined()) {
+  } else if (yoga::resolveValue(
+                 style.maxDimension(Dimension::Height), ownerHeight)
+                 .isDefined()) {
     height =
         yoga::resolveValue(style.maxDimension(Dimension::Height), ownerHeight)
             .unwrap();

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -448,19 +448,17 @@ static void layoutAbsoluteChild(
       depth,
       generationCount);
 
-  if (child->isInlineEndPositionDefined(mainAxis, direction) &&
-      !child->isInlineStartPositionDefined(mainAxis, direction)) {
+  if (child->isFlexEndPositionDefined(mainAxis) &&
+      !child->isFlexStartPositionDefined(mainAxis)) {
     child->setLayoutPosition(
         node->getLayout().measuredDimension(dimension(mainAxis)) -
             child->getLayout().measuredDimension(dimension(mainAxis)) -
-            node->getInlineEndBorder(mainAxis, direction) -
-            child->getInlineEndMargin(
-                mainAxis, direction, isMainAxisRow ? width : height) -
-            child->getInlineEndPosition(
-                mainAxis, direction, isMainAxisRow ? width : height),
+            node->getFlexEndBorder(mainAxis, direction) -
+            child->getFlexEndMargin(mainAxis, isMainAxisRow ? width : height) -
+            child->getFlexEndPosition(mainAxis, isMainAxisRow ? width : height),
         flexStartEdge(mainAxis));
   } else if (
-      !child->isInlineStartPositionDefined(mainAxis, direction) &&
+      !child->isFlexStartPositionDefined(mainAxis) &&
       node->getStyle().justifyContent() == Justify::Center) {
     child->setLayoutPosition(
         (node->getLayout().measuredDimension(dimension(mainAxis)) -
@@ -468,7 +466,7 @@ static void layoutAbsoluteChild(
             2.0f,
         flexStartEdge(mainAxis));
   } else if (
-      !child->isInlineStartPositionDefined(mainAxis, direction) &&
+      !child->isFlexStartPositionDefined(mainAxis) &&
       node->getStyle().justifyContent() == Justify::FlexEnd) {
     child->setLayoutPosition(
         (node->getLayout().measuredDimension(dimension(mainAxis)) -
@@ -477,34 +475,31 @@ static void layoutAbsoluteChild(
   } else if (
       node->getConfig()->isExperimentalFeatureEnabled(
           ExperimentalFeature::AbsolutePercentageAgainstPaddingEdge) &&
-      child->isInlineStartPositionDefined(mainAxis, direction)) {
+      child->isFlexStartPositionDefined(mainAxis)) {
     child->setLayoutPosition(
-        child->getInlineStartPosition(
+        child->getFlexStartPosition(
             mainAxis,
-            direction,
             node->getLayout().measuredDimension(dimension(mainAxis))) +
-            node->getInlineStartBorder(mainAxis, direction) +
-            child->getInlineStartMargin(
+            node->getFlexStartBorder(mainAxis, direction) +
+            child->getFlexStartMargin(
                 mainAxis,
-                direction,
                 node->getLayout().measuredDimension(dimension(mainAxis))),
         flexStartEdge(mainAxis));
   }
 
-  if (child->isInlineEndPositionDefined(crossAxis, direction) &&
-      !child->isInlineStartPositionDefined(crossAxis, direction)) {
+  if (child->isFlexEndPositionDefined(crossAxis) &&
+      !child->isFlexStartPositionDefined(crossAxis)) {
     child->setLayoutPosition(
         node->getLayout().measuredDimension(dimension(crossAxis)) -
             child->getLayout().measuredDimension(dimension(crossAxis)) -
-            node->getInlineEndBorder(crossAxis, direction) -
-            child->getInlineEndMargin(
-                crossAxis, direction, isMainAxisRow ? height : width) -
-            child->getInlineEndPosition(
-                crossAxis, direction, isMainAxisRow ? height : width),
+            node->getFlexEndBorder(crossAxis, direction) -
+            child->getFlexEndMargin(crossAxis, isMainAxisRow ? height : width) -
+            child->getFlexEndPosition(
+                crossAxis, isMainAxisRow ? height : width),
         flexStartEdge(crossAxis));
 
   } else if (
-      !child->isInlineStartPositionDefined(crossAxis, direction) &&
+      !child->isFlexStartPositionDefined(crossAxis) &&
       resolveChildAlignment(node, child) == Align::Center) {
     child->setLayoutPosition(
         (node->getLayout().measuredDimension(dimension(crossAxis)) -
@@ -512,7 +507,7 @@ static void layoutAbsoluteChild(
             2.0f,
         flexStartEdge(crossAxis));
   } else if (
-      !child->isInlineStartPositionDefined(crossAxis, direction) &&
+      !child->isFlexStartPositionDefined(crossAxis) &&
       ((resolveChildAlignment(node, child) == Align::FlexEnd) ^
        (node->getStyle().flexWrap() == Wrap::WrapReverse))) {
     child->setLayoutPosition(
@@ -522,16 +517,14 @@ static void layoutAbsoluteChild(
   } else if (
       node->getConfig()->isExperimentalFeatureEnabled(
           ExperimentalFeature::AbsolutePercentageAgainstPaddingEdge) &&
-      child->isInlineStartPositionDefined(crossAxis, direction)) {
+      child->isFlexStartPositionDefined(crossAxis)) {
     child->setLayoutPosition(
-        child->getInlineStartPosition(
+        child->getFlexStartPosition(
             crossAxis,
-            direction,
             node->getLayout().measuredDimension(dimension(crossAxis))) +
-            node->getInlineStartBorder(crossAxis, direction) +
-            child->getInlineStartMargin(
+            node->getFlexStartBorder(crossAxis, direction) +
+            child->getFlexStartMargin(
                 crossAxis,
-                direction,
                 node->getLayout().measuredDimension(dimension(crossAxis))),
         flexStartEdge(crossAxis));
   }

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -1612,12 +1612,10 @@ static void calculateLayoutImpl(
 
   const float paddingAndBorderAxisMain =
       paddingAndBorderForAxis(node, mainAxis, ownerWidth);
+  const float paddingAndBorderAxisCross =
+      paddingAndBorderForAxis(node, crossAxis, ownerWidth);
   const float leadingPaddingAndBorderCross =
       node->getInlineStartPaddingAndBorder(crossAxis, direction, ownerWidth);
-  const float trailingPaddingAndBorderCross =
-      node->getInlineEndPaddingAndBorder(crossAxis, direction, ownerWidth);
-  const float paddingAndBorderAxisCross =
-      leadingPaddingAndBorderCross + trailingPaddingAndBorderCross;
 
   MeasureMode measureModeMainDim =
       isMainAxisRow ? widthMeasureMode : heightMeasureMode;

--- a/yoga/debug/NodeToString.cpp
+++ b/yoga/debug/NodeToString.cpp
@@ -46,7 +46,7 @@ static void appendFloatOptionalIfDefined(
     std::string& base,
     const std::string key,
     const FloatOptional num) {
-  if (!num.isUndefined()) {
+  if (num.isDefined()) {
     appendFormattedString(base, "%s: %g; ", key.c_str(), num.unwrap());
   }
 }
@@ -177,7 +177,7 @@ void nodeToString(
     appendEdges(str, "padding", style.padding());
     appendEdges(str, "border", style.border());
 
-    if (!style.gap(Gutter::All).isUndefined()) {
+    if (style.gap(Gutter::All).isDefined()) {
       appendNumberIfNotUndefined(str, "gap", style.gap(Gutter::All));
     } else {
       appendNumberIfNotUndefined(str, "column-gap", style.gap(Gutter::Column));

--- a/yoga/node/Node.cpp
+++ b/yoga/node/Node.cpp
@@ -99,6 +99,15 @@ YGEdge Node::getInlineEndEdgeUsingErrata(
       : inlineEndEdge(flexDirection, direction);
 }
 
+bool Node::isFlexStartPositionDefined(FlexDirection axis) const {
+  const YGEdge startEdge = flexStartEdge(axis);
+  auto leadingPosition = isRow(axis)
+      ? computeEdgeValueForRow(style_.position(), YGEdgeStart, startEdge)
+      : computeEdgeValueForColumn(style_.position(), startEdge);
+
+  return leadingPosition.isDefined();
+}
+
 bool Node::isInlineStartPositionDefined(FlexDirection axis, Direction direction)
     const {
   const YGEdge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
@@ -109,6 +118,15 @@ bool Node::isInlineStartPositionDefined(FlexDirection axis, Direction direction)
   return leadingPosition.isDefined();
 }
 
+bool Node::isFlexEndPositionDefined(FlexDirection axis) const {
+  const YGEdge endEdge = flexEndEdge(axis);
+  auto trailingPosition = isRow(axis)
+      ? computeEdgeValueForRow(style_.position(), YGEdgeEnd, endEdge)
+      : computeEdgeValueForColumn(style_.position(), endEdge);
+
+  return !trailingPosition.isUndefined();
+}
+
 bool Node::isInlineEndPositionDefined(FlexDirection axis, Direction direction)
     const {
   const YGEdge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
@@ -117,6 +135,15 @@ bool Node::isInlineEndPositionDefined(FlexDirection axis, Direction direction)
       : computeEdgeValueForColumn(style_.position(), endEdge);
 
   return trailingPosition.isDefined();
+}
+
+float Node::getFlexStartPosition(FlexDirection axis, float axisSize) const {
+  const YGEdge startEdge = flexStartEdge(axis);
+  auto leadingPosition = isRow(axis)
+      ? computeEdgeValueForRow(style_.position(), YGEdgeStart, startEdge)
+      : computeEdgeValueForColumn(style_.position(), startEdge);
+
+  return resolveValue(leadingPosition, axisSize).unwrapOrDefault(0.0f);
 }
 
 float Node::getInlineStartPosition(
@@ -131,6 +158,15 @@ float Node::getInlineStartPosition(
   return resolveValue(leadingPosition, axisSize).unwrapOrDefault(0.0f);
 }
 
+float Node::getFlexEndPosition(FlexDirection axis, float axisSize) const {
+  const YGEdge endEdge = flexEndEdge(axis);
+  auto trailingPosition = isRow(axis)
+      ? computeEdgeValueForRow(style_.position(), YGEdgeEnd, endEdge)
+      : computeEdgeValueForColumn(style_.position(), endEdge);
+
+  return resolveValue(trailingPosition, axisSize).unwrapOrDefault(0.0f);
+}
+
 float Node::getInlineEndPosition(
     FlexDirection axis,
     Direction direction,
@@ -143,6 +179,15 @@ float Node::getInlineEndPosition(
   return resolveValue(trailingPosition, axisSize).unwrapOrDefault(0.0f);
 }
 
+float Node::getFlexStartMargin(FlexDirection axis, float widthSize) const {
+  const YGEdge startEdge = flexStartEdge(axis);
+  auto leadingMargin = isRow(axis)
+      ? computeEdgeValueForRow(style_.margin(), YGEdgeStart, startEdge)
+      : computeEdgeValueForColumn(style_.margin(), startEdge);
+
+  return resolveValue(leadingMargin, widthSize).unwrapOrDefault(0.0f);
+}
+
 float Node::getInlineStartMargin(
     FlexDirection axis,
     Direction direction,
@@ -153,6 +198,15 @@ float Node::getInlineStartMargin(
       : computeEdgeValueForColumn(style_.margin(), startEdge);
 
   return resolveValue(leadingMargin, widthSize).unwrapOrDefault(0.0f);
+}
+
+float Node::getFlexEndMargin(FlexDirection axis, float widthSize) const {
+  const YGEdge endEdge = flexEndEdge(axis);
+  auto trailingMargin = isRow(axis)
+      ? computeEdgeValueForRow(style_.margin(), YGEdgeEnd, endEdge)
+      : computeEdgeValueForColumn(style_.margin(), endEdge);
+
+  return resolveValue(trailingMargin, widthSize).unwrapOrDefault(0.0f);
 }
 
 float Node::getInlineEndMargin(

--- a/yoga/node/Node.cpp
+++ b/yoga/node/Node.cpp
@@ -60,11 +60,11 @@ CompactValue Node::computeEdgeValueForRow(
     const Style::Edges& edges,
     YGEdge rowEdge,
     YGEdge edge) {
-  if (!edges[rowEdge].isUndefined()) {
+  if (edges[rowEdge].isDefined()) {
     return edges[rowEdge];
-  } else if (!edges[edge].isUndefined()) {
+  } else if (edges[edge].isDefined()) {
     return edges[edge];
-  } else if (!edges[YGEdgeHorizontal].isUndefined()) {
+  } else if (edges[YGEdgeHorizontal].isDefined()) {
     return edges[YGEdgeHorizontal];
   } else {
     return edges[YGEdgeAll];
@@ -74,9 +74,9 @@ CompactValue Node::computeEdgeValueForRow(
 CompactValue Node::computeEdgeValueForColumn(
     const Style::Edges& edges,
     YGEdge edge) {
-  if (!edges[edge].isUndefined()) {
+  if (edges[edge].isDefined()) {
     return edges[edge];
-  } else if (!edges[YGEdgeVertical].isUndefined()) {
+  } else if (edges[YGEdgeVertical].isDefined()) {
     return edges[YGEdgeVertical];
   } else {
     return edges[YGEdgeAll];
@@ -106,7 +106,7 @@ bool Node::isInlineStartPositionDefined(FlexDirection axis, Direction direction)
       ? computeEdgeValueForRow(style_.position(), YGEdgeStart, startEdge)
       : computeEdgeValueForColumn(style_.position(), startEdge);
 
-  return !leadingPosition.isUndefined();
+  return leadingPosition.isDefined();
 }
 
 bool Node::isInlineEndPositionDefined(FlexDirection axis, Direction direction)
@@ -116,7 +116,7 @@ bool Node::isInlineEndPositionDefined(FlexDirection axis, Direction direction)
       ? computeEdgeValueForRow(style_.position(), YGEdgeEnd, endEdge)
       : computeEdgeValueForColumn(style_.position(), endEdge);
 
-  return !trailingPosition.isUndefined();
+  return trailingPosition.isDefined();
 }
 
 float Node::getInlineStartPosition(
@@ -511,7 +511,7 @@ void Node::setPosition(
 }
 
 YGValue Node::getFlexStartMarginValue(FlexDirection axis) const {
-  if (isRow(axis) && !style_.margin()[YGEdgeStart].isUndefined()) {
+  if (isRow(axis) && style_.margin()[YGEdgeStart].isDefined()) {
     return style_.margin()[YGEdgeStart];
   } else {
     return style_.margin()[flexStartEdge(axis)];
@@ -519,7 +519,7 @@ YGValue Node::getFlexStartMarginValue(FlexDirection axis) const {
 }
 
 YGValue Node::marginTrailingValue(FlexDirection axis) const {
-  if (isRow(axis) && !style_.margin()[YGEdgeEnd].isUndefined()) {
+  if (isRow(axis) && style_.margin()[YGEdgeEnd].isDefined()) {
     return style_.margin()[YGEdgeEnd];
   } else {
     return style_.margin()[flexEndEdge(axis)];
@@ -531,7 +531,7 @@ YGValue Node::resolveFlexBasisPtr() const {
   if (flexBasis.unit != YGUnitAuto && flexBasis.unit != YGUnitUndefined) {
     return flexBasis;
   }
-  if (!style_.flex().isUndefined() && style_.flex().unwrap() > 0.0f) {
+  if (style_.flex().isDefined() && style_.flex().unwrap() > 0.0f) {
     return config_->useWebDefaults() ? YGValueAuto : YGValueZero;
   }
   return YGValueAuto;
@@ -540,7 +540,7 @@ YGValue Node::resolveFlexBasisPtr() const {
 void Node::resolveDimension() {
   const Style& style = getStyle();
   for (auto dim : {Dimension::Width, Dimension::Height}) {
-    if (!style.maxDimension(dim).isUndefined() &&
+    if (style.maxDimension(dim).isDefined() &&
         yoga::inexactEquals(style.maxDimension(dim), style.minDimension(dim))) {
       resolvedDimensions_[yoga::to_underlying(dim)] = style.maxDimension(dim);
     } else {
@@ -598,10 +598,10 @@ float Node::resolveFlexGrow() const {
   if (owner_ == nullptr) {
     return 0.0;
   }
-  if (!style_.flexGrow().isUndefined()) {
+  if (style_.flexGrow().isDefined()) {
     return style_.flexGrow().unwrap();
   }
-  if (!style_.flex().isUndefined() && style_.flex().unwrap() > 0.0f) {
+  if (style_.flex().isDefined() && style_.flex().unwrap() > 0.0f) {
     return style_.flex().unwrap();
   }
   return Style::DefaultFlexGrow;
@@ -611,10 +611,10 @@ float Node::resolveFlexShrink() const {
   if (owner_ == nullptr) {
     return 0.0;
   }
-  if (!style_.flexShrink().isUndefined()) {
+  if (style_.flexShrink().isDefined()) {
     return style_.flexShrink().unwrap();
   }
-  if (!config_->useWebDefaults() && !style_.flex().isUndefined() &&
+  if (!config_->useWebDefaults() && style_.flex().isDefined() &&
       style_.flex().unwrap() < 0.0f) {
     return -style_.flex().unwrap();
   }

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -199,22 +199,28 @@ class YG_EXPORT Node : public ::YGNode {
       YGEdge edge);
 
   // Methods related to positions, margin, padding and border
+  bool isFlexStartPositionDefined(FlexDirection axis) const;
   bool isInlineStartPositionDefined(FlexDirection axis, Direction direction)
       const;
+  bool isFlexEndPositionDefined(FlexDirection axis) const;
   bool isInlineEndPositionDefined(FlexDirection axis, Direction direction)
       const;
+  float getFlexStartPosition(FlexDirection axis, float axisSize) const;
   float getInlineStartPosition(
       FlexDirection axis,
       Direction direction,
       float axisSize) const;
+  float getFlexEndPosition(FlexDirection axis, float axisSize) const;
   float getInlineEndPosition(
       FlexDirection axis,
       Direction direction,
       float axisSize) const;
+  float getFlexStartMargin(FlexDirection axis, float widthSize) const;
   float getInlineStartMargin(
       FlexDirection axis,
       Direction direction,
       float widthSize) const;
+  float getFlexEndMargin(FlexDirection axis, float widthSize) const;
   float getInlineEndMargin(
       FlexDirection axis,
       Direction direction,

--- a/yoga/numeric/Comparison.h
+++ b/yoga/numeric/Comparison.h
@@ -19,15 +19,19 @@ constexpr bool isUndefined(auto value) {
   return value != value;
 }
 
+constexpr bool isDefined(auto value) {
+  return !isUndefined(value);
+}
+
 constexpr auto maxOrDefined(auto a, auto b) {
-  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
+  if (yoga::isDefined(a) && yoga::isDefined(b)) {
     return std::max(a, b);
   }
   return yoga::isUndefined(a) ? b : a;
 }
 
 constexpr auto minOrDefined(auto a, auto b) {
-  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
+  if (yoga::isDefined(a) && yoga::isDefined(b)) {
     return std::min(a, b);
   }
 
@@ -37,14 +41,14 @@ constexpr auto minOrDefined(auto a, auto b) {
 // Custom equality functions using a hardcoded epsilon of 0.0001f, or returning
 // true if both floats are NaN.
 inline bool inexactEquals(float a, float b) {
-  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
+  if (yoga::isDefined(a) && yoga::isDefined(b)) {
     return std::abs(a - b) < 0.0001f;
   }
   return yoga::isUndefined(a) && yoga::isUndefined(b);
 }
 
 inline bool inexactEquals(double a, double b) {
-  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
+  if (yoga::isDefined(a) && yoga::isDefined(b)) {
     return std::abs(a - b) < 0.0001;
   }
   return yoga::isUndefined(a) && yoga::isUndefined(b);

--- a/yoga/numeric/FloatOptional.h
+++ b/yoga/numeric/FloatOptional.h
@@ -32,6 +32,10 @@ struct FloatOptional {
   constexpr bool isUndefined() const {
     return yoga::isUndefined(value_);
   }
+
+  constexpr bool isDefined() const {
+    return yoga::isDefined(value_);
+  }
 };
 
 // operators take FloatOptional by value, as it is a 32bit value

--- a/yoga/style/CompactValue.h
+++ b/yoga/style/CompactValue.h
@@ -137,6 +137,10 @@ class YG_EXPORT CompactValue {
         repr_ != ZERO_BITS_PERCENT && std::isnan(yoga::bit_cast<float>(repr_)));
   }
 
+  bool isDefined() const noexcept {
+    return !isUndefined();
+  }
+
   bool isAuto() const noexcept {
     return repr_ == AUTO_BITS;
   }

--- a/yoga/style/Style.h
+++ b/yoga/style/Style.h
@@ -312,7 +312,7 @@ class YG_EXPORT Style {
   }
 
   CompactValue resolveColumnGap() const {
-    if (!gap_[yoga::to_underlying(Gutter::Column)].isUndefined()) {
+    if (gap_[yoga::to_underlying(Gutter::Column)].isDefined()) {
       return gap_[yoga::to_underlying(Gutter::Column)];
     } else {
       return gap_[yoga::to_underlying(Gutter::All)];
@@ -320,7 +320,7 @@ class YG_EXPORT Style {
   }
 
   CompactValue resolveRowGap() const {
-    if (!gap_[yoga::to_underlying(Gutter::Row)].isUndefined()) {
+    if (gap_[yoga::to_underlying(Gutter::Row)].isDefined()) {
       return gap_[yoga::to_underlying(Gutter::Row)];
     } else {
       return gap_[yoga::to_underlying(Gutter::All)];


### PR DESCRIPTION
Summary:
NickGerleman pointed out that my recent changes to fix the slew of row-reverse problems in Yoga actually ended up regressing some parts. Specifically, absolute children of row-reverse containers would have their insets set to the wrong side. So if you set left: 10 it would apply it to the right.

Turns out, in `layoutAbsoluteChild` there were cases where we were applying inlineStart/End values to the flexStart/End edge, which can never be right. So I changed the values to also be flexStart/End as the fix here.

Differential Revision: D50945475


