### PR TITLE
"yogalayout.com" to "yogalayout.dev"

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -26,7 +26,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: website/public
-          cname: yogalayout.com
+          cname: yogalayout.dev
           keep_files: true
           user_name: 'Yoga-bot'
           user_email: 'yogabot@fb.com'

--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -8,8 +8,8 @@ Pod::Spec.new do |spec|
   spec.name = 'Yoga'
   spec.version = '2.0.0'
   spec.license =  { :type => 'MIT', :file => "LICENSE" }
-  spec.homepage = 'https://yogalayout.com/'
-  spec.documentation_url = 'https://yogalayout.com/docs'
+  spec.homepage = 'https://yogalayout.dev/'
+  spec.documentation_url = 'https://yogalayout.dev/docs'
 
   spec.summary = 'An embeddable and performant flexbox layout engine with bindings for multiple languages'
 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -4,7 +4,7 @@
   "description": "An embeddable and performant flexbox layout engine with bindings for multiple languages",
   "license": "MIT",
   "author": "Meta Open Source",
-  "homepage": "https://yogalayout.com/",
+  "homepage": "https://yogalayout.dev/",
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/yoga.git"

--- a/website-next/docusaurus.config.js
+++ b/website-next/docusaurus.config.js
@@ -16,7 +16,7 @@ export default {
     'Build flexible layouts on any platform with a highly optimized open source layout engine designed with speed, size, and ease of use in mind.',
   favicon: 'img/favicon.png',
 
-  url: 'https:/yogalayout.com',
+  url: 'https:/yogalayout.dev',
   baseUrl: '/',
 
   organizationName: 'facebook',


### PR DESCRIPTION
Summary:
https://yogalayout.com now redirects to https://yogalayout.dev

This replaces references to "yogalayout.com" with "yogalayout.dev", the same website, with a new domain. This includes:
1. Code comments
2. Yoga website config (publish action CNAME, Docusaurus config)
3. Documentation URLs in Yoga packages

Changelog:
[General][Fixed] - "yogalayout.com" to "yogalayout.dev"

Differential Revision: D51229587


