### PR TITLE
Make trunk builds "0.0.0"

### DIFF
--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -6,7 +6,7 @@
 
 Pod::Spec.new do |spec|
   spec.name = 'Yoga'
-  spec.version = '2.0.0'
+  spec.version = '0.0.0'
   spec.license =  { :type => 'MIT', :file => "LICENSE" }
   spec.homepage = 'https://yogalayout.com/'
   spec.documentation_url = 'https://yogalayout.com/docs'

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ android.useAndroidX=true
 
 org.gradle.jvmargs=-Xmx1536M
 
-VERSION_NAME=2.0.0
+VERSION_NAME=0.0.0

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoga-layout",
-  "version": "2.0.0",
+  "version": "0.0.0",
   "description": "An embeddable and performant flexbox layout engine with bindings for multiple languages",
   "license": "MIT",
   "author": "Meta Open Source",


### PR DESCRIPTION
Summary:
Right now Yoga's main branch says it's 2.0.0, and RN's dirsync says its 1.14.0, but the code is really closer to what will be Yoga 3.0.0.

This changes trunk builds to "0.0.0" for clarity, which will be assigned a real version number the first time publishing a new Yoga branch.

This is separately a good practice to prevent the chance of accidental publishes causing damage.

Differential Revision: D51236778


