### PR TITLE
YGEdge -> yoga::Edge

### DIFF
--- a/tests/CompactValueTest.cpp
+++ b/tests/CompactValueTest.cpp
@@ -304,20 +304,11 @@ TEST(YogaTest, dedicated_unit_factories) {
   ASSERT_EQ(
       CompactValue::of<YGUnitPercent>(123.456f),
       CompactValue(YGValue{123.456f, YGUnitPercent}));
-}
-
-TEST(YogaTest, dedicated_unit_maybe_factories) {
   ASSERT_EQ(
-      CompactValue::ofMaybe<YGUnitPoint>(-9876.5f),
-      CompactValue(YGValue{-9876.5f, YGUnitPoint}));
-  ASSERT_EQ(
-      CompactValue::ofMaybe<YGUnitPoint>(YGUndefined),
+      CompactValue::of<YGUnitPoint>(YGUndefined),
       CompactValue(YGValueUndefined));
   ASSERT_EQ(
-      CompactValue::ofMaybe<YGUnitPercent>(123.456f),
-      CompactValue(YGValue{123.456f, YGUnitPercent}));
-  ASSERT_EQ(
-      CompactValue::ofMaybe<YGUnitPercent>(YGUndefined),
+      CompactValue::of<YGUnitPercent>(YGUndefined),
       CompactValue(YGValueUndefined));
 }
 

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -351,13 +351,13 @@ bool YGNodeCanUseCachedMeasurement(
     float marginColumn,
     YGConfigRef config) {
   return yoga::canUseCachedMeasurement(
-      scopedEnum(widthMode),
+      sizingMode(scopedEnum(widthMode)),
       availableWidth,
-      scopedEnum(heightMode),
+      sizingMode(scopedEnum(heightMode)),
       availableHeight,
-      scopedEnum(lastWidthMode),
+      sizingMode(scopedEnum(lastWidthMode)),
       lastAvailableWidth,
-      scopedEnum(lastHeightMode),
+      sizingMode(scopedEnum(lastHeightMode)),
       lastAvailableHeight,
       lastComputedWidth,
       lastComputedHeight,

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -186,6 +186,19 @@ typedef struct YGSize {
 } YGSize;
 
 /**
+ * Returns the computed dimensions of the node, following the contraints of
+ * `widthMode` and `heightMode`:
+ *
+ * YGMeasureModeUndefined: The parent has not imposed any constraint on the
+ * child. It can be whatever size it wants.
+ *
+ * YGMeasureModeAtMost: The child can be as large as it wants up to the
+ * specified size.
+ *
+ * YGMeasureModeExactly: The parent has determined an exact size for the
+ * child. The child is going to be given those bounds regardless of how big it
+ * wants to be.
+ *
  * @returns the size of the leaf node, measured under the given contraints.
  */
 typedef YGSize (*YGMeasureFunc)(

--- a/yoga/YGNodeLayout.cpp
+++ b/yoga/YGNodeLayout.cpp
@@ -7,6 +7,7 @@
 
 #include <yoga/Yoga.h>
 #include <yoga/debug/AssertFatal.h>
+#include <yoga/enums/Edge.h>
 #include <yoga/node/Node.h>
 
 using namespace facebook;
@@ -15,50 +16,48 @@ using namespace facebook::yoga;
 namespace {
 
 template <auto LayoutMember>
-float getResolvedLayoutProperty(
-    const YGNodeConstRef nodeRef,
-    const YGEdge edge) {
+float getResolvedLayoutProperty(const YGNodeConstRef nodeRef, const Edge edge) {
   const auto node = resolveRef(nodeRef);
   yoga::assertFatalWithNode(
       node,
-      edge <= YGEdgeEnd,
+      edge <= Edge::End,
       "Cannot get layout properties of multi-edge shorthands");
 
-  if (edge == YGEdgeStart) {
+  if (edge == Edge::Start) {
     if (node->getLayout().direction() == Direction::RTL) {
-      return (node->getLayout().*LayoutMember)[YGEdgeRight];
+      return (node->getLayout().*LayoutMember)(Edge::Right);
     } else {
-      return (node->getLayout().*LayoutMember)[YGEdgeLeft];
+      return (node->getLayout().*LayoutMember)(Edge::Left);
     }
   }
 
-  if (edge == YGEdgeEnd) {
+  if (edge == Edge::End) {
     if (node->getLayout().direction() == Direction::RTL) {
-      return (node->getLayout().*LayoutMember)[YGEdgeLeft];
+      return (node->getLayout().*LayoutMember)(Edge::Left);
     } else {
-      return (node->getLayout().*LayoutMember)[YGEdgeRight];
+      return (node->getLayout().*LayoutMember)(Edge::Right);
     }
   }
 
-  return (node->getLayout().*LayoutMember)[edge];
+  return (node->getLayout().*LayoutMember)(edge);
 }
 
 } // namespace
 
 float YGNodeLayoutGetLeft(const YGNodeConstRef node) {
-  return resolveRef(node)->getLayout().position[YGEdgeLeft];
+  return resolveRef(node)->getLayout().position(Edge::Left);
 }
 
 float YGNodeLayoutGetTop(const YGNodeConstRef node) {
-  return resolveRef(node)->getLayout().position[YGEdgeTop];
+  return resolveRef(node)->getLayout().position(Edge::Top);
 }
 
 float YGNodeLayoutGetRight(const YGNodeConstRef node) {
-  return resolveRef(node)->getLayout().position[YGEdgeRight];
+  return resolveRef(node)->getLayout().position(Edge::Right);
 }
 
 float YGNodeLayoutGetBottom(const YGNodeConstRef node) {
-  return resolveRef(node)->getLayout().position[YGEdgeBottom];
+  return resolveRef(node)->getLayout().position(Edge::Bottom);
 }
 
 float YGNodeLayoutGetWidth(const YGNodeConstRef node) {
@@ -78,13 +77,16 @@ bool YGNodeLayoutGetHadOverflow(const YGNodeConstRef node) {
 }
 
 float YGNodeLayoutGetMargin(YGNodeConstRef node, YGEdge edge) {
-  return getResolvedLayoutProperty<&LayoutResults::margin>(node, edge);
+  return getResolvedLayoutProperty<&LayoutResults::margin>(
+      node, scopedEnum(edge));
 }
 
 float YGNodeLayoutGetBorder(YGNodeConstRef node, YGEdge edge) {
-  return getResolvedLayoutProperty<&LayoutResults::border>(node, edge);
+  return getResolvedLayoutProperty<&LayoutResults::border>(
+      node, scopedEnum(edge));
 }
 
 float YGNodeLayoutGetPadding(YGNodeConstRef node, YGEdge edge) {
-  return getResolvedLayoutProperty<&LayoutResults::padding>(node, edge);
+  return getResolvedLayoutProperty<&LayoutResults::padding>(
+      node, scopedEnum(edge));
 }

--- a/yoga/YGNodeStyle.cpp
+++ b/yoga/YGNodeStyle.cpp
@@ -26,22 +26,22 @@ void updateStyle(
   }
 }
 
-template <typename Ref, typename T>
-void updateStyle(YGNodeRef node, Ref (Style::*prop)(), T value) {
+template <typename Ref, typename ValueT>
+void updateStyle(YGNodeRef node, Ref (Style::*prop)(), ValueT value) {
   updateStyle(
       resolveRef(node),
       value,
-      [prop](Style& s, T x) { return (s.*prop)() != x; },
-      [prop](Style& s, T x) { (s.*prop)() = x; });
+      [prop](Style& s, ValueT x) { return (s.*prop)() != x; },
+      [prop](Style& s, ValueT x) { (s.*prop)() = x; });
 }
 
-template <auto GetterT, auto SetterT, typename IdxT>
-void updateIndexedStyleProp(YGNodeRef node, IdxT idx, CompactValue value) {
+template <auto GetterT, auto SetterT, typename IdxT, typename ValueT>
+void updateIndexedStyleProp(YGNodeRef node, IdxT idx, ValueT value) {
   updateStyle(
       resolveRef(node),
       value,
-      [idx](Style& s, CompactValue x) { return (s.*GetterT)(idx) != x; },
-      [idx](Style& s, CompactValue x) { (s.*SetterT)(idx, x); });
+      [idx](Style& s, ValueT x) { return (s.*GetterT)(idx) != x; },
+      [idx](Style& s, ValueT x) { (s.*SetterT)(idx, x); });
 }
 
 } // namespace
@@ -198,20 +198,19 @@ float YGNodeStyleGetFlexShrink(const YGNodeConstRef nodeRef) {
 }
 
 void YGNodeStyleSetFlexBasis(const YGNodeRef node, const float flexBasis) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(flexBasis);
-  updateStyle<MSVC_HINT(flexBasis)>(node, &Style::flexBasis, value);
+  updateStyle<MSVC_HINT(flexBasis)>(
+      node, &Style::flexBasis, value::points(flexBasis));
 }
 
 void YGNodeStyleSetFlexBasisPercent(
     const YGNodeRef node,
     const float flexBasisPercent) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(flexBasisPercent);
-  updateStyle<MSVC_HINT(flexBasis)>(node, &Style::flexBasis, value);
+  updateStyle<MSVC_HINT(flexBasis)>(
+      node, &Style::flexBasis, value::percent(flexBasisPercent));
 }
 
 void YGNodeStyleSetFlexBasisAuto(const YGNodeRef node) {
-  updateStyle<MSVC_HINT(flexBasis)>(
-      node, &Style::flexBasis, CompactValue::ofAuto());
+  updateStyle<MSVC_HINT(flexBasis)>(node, &Style::flexBasis, value::ofAuto());
 }
 
 YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
@@ -223,15 +222,13 @@ YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetPosition(YGNodeRef node, YGEdge edge, float points) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<&Style::position, &Style::setPosition>(
-      node, edge, value);
+      node, edge, value::points(points));
 }
 
 void YGNodeStyleSetPositionPercent(YGNodeRef node, YGEdge edge, float percent) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<&Style::position, &Style::setPosition>(
-      node, edge, value);
+      node, edge, value::percent(percent));
 }
 
 YGValue YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge) {
@@ -239,18 +236,18 @@ YGValue YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge) {
 }
 
 void YGNodeStyleSetMargin(YGNodeRef node, YGEdge edge, float points) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
-  updateIndexedStyleProp<&Style::margin, &Style::setMargin>(node, edge, value);
+  updateIndexedStyleProp<&Style::margin, &Style::setMargin>(
+      node, edge, value::points(points));
 }
 
 void YGNodeStyleSetMarginPercent(YGNodeRef node, YGEdge edge, float percent) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
-  updateIndexedStyleProp<&Style::margin, &Style::setMargin>(node, edge, value);
+  updateIndexedStyleProp<&Style::margin, &Style::setMargin>(
+      node, edge, value::percent(percent));
 }
 
 void YGNodeStyleSetMarginAuto(YGNodeRef node, YGEdge edge) {
   updateIndexedStyleProp<&Style::margin, &Style::setMargin>(
-      node, edge, CompactValue::ofAuto());
+      node, edge, value::ofAuto());
 }
 
 YGValue YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge) {
@@ -258,15 +255,13 @@ YGValue YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge) {
 }
 
 void YGNodeStyleSetPadding(YGNodeRef node, YGEdge edge, float points) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<&Style::padding, &Style::setPadding>(
-      node, edge, value);
+      node, edge, value::points(points));
 }
 
 void YGNodeStyleSetPaddingPercent(YGNodeRef node, YGEdge edge, float percent) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<&Style::padding, &Style::setPadding>(
-      node, edge, value);
+      node, edge, value::percent(percent));
 }
 
 YGValue YGNodeStyleGetPadding(YGNodeConstRef node, YGEdge edge) {
@@ -277,8 +272,8 @@ void YGNodeStyleSetBorder(
     const YGNodeRef node,
     const YGEdge edge,
     const float border) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(border);
-  updateIndexedStyleProp<&Style::border, &Style::setBorder>(node, edge, value);
+  updateIndexedStyleProp<&Style::border, &Style::setBorder>(
+      node, edge, value::points(border));
 }
 
 float YGNodeStyleGetBorder(const YGNodeConstRef node, const YGEdge edge) {
@@ -294,9 +289,8 @@ void YGNodeStyleSetGap(
     const YGNodeRef node,
     const YGGutter gutter,
     const float gapLength) {
-  auto length = CompactValue::ofMaybe<YGUnitPoint>(gapLength);
   updateIndexedStyleProp<&Style::gap, &Style::setGap>(
-      node, scopedEnum(gutter), length);
+      node, scopedEnum(gutter), value::points(gapLength));
 }
 
 float YGNodeStyleGetGap(const YGNodeConstRef node, const YGGutter gutter) {
@@ -319,20 +313,18 @@ float YGNodeStyleGetAspectRatio(const YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetWidth(YGNodeRef node, float points) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Width, value);
+      node, Dimension::Width, value::points(points));
 }
 
 void YGNodeStyleSetWidthPercent(YGNodeRef node, float percent) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Width, value);
+      node, Dimension::Width, value::percent(percent));
 }
 
 void YGNodeStyleSetWidthAuto(YGNodeRef node) {
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Width, CompactValue::ofAuto());
+      node, Dimension::Width, value::ofAuto());
 }
 
 YGValue YGNodeStyleGetWidth(YGNodeConstRef node) {
@@ -340,20 +332,18 @@ YGValue YGNodeStyleGetWidth(YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetHeight(YGNodeRef node, float points) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Height, value);
+      node, Dimension::Height, value::points(points));
 }
 
 void YGNodeStyleSetHeightPercent(YGNodeRef node, float percent) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Height, value);
+      node, Dimension::Height, value::percent(percent));
 }
 
 void YGNodeStyleSetHeightAuto(YGNodeRef node) {
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Height, CompactValue::ofAuto());
+      node, Dimension::Height, value::ofAuto());
 }
 
 YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
@@ -361,15 +351,13 @@ YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetMinWidth(const YGNodeRef node, const float minWidth) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(minWidth);
   updateIndexedStyleProp<&Style::minDimension, &Style::setMinDimension>(
-      node, Dimension::Width, value);
+      node, Dimension::Width, value::points(minWidth));
 }
 
 void YGNodeStyleSetMinWidthPercent(const YGNodeRef node, const float minWidth) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(minWidth);
   updateIndexedStyleProp<&Style::minDimension, &Style::setMinDimension>(
-      node, Dimension::Width, value);
+      node, Dimension::Width, value::percent(minWidth));
 }
 
 YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
@@ -377,17 +365,15 @@ YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetMinHeight(const YGNodeRef node, const float minHeight) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(minHeight);
   updateIndexedStyleProp<&Style::minDimension, &Style::setMinDimension>(
-      node, Dimension::Height, value);
+      node, Dimension::Height, value::points(minHeight));
 }
 
 void YGNodeStyleSetMinHeightPercent(
     const YGNodeRef node,
     const float minHeight) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(minHeight);
   updateIndexedStyleProp<&Style::minDimension, &Style::setMinDimension>(
-      node, Dimension::Height, value);
+      node, Dimension::Height, value::percent(minHeight));
 }
 
 YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
@@ -395,15 +381,13 @@ YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetMaxWidth(const YGNodeRef node, const float maxWidth) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(maxWidth);
   updateIndexedStyleProp<&Style::maxDimension, &Style::setMaxDimension>(
-      node, Dimension::Width, value);
+      node, Dimension::Width, value::points(maxWidth));
 }
 
 void YGNodeStyleSetMaxWidthPercent(const YGNodeRef node, const float maxWidth) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(maxWidth);
   updateIndexedStyleProp<&Style::maxDimension, &Style::setMaxDimension>(
-      node, Dimension::Width, value);
+      node, Dimension::Width, value::percent(maxWidth));
 }
 
 YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
@@ -411,17 +395,15 @@ YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetMaxHeight(const YGNodeRef node, const float maxHeight) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(maxHeight);
   updateIndexedStyleProp<&Style::maxDimension, &Style::setMaxDimension>(
-      node, Dimension::Height, value);
+      node, Dimension::Height, value::points(maxHeight));
 }
 
 void YGNodeStyleSetMaxHeightPercent(
     const YGNodeRef node,
     const float maxHeight) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(maxHeight);
   updateIndexedStyleProp<&Style::maxDimension, &Style::setMaxDimension>(
-      node, Dimension::Height, value);
+      node, Dimension::Height, value::percent(maxHeight));
 }
 
 YGValue YGNodeStyleGetMaxHeight(const YGNodeConstRef node) {

--- a/yoga/YGNodeStyle.cpp
+++ b/yoga/YGNodeStyle.cpp
@@ -223,49 +223,49 @@ YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
 
 void YGNodeStyleSetPosition(YGNodeRef node, YGEdge edge, float points) {
   updateIndexedStyleProp<&Style::position, &Style::setPosition>(
-      node, edge, value::points(points));
+      node, scopedEnum(edge), value::points(points));
 }
 
 void YGNodeStyleSetPositionPercent(YGNodeRef node, YGEdge edge, float percent) {
   updateIndexedStyleProp<&Style::position, &Style::setPosition>(
-      node, edge, value::percent(percent));
+      node, scopedEnum(edge), value::percent(percent));
 }
 
 YGValue YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge) {
-  return resolveRef(node)->getStyle().position(edge);
+  return resolveRef(node)->getStyle().position(scopedEnum(edge));
 }
 
 void YGNodeStyleSetMargin(YGNodeRef node, YGEdge edge, float points) {
   updateIndexedStyleProp<&Style::margin, &Style::setMargin>(
-      node, edge, value::points(points));
+      node, scopedEnum(edge), value::points(points));
 }
 
 void YGNodeStyleSetMarginPercent(YGNodeRef node, YGEdge edge, float percent) {
   updateIndexedStyleProp<&Style::margin, &Style::setMargin>(
-      node, edge, value::percent(percent));
+      node, scopedEnum(edge), value::percent(percent));
 }
 
 void YGNodeStyleSetMarginAuto(YGNodeRef node, YGEdge edge) {
   updateIndexedStyleProp<&Style::margin, &Style::setMargin>(
-      node, edge, value::ofAuto());
+      node, scopedEnum(edge), value::ofAuto());
 }
 
 YGValue YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge) {
-  return resolveRef(node)->getStyle().margin(edge);
+  return resolveRef(node)->getStyle().margin(scopedEnum(edge));
 }
 
 void YGNodeStyleSetPadding(YGNodeRef node, YGEdge edge, float points) {
   updateIndexedStyleProp<&Style::padding, &Style::setPadding>(
-      node, edge, value::points(points));
+      node, scopedEnum(edge), value::points(points));
 }
 
 void YGNodeStyleSetPaddingPercent(YGNodeRef node, YGEdge edge, float percent) {
   updateIndexedStyleProp<&Style::padding, &Style::setPadding>(
-      node, edge, value::percent(percent));
+      node, scopedEnum(edge), value::percent(percent));
 }
 
 YGValue YGNodeStyleGetPadding(YGNodeConstRef node, YGEdge edge) {
-  return resolveRef(node)->getStyle().padding(edge);
+  return resolveRef(node)->getStyle().padding(scopedEnum(edge));
 }
 
 void YGNodeStyleSetBorder(
@@ -273,11 +273,11 @@ void YGNodeStyleSetBorder(
     const YGEdge edge,
     const float border) {
   updateIndexedStyleProp<&Style::border, &Style::setBorder>(
-      node, edge, value::points(border));
+      node, scopedEnum(edge), value::points(border));
 }
 
 float YGNodeStyleGetBorder(const YGNodeConstRef node, const YGEdge edge) {
-  auto border = resolveRef(node)->getStyle().border(edge);
+  auto border = resolveRef(node)->getStyle().border(scopedEnum(edge));
   if (border.isUndefined() || border.isAuto()) {
     return YGUndefined;
   }

--- a/yoga/algorithm/Baseline.cpp
+++ b/yoga/algorithm/Baseline.cpp
@@ -57,7 +57,7 @@ float calculateBaseline(const yoga::Node* node) {
   }
 
   const float baseline = calculateBaseline(baselineChild);
-  return baseline + baselineChild->getLayout().position[YGEdgeTop];
+  return baseline + baselineChild->getLayout().position(Edge::Top);
 }
 
 bool isBaselineLayout(const yoga::Node* node) {

--- a/yoga/algorithm/Cache.h
+++ b/yoga/algorithm/Cache.h
@@ -7,19 +7,19 @@
 
 #pragma once
 
+#include <yoga/algorithm/SizingMode.h>
 #include <yoga/config/Config.h>
-#include <yoga/enums/MeasureMode.h>
 
 namespace facebook::yoga {
 
 bool canUseCachedMeasurement(
-    MeasureMode widthMode,
+    SizingMode widthMode,
     float availableWidth,
-    MeasureMode heightMode,
+    SizingMode heightMode,
     float availableHeight,
-    MeasureMode lastWidthMode,
+    SizingMode lastWidthMode,
     float lastAvailableWidth,
-    MeasureMode lastHeightMode,
+    SizingMode lastHeightMode,
     float lastAvailableHeight,
     float lastComputedWidth,
     float lastComputedHeight,

--- a/yoga/algorithm/FlexDirection.h
+++ b/yoga/algorithm/FlexDirection.h
@@ -12,6 +12,7 @@
 #include <yoga/debug/AssertFatal.h>
 #include <yoga/enums/Dimension.h>
 #include <yoga/enums/Direction.h>
+#include <yoga/enums/Edge.h>
 #include <yoga/enums/FlexDirection.h>
 
 namespace facebook::yoga {
@@ -48,80 +49,80 @@ inline FlexDirection resolveCrossDirection(
       : FlexDirection::Column;
 }
 
-inline YGEdge flexStartEdge(const FlexDirection flexDirection) {
+inline Edge flexStartEdge(const FlexDirection flexDirection) {
   switch (flexDirection) {
     case FlexDirection::Column:
-      return YGEdgeTop;
+      return Edge::Top;
     case FlexDirection::ColumnReverse:
-      return YGEdgeBottom;
+      return Edge::Bottom;
     case FlexDirection::Row:
-      return YGEdgeLeft;
+      return Edge::Left;
     case FlexDirection::RowReverse:
-      return YGEdgeRight;
+      return Edge::Right;
   }
 
   fatalWithMessage("Invalid FlexDirection");
 }
 
-inline YGEdge flexEndEdge(const FlexDirection flexDirection) {
+inline Edge flexEndEdge(const FlexDirection flexDirection) {
   switch (flexDirection) {
     case FlexDirection::Column:
-      return YGEdgeBottom;
+      return Edge::Bottom;
     case FlexDirection::ColumnReverse:
-      return YGEdgeTop;
+      return Edge::Top;
     case FlexDirection::Row:
-      return YGEdgeRight;
+      return Edge::Right;
     case FlexDirection::RowReverse:
-      return YGEdgeLeft;
+      return Edge::Left;
   }
 
   fatalWithMessage("Invalid FlexDirection");
 }
 
-inline YGEdge inlineStartEdge(
+inline Edge inlineStartEdge(
     const FlexDirection flexDirection,
     const Direction direction) {
   if (isRow(flexDirection)) {
-    return direction == Direction::RTL ? YGEdgeRight : YGEdgeLeft;
+    return direction == Direction::RTL ? Edge::Right : Edge::Left;
   }
 
-  return YGEdgeTop;
+  return Edge::Top;
 }
 
-inline YGEdge inlineEndEdge(
+inline Edge inlineEndEdge(
     const FlexDirection flexDirection,
     const Direction direction) {
   if (isRow(flexDirection)) {
-    return direction == Direction::RTL ? YGEdgeLeft : YGEdgeRight;
+    return direction == Direction::RTL ? Edge::Left : Edge::Right;
   }
 
-  return YGEdgeBottom;
+  return Edge::Bottom;
 }
 
 /**
- * The physical edges that YGEdgeStart and YGEdgeEnd correspond to (e.g.
+ * The physical edges that Edge::Start and Edge::End correspond to (e.g.
  * left/right) are soley dependent on the direction. However, there are cases
  * where we want the flex start/end edge (i.e. which edge is the start/end
  * for laying out flex items), which can be distinct from the corresponding
  * inline edge. In these cases we need to know which "relative edge"
- * (YGEdgeStart/YGEdgeEnd) corresponds to the said flex start/end edge as these
+ * (Edge::Start/Edge::End) corresponds to the said flex start/end edge as these
  * relative edges can be used instead of physical ones when defining certain
  * attributes like border or padding.
  */
-inline YGEdge flexStartRelativeEdge(
+inline Edge flexStartRelativeEdge(
     FlexDirection flexDirection,
     Direction direction) {
-  const YGEdge leadLayoutEdge = inlineStartEdge(flexDirection, direction);
-  const YGEdge leadFlexItemEdge = flexStartEdge(flexDirection);
-  return leadLayoutEdge == leadFlexItemEdge ? YGEdgeStart : YGEdgeEnd;
+  const Edge leadLayoutEdge = inlineStartEdge(flexDirection, direction);
+  const Edge leadFlexItemEdge = flexStartEdge(flexDirection);
+  return leadLayoutEdge == leadFlexItemEdge ? Edge::Start : Edge::End;
 }
 
-inline YGEdge flexEndRelativeEdge(
+inline Edge flexEndRelativeEdge(
     FlexDirection flexDirection,
     Direction direction) {
-  const YGEdge trailLayoutEdge = inlineEndEdge(flexDirection, direction);
-  const YGEdge trailFlexItemEdge = flexEndEdge(flexDirection);
-  return trailLayoutEdge == trailFlexItemEdge ? YGEdgeEnd : YGEdgeStart;
+  const Edge trailLayoutEdge = inlineEndEdge(flexDirection, direction);
+  const Edge trailFlexItemEdge = flexEndEdge(flexDirection);
+  return trailLayoutEdge == trailFlexItemEdge ? Edge::End : Edge::Start;
 }
 
 inline Dimension dimension(const FlexDirection flexDirection) {

--- a/yoga/algorithm/PixelGrid.cpp
+++ b/yoga/algorithm/PixelGrid.cpp
@@ -68,8 +68,8 @@ void roundLayoutResultsToPixelGrid(
     const double absoluteTop) {
   const auto pointScaleFactor = node->getConfig()->getPointScaleFactor();
 
-  const double nodeLeft = node->getLayout().position[YGEdgeLeft];
-  const double nodeTop = node->getLayout().position[YGEdgeTop];
+  const double nodeLeft = node->getLayout().position(Edge::Left);
+  const double nodeTop = node->getLayout().position(Edge::Top);
 
   const double nodeWidth = node->getLayout().dimension(Dimension::Width);
   const double nodeHeight = node->getLayout().dimension(Dimension::Height);
@@ -87,11 +87,11 @@ void roundLayoutResultsToPixelGrid(
 
     node->setLayoutPosition(
         roundValueToPixelGrid(nodeLeft, pointScaleFactor, false, textRounding),
-        YGEdgeLeft);
+        Edge::Left);
 
     node->setLayoutPosition(
         roundValueToPixelGrid(nodeTop, pointScaleFactor, false, textRounding),
-        YGEdgeTop);
+        Edge::Top);
 
     // We multiply dimension by scale factor and if the result is close to the
     // whole number, we don't have any fraction To verify if the result is close

--- a/yoga/algorithm/ResolveValue.h
+++ b/yoga/algorithm/ResolveValue.h
@@ -10,7 +10,7 @@
 #include <yoga/Yoga.h>
 
 #include <yoga/numeric/FloatOptional.h>
-#include <yoga/style/CompactValue.h>
+#include <yoga/style/Style.h>
 
 namespace facebook::yoga {
 
@@ -25,7 +25,7 @@ inline FloatOptional resolveValue(const YGValue value, const float ownerSize) {
   }
 }
 
-inline FloatOptional resolveValue(CompactValue value, float ownerSize) {
+inline FloatOptional resolveValue(Style::Length value, float ownerSize) {
   return resolveValue((YGValue)value, ownerSize);
 }
 

--- a/yoga/algorithm/SizingMode.h
+++ b/yoga/algorithm/SizingMode.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <yoga/debug/AssertFatal.h>
+#include <yoga/enums/MeasureMode.h>
+
+namespace facebook::yoga {
+
+/**
+ * Corresponds to a CSS auto box sizes. Missing "min-content", as Yoga does not
+ * current support automatic minimum sizes.
+ * https://www.w3.org/TR/css-sizing-3/#auto-box-sizes
+ * https://www.w3.org/TR/css-flexbox-1/#min-size-auto
+ */
+enum class SizingMode {
+  /**
+   * The size a box would take if its outer size filled the available space in
+   * the given axis; in other words, the stretch fit into the available space,
+   * if that is definite. Undefined if the available space is indefinite.
+   */
+  StretchFit,
+
+  /**
+   * A box’s “ideal” size in a given axis when given infinite available space.
+   * Usually this is the smallest size the box could take in that axis while
+   * still fitting around its contents, i.e. minimizing unfilled space while
+   * avoiding overflow.
+   */
+  MaxContent,
+
+  /**
+   * If the available space in a given axis is definite, equal to
+   * clamp(min-content size, stretch-fit size, max-content size) (i.e.
+   * max(min-content size, min(max-content size, stretch-fit size))). When
+   * sizing under a min-content constraint, equal to the min-content size.
+   * Otherwise, equal to the max-content size in that axis.
+   */
+  FitContent,
+};
+
+inline MeasureMode measureMode(SizingMode mode) {
+  switch (mode) {
+    case SizingMode::StretchFit:
+      return MeasureMode::Exactly;
+    case SizingMode::MaxContent:
+      return MeasureMode::Undefined;
+    case SizingMode::FitContent:
+      return MeasureMode::AtMost;
+  }
+
+  fatalWithMessage("Invalid SizingMode");
+}
+
+inline SizingMode sizingMode(MeasureMode mode) {
+  switch (mode) {
+    case MeasureMode::Exactly:
+      return SizingMode::StretchFit;
+    case MeasureMode::Undefined:
+      return SizingMode::MaxContent;
+    case MeasureMode::AtMost:
+      return SizingMode::FitContent;
+  }
+
+  fatalWithMessage("Invalid MeasureMode");
+}
+
+} // namespace facebook::yoga

--- a/yoga/debug/AssertFatal.cpp
+++ b/yoga/debug/AssertFatal.cpp
@@ -7,8 +7,10 @@
 
 #include <stdexcept>
 
+#include <yoga/config/Config.h>
 #include <yoga/debug/AssertFatal.h>
 #include <yoga/debug/Log.h>
+#include <yoga/node/Node.h>
 
 namespace facebook::yoga {
 

--- a/yoga/debug/AssertFatal.h
+++ b/yoga/debug/AssertFatal.h
@@ -8,10 +8,11 @@
 #pragma once
 
 #include <yoga/Yoga.h>
-#include <yoga/config/Config.h>
-#include <yoga/node/Node.h>
 
 namespace facebook::yoga {
+
+class Node;
+class Config;
 
 [[noreturn]] void fatalWithMessage(const char* message);
 

--- a/yoga/debug/NodeToString.cpp
+++ b/yoga/debug/NodeToString.cpp
@@ -9,8 +9,6 @@
 
 #include <stdarg.h>
 
-#include <yoga/YGEnums.h>
-
 #include <yoga/debug/Log.h>
 #include <yoga/debug/NodeToString.h>
 #include <yoga/numeric/Comparison.h>
@@ -85,7 +83,7 @@ static void
 appendEdges(std::string& base, const std::string& key, const Style& style) {
   for (auto edge : ordinals<Edge>()) {
     std::string str = key + "-" + toString(edge);
-    appendNumberIfNotZero(base, str, (style.*Field)(unscopedEnum(edge)));
+    appendNumberIfNotZero(base, str, (style.*Field)(edge));
   }
 }
 
@@ -104,9 +102,9 @@ void nodeToString(
     appendFormattedString(
         str, "height: %g; ", node->getLayout().dimension(Dimension::Height));
     appendFormattedString(
-        str, "top: %g; ", node->getLayout().position[YGEdgeTop]);
+        str, "top: %g; ", node->getLayout().position(Edge::Top));
     appendFormattedString(
-        str, "left: %g;", node->getLayout().position[YGEdgeLeft]);
+        str, "left: %g;", node->getLayout().position(Edge::Left));
     appendFormattedString(str, "\" ");
   }
 

--- a/yoga/node/CachedMeasurement.h
+++ b/yoga/node/CachedMeasurement.h
@@ -11,7 +11,7 @@
 
 #include <yoga/Yoga.h>
 
-#include <yoga/enums/MeasureMode.h>
+#include <yoga/algorithm/SizingMode.h>
 #include <yoga/numeric/Comparison.h>
 
 namespace facebook::yoga {
@@ -19,15 +19,15 @@ namespace facebook::yoga {
 struct CachedMeasurement {
   float availableWidth{-1};
   float availableHeight{-1};
-  MeasureMode widthMeasureMode{MeasureMode::Undefined};
-  MeasureMode heightMeasureMode{MeasureMode::Undefined};
+  SizingMode widthSizingMode{SizingMode::MaxContent};
+  SizingMode heightSizingMode{SizingMode::MaxContent};
 
   float computedWidth{-1};
   float computedHeight{-1};
 
   bool operator==(CachedMeasurement measurement) const {
-    bool isEqual = widthMeasureMode == measurement.widthMeasureMode &&
-        heightMeasureMode == measurement.heightMeasureMode;
+    bool isEqual = widthSizingMode == measurement.widthSizingMode &&
+        heightSizingMode == measurement.heightSizingMode;
 
     if (!yoga::isUndefined(availableWidth) ||
         !yoga::isUndefined(measurement.availableWidth)) {

--- a/yoga/node/LayoutResults.cpp
+++ b/yoga/node/LayoutResults.cpp
@@ -13,11 +13,11 @@
 namespace facebook::yoga {
 
 bool LayoutResults::operator==(LayoutResults layout) const {
-  bool isEqual = yoga::inexactEquals(position, layout.position) &&
+  bool isEqual = yoga::inexactEquals(position_, layout.position_) &&
       yoga::inexactEquals(dimensions_, layout.dimensions_) &&
-      yoga::inexactEquals(margin, layout.margin) &&
-      yoga::inexactEquals(border, layout.border) &&
-      yoga::inexactEquals(padding, layout.padding) &&
+      yoga::inexactEquals(margin_, layout.margin_) &&
+      yoga::inexactEquals(border_, layout.border_) &&
+      yoga::inexactEquals(padding_, layout.padding_) &&
       direction() == layout.direction() &&
       hadOverflow() == layout.hadOverflow() &&
       lastOwnerDirection == layout.lastOwnerDirection &&

--- a/yoga/node/LayoutResults.h
+++ b/yoga/node/LayoutResults.h
@@ -10,8 +10,10 @@
 #include <array>
 
 #include <yoga/bits/NumericBitfield.h>
+#include <yoga/debug/AssertFatal.h>
 #include <yoga/enums/Dimension.h>
 #include <yoga/enums/Direction.h>
+#include <yoga/enums/Edge.h>
 #include <yoga/node/CachedMeasurement.h>
 #include <yoga/numeric/FloatOptional.h>
 
@@ -22,19 +24,6 @@ struct LayoutResults {
   // 98% of analyzed layouts require less than 8 entries.
   static constexpr int32_t MaxCachedMeasurements = 8;
 
-  std::array<float, 4> position = {};
-  std::array<float, 4> margin = {};
-  std::array<float, 4> border = {};
-  std::array<float, 4> padding = {};
-
- private:
-  Direction direction_ : bitCount<Direction>() = Direction::Inherit;
-  bool hadOverflow_ : 1 = false;
-
-  std::array<float, 2> dimensions_ = {{YGUndefined, YGUndefined}};
-  std::array<float, 2> measuredDimensions_ = {{YGUndefined, YGUndefined}};
-
- public:
   uint32_t computedFlexBasisGeneration = 0;
   FloatOptional computedFlexBasis = {};
 
@@ -80,10 +69,66 @@ struct LayoutResults {
     measuredDimensions_[yoga::to_underlying(axis)] = dimension;
   }
 
+  float position(Edge cardinalEdge) const {
+    assertCardinalEdge(cardinalEdge);
+    return position_[yoga::to_underlying(cardinalEdge)];
+  }
+
+  void setPosition(Edge cardinalEdge, float dimension) {
+    assertCardinalEdge(cardinalEdge);
+    position_[yoga::to_underlying(cardinalEdge)] = dimension;
+  }
+
+  float margin(Edge cardinalEdge) const {
+    assertCardinalEdge(cardinalEdge);
+    return margin_[yoga::to_underlying(cardinalEdge)];
+  }
+
+  void setMargin(Edge cardinalEdge, float dimension) {
+    assertCardinalEdge(cardinalEdge);
+    margin_[yoga::to_underlying(cardinalEdge)] = dimension;
+  }
+
+  float border(Edge cardinalEdge) const {
+    assertCardinalEdge(cardinalEdge);
+    return border_[yoga::to_underlying(cardinalEdge)];
+  }
+
+  void setBorder(Edge cardinalEdge, float dimension) {
+    assertCardinalEdge(cardinalEdge);
+    border_[yoga::to_underlying(cardinalEdge)] = dimension;
+  }
+
+  float padding(Edge cardinalEdge) const {
+    assertCardinalEdge(cardinalEdge);
+    return padding_[yoga::to_underlying(cardinalEdge)];
+  }
+
+  void setPadding(Edge cardinalEdge, float dimension) {
+    assertCardinalEdge(cardinalEdge);
+    padding_[yoga::to_underlying(cardinalEdge)] = dimension;
+  }
+
   bool operator==(LayoutResults layout) const;
   bool operator!=(LayoutResults layout) const {
     return !(*this == layout);
   }
+
+ private:
+  static inline void assertCardinalEdge(Edge edge) {
+    assertFatal(
+        static_cast<int>(edge) <= 3, "Edge must be top/left/bottom/right");
+  }
+
+  Direction direction_ : bitCount<Direction>() = Direction::Inherit;
+  bool hadOverflow_ : 1 = false;
+
+  std::array<float, 2> dimensions_ = {{YGUndefined, YGUndefined}};
+  std::array<float, 2> measuredDimensions_ = {{YGUndefined, YGUndefined}};
+  std::array<float, 4> position_ = {};
+  std::array<float, 4> margin_ = {};
+  std::array<float, 4> border_ = {};
+  std::array<float, 4> padding_ = {};
 };
 
 } // namespace facebook::yoga

--- a/yoga/node/Node.cpp
+++ b/yoga/node/Node.cpp
@@ -58,7 +58,7 @@ void Node::print() {
 
 // TODO: Edge value resolution should be moved to `yoga::Style`
 template <auto Field>
-CompactValue Node::computeEdgeValueForRow(YGEdge rowEdge, YGEdge edge) const {
+Style::Length Node::computeEdgeValueForRow(YGEdge rowEdge, YGEdge edge) const {
   if ((style_.*Field)(rowEdge).isDefined()) {
     return (style_.*Field)(rowEdge);
   } else if ((style_.*Field)(edge).isDefined()) {
@@ -72,7 +72,7 @@ CompactValue Node::computeEdgeValueForRow(YGEdge rowEdge, YGEdge edge) const {
 
 // TODO: Edge value resolution should be moved to `yoga::Style`
 template <auto Field>
-CompactValue Node::computeEdgeValueForColumn(YGEdge edge) const {
+Style::Length Node::computeEdgeValueForColumn(YGEdge edge) const {
   if ((style_.*Field)(edge).isDefined()) {
     return (style_.*Field)(edge);
   } else if ((style_.*Field)(YGEdgeVertical).isDefined()) {
@@ -497,8 +497,8 @@ void Node::setLayoutHadOverflow(bool hadOverflow) {
   layout_.setHadOverflow(hadOverflow);
 }
 
-void Node::setLayoutDimension(float dimensionValue, Dimension dimension) {
-  layout_.setDimension(dimension, dimensionValue);
+void Node::setLayoutDimension(float LengthValue, Dimension dimension) {
+  layout_.setDimension(dimension, LengthValue);
 }
 
 // If both left and right are defined, then use left. Otherwise return +left or

--- a/yoga/node/Node.cpp
+++ b/yoga/node/Node.cpp
@@ -58,31 +58,31 @@ void Node::print() {
 
 // TODO: Edge value resolution should be moved to `yoga::Style`
 template <auto Field>
-Style::Length Node::computeEdgeValueForRow(YGEdge rowEdge, YGEdge edge) const {
+Style::Length Node::computeEdgeValueForRow(Edge rowEdge, Edge edge) const {
   if ((style_.*Field)(rowEdge).isDefined()) {
     return (style_.*Field)(rowEdge);
   } else if ((style_.*Field)(edge).isDefined()) {
     return (style_.*Field)(edge);
-  } else if ((style_.*Field)(YGEdgeHorizontal).isDefined()) {
-    return (style_.*Field)(YGEdgeHorizontal);
+  } else if ((style_.*Field)(Edge::Horizontal).isDefined()) {
+    return (style_.*Field)(Edge::Horizontal);
   } else {
-    return (style_.*Field)(YGEdgeAll);
+    return (style_.*Field)(Edge::All);
   }
 }
 
 // TODO: Edge value resolution should be moved to `yoga::Style`
 template <auto Field>
-Style::Length Node::computeEdgeValueForColumn(YGEdge edge) const {
+Style::Length Node::computeEdgeValueForColumn(Edge edge) const {
   if ((style_.*Field)(edge).isDefined()) {
     return (style_.*Field)(edge);
-  } else if ((style_.*Field)(YGEdgeVertical).isDefined()) {
-    return (style_.*Field)(YGEdgeVertical);
+  } else if ((style_.*Field)(Edge::Vertical).isDefined()) {
+    return (style_.*Field)(Edge::Vertical);
   } else {
-    return (style_.*Field)(YGEdgeAll);
+    return (style_.*Field)(Edge::All);
   }
 }
 
-YGEdge Node::getInlineStartEdgeUsingErrata(
+Edge Node::getInlineStartEdgeUsingErrata(
     FlexDirection flexDirection,
     Direction direction) const {
   return hasErrata(Errata::StartingEndingEdgeFromFlexDirection)
@@ -90,7 +90,7 @@ YGEdge Node::getInlineStartEdgeUsingErrata(
       : inlineStartEdge(flexDirection, direction);
 }
 
-YGEdge Node::getInlineEndEdgeUsingErrata(
+Edge Node::getInlineEndEdgeUsingErrata(
     FlexDirection flexDirection,
     Direction direction) const {
   return hasErrata(Errata::StartingEndingEdgeFromFlexDirection)
@@ -99,9 +99,9 @@ YGEdge Node::getInlineEndEdgeUsingErrata(
 }
 
 bool Node::isFlexStartPositionDefined(FlexDirection axis) const {
-  const YGEdge startEdge = flexStartEdge(axis);
+  const Edge startEdge = flexStartEdge(axis);
   auto leadingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(YGEdgeStart, startEdge)
+      ? computeEdgeValueForRow<&Style::position>(Edge::Start, startEdge)
       : computeEdgeValueForColumn<&Style::position>(startEdge);
 
   return leadingPosition.isDefined();
@@ -109,18 +109,18 @@ bool Node::isFlexStartPositionDefined(FlexDirection axis) const {
 
 bool Node::isInlineStartPositionDefined(FlexDirection axis, Direction direction)
     const {
-  const YGEdge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
+  const Edge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
   auto leadingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(YGEdgeStart, startEdge)
+      ? computeEdgeValueForRow<&Style::position>(Edge::Start, startEdge)
       : computeEdgeValueForColumn<&Style::position>(startEdge);
 
   return leadingPosition.isDefined();
 }
 
 bool Node::isFlexEndPositionDefined(FlexDirection axis) const {
-  const YGEdge endEdge = flexEndEdge(axis);
+  const Edge endEdge = flexEndEdge(axis);
   auto trailingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(YGEdgeEnd, endEdge)
+      ? computeEdgeValueForRow<&Style::position>(Edge::End, endEdge)
       : computeEdgeValueForColumn<&Style::position>(endEdge);
 
   return !trailingPosition.isUndefined();
@@ -128,18 +128,18 @@ bool Node::isFlexEndPositionDefined(FlexDirection axis) const {
 
 bool Node::isInlineEndPositionDefined(FlexDirection axis, Direction direction)
     const {
-  const YGEdge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
+  const Edge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
   auto trailingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(YGEdgeEnd, endEdge)
+      ? computeEdgeValueForRow<&Style::position>(Edge::End, endEdge)
       : computeEdgeValueForColumn<&Style::position>(endEdge);
 
   return trailingPosition.isDefined();
 }
 
 float Node::getFlexStartPosition(FlexDirection axis, float axisSize) const {
-  const YGEdge startEdge = flexStartEdge(axis);
+  const Edge startEdge = flexStartEdge(axis);
   auto leadingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(YGEdgeStart, startEdge)
+      ? computeEdgeValueForRow<&Style::position>(Edge::Start, startEdge)
       : computeEdgeValueForColumn<&Style::position>(startEdge);
 
   return resolveValue(leadingPosition, axisSize).unwrapOrDefault(0.0f);
@@ -149,18 +149,18 @@ float Node::getInlineStartPosition(
     FlexDirection axis,
     Direction direction,
     float axisSize) const {
-  const YGEdge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
+  const Edge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
   auto leadingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(YGEdgeStart, startEdge)
+      ? computeEdgeValueForRow<&Style::position>(Edge::Start, startEdge)
       : computeEdgeValueForColumn<&Style::position>(startEdge);
 
   return resolveValue(leadingPosition, axisSize).unwrapOrDefault(0.0f);
 }
 
 float Node::getFlexEndPosition(FlexDirection axis, float axisSize) const {
-  const YGEdge endEdge = flexEndEdge(axis);
+  const Edge endEdge = flexEndEdge(axis);
   auto trailingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(YGEdgeEnd, endEdge)
+      ? computeEdgeValueForRow<&Style::position>(Edge::End, endEdge)
       : computeEdgeValueForColumn<&Style::position>(endEdge);
 
   return resolveValue(trailingPosition, axisSize).unwrapOrDefault(0.0f);
@@ -170,18 +170,18 @@ float Node::getInlineEndPosition(
     FlexDirection axis,
     Direction direction,
     float axisSize) const {
-  const YGEdge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
+  const Edge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
   auto trailingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(YGEdgeEnd, endEdge)
+      ? computeEdgeValueForRow<&Style::position>(Edge::End, endEdge)
       : computeEdgeValueForColumn<&Style::position>(endEdge);
 
   return resolveValue(trailingPosition, axisSize).unwrapOrDefault(0.0f);
 }
 
 float Node::getFlexStartMargin(FlexDirection axis, float widthSize) const {
-  const YGEdge startEdge = flexStartEdge(axis);
+  const Edge startEdge = flexStartEdge(axis);
   auto leadingMargin = isRow(axis)
-      ? computeEdgeValueForRow<&Style::margin>(YGEdgeStart, startEdge)
+      ? computeEdgeValueForRow<&Style::margin>(Edge::Start, startEdge)
       : computeEdgeValueForColumn<&Style::margin>(startEdge);
 
   return resolveValue(leadingMargin, widthSize).unwrapOrDefault(0.0f);
@@ -191,18 +191,18 @@ float Node::getInlineStartMargin(
     FlexDirection axis,
     Direction direction,
     float widthSize) const {
-  const YGEdge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
+  const Edge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
   auto leadingMargin = isRow(axis)
-      ? computeEdgeValueForRow<&Style::margin>(YGEdgeStart, startEdge)
+      ? computeEdgeValueForRow<&Style::margin>(Edge::Start, startEdge)
       : computeEdgeValueForColumn<&Style::margin>(startEdge);
 
   return resolveValue(leadingMargin, widthSize).unwrapOrDefault(0.0f);
 }
 
 float Node::getFlexEndMargin(FlexDirection axis, float widthSize) const {
-  const YGEdge endEdge = flexEndEdge(axis);
+  const Edge endEdge = flexEndEdge(axis);
   auto trailingMargin = isRow(axis)
-      ? computeEdgeValueForRow<&Style::margin>(YGEdgeEnd, endEdge)
+      ? computeEdgeValueForRow<&Style::margin>(Edge::End, endEdge)
       : computeEdgeValueForColumn<&Style::margin>(endEdge);
 
   return resolveValue(trailingMargin, widthSize).unwrapOrDefault(0.0f);
@@ -212,9 +212,9 @@ float Node::getInlineEndMargin(
     FlexDirection axis,
     Direction direction,
     float widthSize) const {
-  const YGEdge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
+  const Edge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
   auto trailingMargin = isRow(axis)
-      ? computeEdgeValueForRow<&Style::margin>(YGEdgeEnd, endEdge)
+      ? computeEdgeValueForRow<&Style::margin>(Edge::End, endEdge)
       : computeEdgeValueForColumn<&Style::margin>(endEdge);
 
   return resolveValue(trailingMargin, widthSize).unwrapOrDefault(0.0f);
@@ -222,17 +222,16 @@ float Node::getInlineEndMargin(
 
 float Node::getInlineStartBorder(FlexDirection axis, Direction direction)
     const {
-  const YGEdge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
+  const Edge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
   YGValue leadingBorder = isRow(axis)
-      ? computeEdgeValueForRow<&Style::border>(YGEdgeStart, startEdge)
+      ? computeEdgeValueForRow<&Style::border>(Edge::Start, startEdge)
       : computeEdgeValueForColumn<&Style::border>(startEdge);
 
   return maxOrDefined(leadingBorder.value, 0.0f);
 }
 
 float Node::getFlexStartBorder(FlexDirection axis, Direction direction) const {
-  const YGEdge leadRelativeFlexItemEdge =
-      flexStartRelativeEdge(axis, direction);
+  const Edge leadRelativeFlexItemEdge = flexStartRelativeEdge(axis, direction);
   YGValue leadingBorder = isRow(axis)
       ? computeEdgeValueForRow<&Style::border>(
             leadRelativeFlexItemEdge, flexStartEdge(axis))
@@ -242,16 +241,16 @@ float Node::getFlexStartBorder(FlexDirection axis, Direction direction) const {
 }
 
 float Node::getInlineEndBorder(FlexDirection axis, Direction direction) const {
-  const YGEdge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
+  const Edge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
   YGValue trailingBorder = isRow(axis)
-      ? computeEdgeValueForRow<&Style::border>(YGEdgeEnd, endEdge)
+      ? computeEdgeValueForRow<&Style::border>(Edge::End, endEdge)
       : computeEdgeValueForColumn<&Style::border>(endEdge);
 
   return maxOrDefined(trailingBorder.value, 0.0f);
 }
 
 float Node::getFlexEndBorder(FlexDirection axis, Direction direction) const {
-  const YGEdge trailRelativeFlexItemEdge = flexEndRelativeEdge(axis, direction);
+  const Edge trailRelativeFlexItemEdge = flexEndRelativeEdge(axis, direction);
   YGValue trailingBorder = isRow(axis)
       ? computeEdgeValueForRow<&Style::border>(
             trailRelativeFlexItemEdge, flexEndEdge(axis))
@@ -264,9 +263,9 @@ float Node::getInlineStartPadding(
     FlexDirection axis,
     Direction direction,
     float widthSize) const {
-  const YGEdge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
+  const Edge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
   auto leadingPadding = isRow(axis)
-      ? computeEdgeValueForRow<&Style::padding>(YGEdgeStart, startEdge)
+      ? computeEdgeValueForRow<&Style::padding>(Edge::Start, startEdge)
       : computeEdgeValueForColumn<&Style::padding>(startEdge);
 
   return maxOrDefined(resolveValue(leadingPadding, widthSize).unwrap(), 0.0f);
@@ -276,8 +275,7 @@ float Node::getFlexStartPadding(
     FlexDirection axis,
     Direction direction,
     float widthSize) const {
-  const YGEdge leadRelativeFlexItemEdge =
-      flexStartRelativeEdge(axis, direction);
+  const Edge leadRelativeFlexItemEdge = flexStartRelativeEdge(axis, direction);
   auto leadingPadding = isRow(axis)
       ? computeEdgeValueForRow<&Style::padding>(
             leadRelativeFlexItemEdge, flexStartEdge(axis))
@@ -290,9 +288,9 @@ float Node::getInlineEndPadding(
     FlexDirection axis,
     Direction direction,
     float widthSize) const {
-  const YGEdge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
+  const Edge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
   auto trailingPadding = isRow(axis)
-      ? computeEdgeValueForRow<&Style::padding>(YGEdgeEnd, endEdge)
+      ? computeEdgeValueForRow<&Style::padding>(Edge::End, endEdge)
       : computeEdgeValueForColumn<&Style::padding>(endEdge);
 
   return maxOrDefined(resolveValue(trailingPadding, widthSize).unwrap(), 0.0f);
@@ -302,7 +300,7 @@ float Node::getFlexEndPadding(
     FlexDirection axis,
     Direction direction,
     float widthSize) const {
-  const YGEdge trailRelativeFlexItemEdge = flexEndRelativeEdge(axis, direction);
+  const Edge trailRelativeFlexItemEdge = flexEndRelativeEdge(axis, direction);
   auto trailingPadding = isRow(axis)
       ? computeEdgeValueForRow<&Style::padding>(
             trailRelativeFlexItemEdge, flexEndEdge(axis))
@@ -446,25 +444,16 @@ void Node::setLayoutDirection(Direction direction) {
   layout_.setDirection(direction);
 }
 
-void Node::setLayoutMargin(float margin, YGEdge edge) {
-  assertFatal(
-      edge < static_cast<int>(layout_.margin.size()),
-      "Edge must be top/left/bottom/right");
-  layout_.margin[edge] = margin;
+void Node::setLayoutMargin(float margin, Edge edge) {
+  layout_.setMargin(edge, margin);
 }
 
-void Node::setLayoutBorder(float border, YGEdge edge) {
-  assertFatal(
-      edge < static_cast<int>(layout_.border.size()),
-      "Edge must be top/left/bottom/right");
-  layout_.border[edge] = border;
+void Node::setLayoutBorder(float border, Edge edge) {
+  layout_.setBorder(edge, border);
 }
 
-void Node::setLayoutPadding(float padding, YGEdge edge) {
-  assertFatal(
-      edge < static_cast<int>(layout_.padding.size()),
-      "Edge must be top/left/bottom/right");
-  layout_.padding[edge] = padding;
+void Node::setLayoutPadding(float padding, Edge edge) {
+  layout_.setPadding(edge, padding);
 }
 
 void Node::setLayoutLastOwnerDirection(Direction direction) {
@@ -475,11 +464,8 @@ void Node::setLayoutComputedFlexBasis(const FloatOptional computedFlexBasis) {
   layout_.computedFlexBasis = computedFlexBasis;
 }
 
-void Node::setLayoutPosition(float position, YGEdge edge) {
-  assertFatal(
-      edge < static_cast<int>(layout_.position.size()),
-      "Edge must be top/left/bottom/right");
-  layout_.position[edge] = position;
+void Node::setLayoutPosition(float position, Edge edge) {
+  layout_.setPosition(edge, position);
 }
 
 void Node::setLayoutComputedFlexBasisGeneration(
@@ -536,13 +522,13 @@ void Node::setPosition(
   const float relativePositionCross =
       relativePosition(crossAxis, directionRespectingRoot, crossSize);
 
-  const YGEdge mainAxisLeadingEdge =
+  const Edge mainAxisLeadingEdge =
       getInlineStartEdgeUsingErrata(mainAxis, direction);
-  const YGEdge mainAxisTrailingEdge =
+  const Edge mainAxisTrailingEdge =
       getInlineEndEdgeUsingErrata(mainAxis, direction);
-  const YGEdge crossAxisLeadingEdge =
+  const Edge crossAxisLeadingEdge =
       getInlineStartEdgeUsingErrata(crossAxis, direction);
-  const YGEdge crossAxisTrailingEdge =
+  const Edge crossAxisTrailingEdge =
       getInlineEndEdgeUsingErrata(crossAxis, direction);
 
   setLayoutPosition(
@@ -564,16 +550,16 @@ void Node::setPosition(
 }
 
 YGValue Node::getFlexStartMarginValue(FlexDirection axis) const {
-  if (isRow(axis) && style_.margin(YGEdgeStart).isDefined()) {
-    return style_.margin(YGEdgeStart);
+  if (isRow(axis) && style_.margin(Edge::Start).isDefined()) {
+    return style_.margin(Edge::Start);
   } else {
     return style_.margin(flexStartEdge(axis));
   }
 }
 
 YGValue Node::marginTrailingValue(FlexDirection axis) const {
-  if (isRow(axis) && style_.margin(YGEdgeEnd).isDefined()) {
-    return style_.margin(YGEdgeEnd);
+  if (isRow(axis) && style_.margin(Edge::End).isDefined()) {
+    return style_.margin(Edge::End);
   } else {
     return style_.margin(flexEndEdge(axis));
   }

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -20,7 +20,6 @@
 #include <yoga/enums/MeasureMode.h>
 #include <yoga/enums/NodeType.h>
 #include <yoga/node/LayoutResults.h>
-#include <yoga/style/CompactValue.h>
 #include <yoga/style/Style.h>
 
 // Tag struct used to form the opaque YGNodeRef for the public C API
@@ -66,10 +65,10 @@ class YG_EXPORT Node : public ::YGNode {
   }
 
   template <auto Field>
-  CompactValue computeEdgeValueForColumn(YGEdge edge) const;
+  Style::Length computeEdgeValueForColumn(YGEdge edge) const;
 
   template <auto Field>
-  CompactValue computeEdgeValueForRow(YGEdge rowEdge, YGEdge edge) const;
+  Style::Length computeEdgeValueForRow(YGEdge rowEdge, YGEdge edge) const;
 
   // DANGER DANGER DANGER!
   // If the node assigned to has children, we'd either have to deallocate
@@ -327,7 +326,7 @@ class YG_EXPORT Node : public ::YGNode {
       uint32_t computedFlexBasisGeneration);
   void setLayoutMeasuredDimension(float measuredDimension, Dimension dimension);
   void setLayoutHadOverflow(bool hadOverflow);
-  void setLayoutDimension(float dimensionValue, Dimension dimension);
+  void setLayoutDimension(float LengthValue, Dimension dimension);
   void setLayoutDirection(Direction direction);
   void setLayoutMargin(float margin, YGEdge edge);
   void setLayoutBorder(float border, YGEdge edge);

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -16,6 +16,7 @@
 #include <yoga/config/Config.h>
 #include <yoga/enums/Dimension.h>
 #include <yoga/enums/Direction.h>
+#include <yoga/enums/Edge.h>
 #include <yoga/enums/Errata.h>
 #include <yoga/enums/MeasureMode.h>
 #include <yoga/enums/NodeType.h>
@@ -52,10 +53,10 @@ class YG_EXPORT Node : public ::YGNode {
       Direction direction,
       const float axisSize) const;
 
-  YGEdge getInlineStartEdgeUsingErrata(
+  Edge getInlineStartEdgeUsingErrata(
       FlexDirection flexDirection,
       Direction direction) const;
-  YGEdge getInlineEndEdgeUsingErrata(
+  Edge getInlineEndEdgeUsingErrata(
       FlexDirection flexDirection,
       Direction direction) const;
 
@@ -65,10 +66,10 @@ class YG_EXPORT Node : public ::YGNode {
   }
 
   template <auto Field>
-  Style::Length computeEdgeValueForColumn(YGEdge edge) const;
+  Style::Length computeEdgeValueForColumn(Edge edge) const;
 
   template <auto Field>
-  Style::Length computeEdgeValueForRow(YGEdge rowEdge, YGEdge edge) const;
+  Style::Length computeEdgeValueForRow(Edge rowEdge, Edge edge) const;
 
   // DANGER DANGER DANGER!
   // If the node assigned to has children, we'd either have to deallocate
@@ -328,10 +329,10 @@ class YG_EXPORT Node : public ::YGNode {
   void setLayoutHadOverflow(bool hadOverflow);
   void setLayoutDimension(float LengthValue, Dimension dimension);
   void setLayoutDirection(Direction direction);
-  void setLayoutMargin(float margin, YGEdge edge);
-  void setLayoutBorder(float border, YGEdge edge);
-  void setLayoutPadding(float padding, YGEdge edge);
-  void setLayoutPosition(float position, YGEdge edge);
+  void setLayoutMargin(float margin, Edge edge);
+  void setLayoutBorder(float border, Edge edge);
+  void setLayoutPadding(float padding, Edge edge);
+  void setLayoutPosition(float position, Edge edge);
   void setPosition(
       const Direction direction,
       const float mainSize,

--- a/yoga/style/CompactValue.h
+++ b/yoga/style/CompactValue.h
@@ -52,6 +52,10 @@ class YG_EXPORT CompactValue {
 
   template <YGUnit Unit>
   static CompactValue of(float value) noexcept {
+    if (yoga::isUndefined(value) || std::isinf(value)) {
+      return ofUndefined();
+    }
+
     if (value == 0.0f || (value < LOWER_BOUND && value > -LOWER_BOUND)) {
       constexpr auto zero =
           Unit == YGUnitPercent ? ZERO_BITS_PERCENT : ZERO_BITS_POINT;
@@ -69,16 +73,6 @@ class YG_EXPORT CompactValue {
     data -= BIAS;
     data |= unitBit;
     return {data};
-  }
-
-  template <YGUnit Unit>
-  static CompactValue ofMaybe(float value) noexcept {
-    return std::isnan(value) || std::isinf(value) ? ofUndefined()
-                                                  : of<Unit>(value);
-  }
-
-  static constexpr CompactValue ofZero() noexcept {
-    return CompactValue{ZERO_BITS_POINT};
   }
 
   static constexpr CompactValue ofUndefined() noexcept {
@@ -168,10 +162,6 @@ template <>
 CompactValue CompactValue::of<YGUnitUndefined>(float) noexcept = delete;
 template <>
 CompactValue CompactValue::of<YGUnitAuto>(float) noexcept = delete;
-template <>
-CompactValue CompactValue::ofMaybe<YGUnitUndefined>(float) noexcept = delete;
-template <>
-CompactValue CompactValue::ofMaybe<YGUnitAuto>(float) noexcept = delete;
 
 constexpr bool operator==(CompactValue a, CompactValue b) noexcept {
   return a.repr_ == b.repr_;

--- a/yoga/style/Style.h
+++ b/yoga/style/Style.h
@@ -28,18 +28,29 @@
 #include <yoga/enums/Wrap.h>
 #include <yoga/numeric/FloatOptional.h>
 #include <yoga/style/CompactValue.h>
+#include <yoga/style/ValueFactories.h>
 
 namespace facebook::yoga {
 
 class YG_EXPORT Style {
-  template <typename Enum>
-  using Values = std::array<CompactValue, ordinalCount<Enum>()>;
-
-  using Dimensions = Values<Dimension>;
-  using Edges = Values<YGEdge>;
-  using Gutters = Values<Gutter>;
-
  public:
+  /**
+   * Style::Length represents a CSS Value which may be one of:
+   * 1. Undefined
+   * 2. A keyword (e.g. auto)
+   * 3. A CSS <length-percentage> value:
+   *    a. <length> value (e.g. 10px)
+   *    b. <percentage> value of a reference <length>
+   * 4. (soon) A math function which returns a <length-percentage> value
+   *
+   * References:
+   * 1. https://www.w3.org/TR/css-values-4/#lengths
+   * 2. https://www.w3.org/TR/css-values-4/#percentage-value
+   * 3. https://www.w3.org/TR/css-values-4/#mixed-percentages
+   * 4. https://www.w3.org/TR/css-values-4/#math
+   */
+  using Length = CompactValue;
+
   static constexpr float DefaultFlexGrow = 0.0f;
   static constexpr float DefaultFlexShrink = 0.0f;
   static constexpr float WebDefaultFlexShrink = 1.0f;
@@ -76,6 +87,10 @@ class YG_EXPORT Style {
   ~Style() = default;
 
  private:
+  using Dimensions = std::array<Style::Length, ordinalCount<Dimension>()>;
+  using Edges = std::array<Style::Length, ordinalCount<Edge>()>;
+  using Gutters = std::array<Style::Length, ordinalCount<Gutter>()>;
+
   static constexpr uint8_t directionOffset = 0;
   static constexpr uint8_t flexdirectionOffset =
       directionOffset + minimumBitCount<Direction>();
@@ -101,13 +116,13 @@ class YG_EXPORT Style {
   FloatOptional flex_ = {};
   FloatOptional flexGrow_ = {};
   FloatOptional flexShrink_ = {};
-  CompactValue flexBasis_ = CompactValue::ofAuto();
+  Style::Length flexBasis_ = value::ofAuto();
   Edges margin_ = {};
   Edges position_ = {};
   Edges padding_ = {};
   Edges border_ = {};
   Gutters gap_ = {};
-  Dimensions dimensions_{CompactValue::ofAuto(), CompactValue::ofAuto()};
+  Dimensions dimensions_{value::ofAuto(), value::ofAuto()};
   Dimensions minDimensions_ = {};
   Dimensions maxDimensions_ = {};
   // Yoga specific properties, not compatible with flexbox specification
@@ -205,66 +220,66 @@ class YG_EXPORT Style {
     return {*this};
   }
 
-  CompactValue flexBasis() const {
+  Style::Length flexBasis() const {
     return flexBasis_;
   }
-  Ref<CompactValue, &Style::flexBasis_> flexBasis() {
+  Ref<Style::Length, &Style::flexBasis_> flexBasis() {
     return {*this};
   }
 
-  CompactValue margin(YGEdge edge) const {
+  Style::Length margin(YGEdge edge) const {
     return margin_[edge];
   }
-  void setMargin(YGEdge edge, CompactValue value) {
+  void setMargin(YGEdge edge, Style::Length value) {
     margin_[edge] = value;
   }
 
-  CompactValue position(YGEdge edge) const {
+  Style::Length position(YGEdge edge) const {
     return position_[edge];
   }
-  void setPosition(YGEdge edge, CompactValue value) {
+  void setPosition(YGEdge edge, Style::Length value) {
     position_[edge] = value;
   }
 
-  CompactValue padding(YGEdge edge) const {
+  Style::Length padding(YGEdge edge) const {
     return padding_[edge];
   }
-  void setPadding(YGEdge edge, CompactValue value) {
+  void setPadding(YGEdge edge, Style::Length value) {
     padding_[edge] = value;
   }
 
-  CompactValue border(YGEdge edge) const {
+  Style::Length border(YGEdge edge) const {
     return border_[edge];
   }
-  void setBorder(YGEdge edge, CompactValue value) {
+  void setBorder(YGEdge edge, Style::Length value) {
     border_[edge] = value;
   }
 
-  CompactValue gap(Gutter gutter) const {
+  Style::Length gap(Gutter gutter) const {
     return gap_[yoga::to_underlying(gutter)];
   }
-  void setGap(Gutter gutter, CompactValue value) {
+  void setGap(Gutter gutter, Style::Length value) {
     gap_[yoga::to_underlying(gutter)] = value;
   }
 
-  CompactValue dimension(Dimension axis) const {
+  Style::Length dimension(Dimension axis) const {
     return dimensions_[yoga::to_underlying(axis)];
   }
-  void setDimension(Dimension axis, CompactValue value) {
+  void setDimension(Dimension axis, Style::Length value) {
     dimensions_[yoga::to_underlying(axis)] = value;
   }
 
-  CompactValue minDimension(Dimension axis) const {
+  Style::Length minDimension(Dimension axis) const {
     return minDimensions_[yoga::to_underlying(axis)];
   }
-  void setMinDimension(Dimension axis, CompactValue value) {
+  void setMinDimension(Dimension axis, Style::Length value) {
     minDimensions_[yoga::to_underlying(axis)] = value;
   }
 
-  CompactValue maxDimension(Dimension axis) const {
+  Style::Length maxDimension(Dimension axis) const {
     return maxDimensions_[yoga::to_underlying(axis)];
   }
-  void setMaxDimension(Dimension axis, CompactValue value) {
+  void setMaxDimension(Dimension axis, Style::Length value) {
     maxDimensions_[yoga::to_underlying(axis)] = value;
   }
 
@@ -276,7 +291,7 @@ class YG_EXPORT Style {
     return {*this};
   }
 
-  CompactValue resolveColumnGap() const {
+  Length resolveColumnGap() const {
     if (gap_[yoga::to_underlying(Gutter::Column)].isDefined()) {
       return gap_[yoga::to_underlying(Gutter::Column)];
     } else {
@@ -284,7 +299,7 @@ class YG_EXPORT Style {
     }
   }
 
-  CompactValue resolveRowGap() const {
+  Style::Length resolveRowGap() const {
     if (gap_[yoga::to_underlying(Gutter::Row)].isDefined()) {
       return gap_[yoga::to_underlying(Gutter::Row)];
     } else {

--- a/yoga/style/Style.h
+++ b/yoga/style/Style.h
@@ -227,32 +227,32 @@ class YG_EXPORT Style {
     return {*this};
   }
 
-  Style::Length margin(YGEdge edge) const {
-    return margin_[edge];
+  Style::Length margin(Edge edge) const {
+    return margin_[yoga::to_underlying(edge)];
   }
-  void setMargin(YGEdge edge, Style::Length value) {
-    margin_[edge] = value;
-  }
-
-  Style::Length position(YGEdge edge) const {
-    return position_[edge];
-  }
-  void setPosition(YGEdge edge, Style::Length value) {
-    position_[edge] = value;
+  void setMargin(Edge edge, Style::Length value) {
+    margin_[yoga::to_underlying(edge)] = value;
   }
 
-  Style::Length padding(YGEdge edge) const {
-    return padding_[edge];
+  Style::Length position(Edge edge) const {
+    return position_[yoga::to_underlying(edge)];
   }
-  void setPadding(YGEdge edge, Style::Length value) {
-    padding_[edge] = value;
+  void setPosition(Edge edge, Style::Length value) {
+    position_[yoga::to_underlying(edge)] = value;
   }
 
-  Style::Length border(YGEdge edge) const {
-    return border_[edge];
+  Style::Length padding(Edge edge) const {
+    return padding_[yoga::to_underlying(edge)];
   }
-  void setBorder(YGEdge edge, Style::Length value) {
-    border_[edge] = value;
+  void setPadding(Edge edge, Style::Length value) {
+    padding_[yoga::to_underlying(edge)] = value;
+  }
+
+  Style::Length border(Edge edge) const {
+    return border_[yoga::to_underlying(edge)];
+  }
+  void setBorder(Edge edge, Style::Length value) {
+    border_[yoga::to_underlying(edge)] = value;
   }
 
   Style::Length gap(Gutter gutter) const {

--- a/yoga/style/ValueFactories.h
+++ b/yoga/style/ValueFactories.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <yoga/style/CompactValue.h>
+
+namespace facebook::yoga::value {
+
+/**
+ * Canonical unit (one YGUnitPoint)
+ */
+inline CompactValue points(float value) {
+  return CompactValue::of<YGUnitPoint>(value);
+}
+
+/**
+ * Percent of reference
+ */
+inline CompactValue percent(float value) {
+  return CompactValue::of<YGUnitPercent>(value);
+}
+
+/**
+ * "auto" keyword
+ */
+inline CompactValue ofAuto() {
+  return CompactValue::ofAuto();
+}
+
+/**
+ * Undefined
+ */
+inline CompactValue undefined() {
+  return CompactValue::ofUndefined();
+}
+
+} // namespace facebook::yoga::value


### PR DESCRIPTION
Summary:
Converts usages of `YGEdge` within internal APIs to `yoga::Edge` scoped enum.

With the exception of YGUnit which is in its own state of transition, this is the last public yoga enum to need to be moved to scoped enum form for usages internal to the Yoga public API.

Changelog: [internal]

Differential Revision: D51152779

