### PR TITLE
Change default back to `position: "relative"`

### DIFF
--- a/gentest/gentest.js
+++ b/gentest/gentest.js
@@ -165,7 +165,7 @@ function checkDefaultValues() {
     {style: 'justify-content', value: 'flex-start'},
     {style: 'align-content', value: 'flex-start'},
     {style: 'align-items', value: 'stretch'},
-    {style: 'position', value: 'static'},
+    {style: 'position', value: 'relative'},
     {style: 'flex-wrap', value: 'nowrap'},
     {style: 'overflow', value: 'visible'},
     {style: 'flex-grow', value: '0'},
@@ -643,7 +643,7 @@ function isDefaultStyleValue(style, value) {
   if (defaultStyle == null) {
     switch (style) {
       case 'position':
-        defaultStyle = new Set(['static']);
+        defaultStyle = new Set(['relative']);
         break;
 
       case 'left':

--- a/java/tests/com/facebook/yoga/YGAbsolutePositionTest.java
+++ b/java/tests/com/facebook/yoga/YGAbsolutePositionTest.java
@@ -222,7 +222,6 @@ public class YGAbsolutePositionTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -1077,7 +1076,6 @@ public class YGAbsolutePositionTest {
     root.setWidth(300f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(300f);
     root.addChildAt(root_child0, 0);
 
@@ -1177,7 +1175,6 @@ public class YGAbsolutePositionTest {
     final YogaNode root = createNode(config);
     root.setJustifyContent(YogaJustify.CENTER);
     root.setAlignItems(YogaAlign.CENTER);
-    root.setPositionType(YogaPositionType.RELATIVE);
     root.setPadding(YogaEdge.TOP, 20);
     root.setPadding(YogaEdge.BOTTOM, 20);
     root.setWidth(100f);

--- a/java/tests/com/facebook/yoga/YGAlignContentTest.java
+++ b/java/tests/com/facebook/yoga/YGAlignContentTest.java
@@ -37,13 +37,11 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
@@ -97,31 +95,26 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root_child3.setHeight(10f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root_child4.setHeight(10f);
     root.addChildAt(root_child4, 4);
@@ -205,13 +198,11 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
@@ -269,25 +260,21 @@ public class YGAlignContentTest {
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setJustifyContent(YogaJustify.CENTER);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(80f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidthPercent(80f);
     root_child0_child1.setHeight(20f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidthPercent(80f);
     root_child0_child2.setHeight(20f);
     root_child0.addChildAt(root_child0_child2, 2);
@@ -365,7 +352,6 @@ public class YGAlignContentTest {
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setJustifyContent(YogaJustify.CENTER);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setHeight(10f);
     root_child0.setGap(YogaGutter.COLUMN, 10f);
@@ -373,19 +359,16 @@ public class YGAlignContentTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(80f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidthPercent(80f);
     root_child0_child1.setHeight(20f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidthPercent(80f);
     root_child0_child2.setHeight(20f);
     root_child0.addChildAt(root_child0_child2, 2);
@@ -458,29 +441,24 @@ public class YGAlignContentTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root_child3.setHeight(10f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -562,14 +540,12 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasisPercent(0f);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexBasisPercent(0f);
     root_child1.setWidth(50f);
@@ -577,12 +553,10 @@ public class YGAlignContentTest {
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setFlexGrow(1f);
     root_child3.setFlexShrink(1f);
     root_child3.setFlexBasisPercent(0f);
@@ -590,7 +564,6 @@ public class YGAlignContentTest {
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -673,13 +646,11 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
@@ -734,31 +705,26 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root_child3.setHeight(10f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root_child4.setHeight(10f);
     root.addChildAt(root_child4, 4);
@@ -843,13 +809,11 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
@@ -908,25 +872,21 @@ public class YGAlignContentTest {
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setJustifyContent(YogaJustify.CENTER);
     root_child0.setAlignContent(YogaAlign.FLEX_END);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(80f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidthPercent(80f);
     root_child0_child1.setHeight(20f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidthPercent(80f);
     root_child0_child2.setHeight(20f);
     root_child0.addChildAt(root_child0_child2, 2);
@@ -1005,7 +965,6 @@ public class YGAlignContentTest {
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setJustifyContent(YogaJustify.CENTER);
     root_child0.setAlignContent(YogaAlign.FLEX_END);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setHeight(10f);
     root_child0.setGap(YogaGutter.COLUMN, 10f);
@@ -1013,19 +972,16 @@ public class YGAlignContentTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(80f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidthPercent(80f);
     root_child0_child1.setHeight(20f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidthPercent(80f);
     root_child0_child2.setHeight(20f);
     root_child0.addChildAt(root_child0_child2, 2);
@@ -1099,13 +1055,11 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
@@ -1160,31 +1114,26 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root_child3.setHeight(10f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root_child4.setHeight(10f);
     root.addChildAt(root_child4, 4);
@@ -1269,13 +1218,11 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
@@ -1334,25 +1281,21 @@ public class YGAlignContentTest {
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setJustifyContent(YogaJustify.CENTER);
     root_child0.setAlignContent(YogaAlign.CENTER);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(80f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidthPercent(80f);
     root_child0_child1.setHeight(20f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidthPercent(80f);
     root_child0_child2.setHeight(20f);
     root_child0.addChildAt(root_child0_child2, 2);
@@ -1431,7 +1374,6 @@ public class YGAlignContentTest {
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setJustifyContent(YogaJustify.CENTER);
     root_child0.setAlignContent(YogaAlign.CENTER);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setHeight(10f);
     root_child0.setGap(YogaGutter.COLUMN, 10f);
@@ -1439,19 +1381,16 @@ public class YGAlignContentTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(80f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidthPercent(80f);
     root_child0_child1.setHeight(20f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidthPercent(80f);
     root_child0_child2.setHeight(20f);
     root_child0.addChildAt(root_child0_child2, 2);
@@ -1525,13 +1464,11 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
@@ -1586,31 +1523,26 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root_child3.setHeight(10f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root_child4.setHeight(10f);
     root.addChildAt(root_child4, 4);
@@ -1695,13 +1627,11 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
@@ -1760,25 +1690,21 @@ public class YGAlignContentTest {
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setJustifyContent(YogaJustify.CENTER);
     root_child0.setAlignContent(YogaAlign.SPACE_BETWEEN);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(80f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidthPercent(80f);
     root_child0_child1.setHeight(20f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidthPercent(80f);
     root_child0_child2.setHeight(20f);
     root_child0.addChildAt(root_child0_child2, 2);
@@ -1857,7 +1783,6 @@ public class YGAlignContentTest {
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setJustifyContent(YogaJustify.CENTER);
     root_child0.setAlignContent(YogaAlign.SPACE_BETWEEN);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setHeight(10f);
     root_child0.setGap(YogaGutter.COLUMN, 10f);
@@ -1865,19 +1790,16 @@ public class YGAlignContentTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(80f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidthPercent(80f);
     root_child0_child1.setHeight(20f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidthPercent(80f);
     root_child0_child2.setHeight(20f);
     root_child0.addChildAt(root_child0_child2, 2);
@@ -1951,13 +1873,11 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
@@ -2012,31 +1932,26 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root_child3.setHeight(10f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root_child4.setHeight(10f);
     root.addChildAt(root_child4, 4);
@@ -2121,13 +2036,11 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
@@ -2186,25 +2099,21 @@ public class YGAlignContentTest {
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setJustifyContent(YogaJustify.CENTER);
     root_child0.setAlignContent(YogaAlign.SPACE_AROUND);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(80f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidthPercent(80f);
     root_child0_child1.setHeight(20f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidthPercent(80f);
     root_child0_child2.setHeight(20f);
     root_child0.addChildAt(root_child0_child2, 2);
@@ -2283,7 +2192,6 @@ public class YGAlignContentTest {
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setJustifyContent(YogaJustify.CENTER);
     root_child0.setAlignContent(YogaAlign.SPACE_AROUND);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setHeight(10f);
     root_child0.setGap(YogaGutter.COLUMN, 10f);
@@ -2291,19 +2199,16 @@ public class YGAlignContentTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(80f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidthPercent(80f);
     root_child0_child1.setHeight(20f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidthPercent(80f);
     root_child0_child2.setHeight(20f);
     root_child0.addChildAt(root_child0_child2, 2);
@@ -2377,13 +2282,11 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
@@ -2438,31 +2341,26 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root_child3.setHeight(10f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root_child4.setHeight(10f);
     root.addChildAt(root_child4, 4);
@@ -2547,13 +2445,11 @@ public class YGAlignContentTest {
     root.setHeight(120f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
@@ -2612,25 +2508,21 @@ public class YGAlignContentTest {
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setJustifyContent(YogaJustify.CENTER);
     root_child0.setAlignContent(YogaAlign.SPACE_EVENLY);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(80f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidthPercent(80f);
     root_child0_child1.setHeight(20f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidthPercent(80f);
     root_child0_child2.setHeight(20f);
     root_child0.addChildAt(root_child0_child2, 2);
@@ -2709,7 +2601,6 @@ public class YGAlignContentTest {
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setJustifyContent(YogaJustify.CENTER);
     root_child0.setAlignContent(YogaAlign.SPACE_EVENLY);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setHeight(10f);
     root_child0.setGap(YogaGutter.COLUMN, 10f);
@@ -2717,19 +2608,16 @@ public class YGAlignContentTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(80f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidthPercent(80f);
     root_child0_child1.setHeight(20f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidthPercent(80f);
     root_child0_child2.setHeight(20f);
     root_child0.addChildAt(root_child0_child2, 2);
@@ -2803,27 +2691,22 @@ public class YGAlignContentTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -2907,27 +2790,22 @@ public class YGAlignContentTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -3011,34 +2889,28 @@ public class YGAlignContentTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setFlexShrink(1f);
     root_child0_child0.setFlexBasisPercent(0f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -3132,12 +3004,10 @@ public class YGAlignContentTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexShrink(1f);
     root_child1.setFlexBasisPercent(0f);
@@ -3145,12 +3015,10 @@ public class YGAlignContentTest {
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setFlexGrow(1f);
     root_child3.setFlexShrink(1f);
     root_child3.setFlexBasisPercent(0f);
@@ -3158,7 +3026,6 @@ public class YGAlignContentTest {
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -3242,12 +3109,10 @@ public class YGAlignContentTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexShrink(1f);
     root_child1.setFlexBasisPercent(0f);
@@ -3255,19 +3120,16 @@ public class YGAlignContentTest {
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setFlexGrow(1f);
     root_child3.setFlexBasisPercent(0f);
     root_child3.setWidth(50f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -3351,12 +3213,10 @@ public class YGAlignContentTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setMargin(YogaEdge.LEFT, 10f);
     root_child1.setMargin(YogaEdge.TOP, 10f);
     root_child1.setMargin(YogaEdge.RIGHT, 10f);
@@ -3365,12 +3225,10 @@ public class YGAlignContentTest {
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setMargin(YogaEdge.LEFT, 10f);
     root_child3.setMargin(YogaEdge.TOP, 10f);
     root_child3.setMargin(YogaEdge.RIGHT, 10f);
@@ -3379,7 +3237,6 @@ public class YGAlignContentTest {
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -3463,12 +3320,10 @@ public class YGAlignContentTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setPadding(YogaEdge.LEFT, 10);
     root_child1.setPadding(YogaEdge.TOP, 10);
     root_child1.setPadding(YogaEdge.RIGHT, 10);
@@ -3477,12 +3332,10 @@ public class YGAlignContentTest {
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setPadding(YogaEdge.LEFT, 10);
     root_child3.setPadding(YogaEdge.TOP, 10);
     root_child3.setPadding(YogaEdge.RIGHT, 10);
@@ -3491,7 +3344,6 @@ public class YGAlignContentTest {
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -3575,12 +3427,10 @@ public class YGAlignContentTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -3634,28 +3484,23 @@ public class YGAlignContentTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(60f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -3739,28 +3584,23 @@ public class YGAlignContentTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setMaxHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -3844,28 +3684,23 @@ public class YGAlignContentTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setMinHeight(80f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(50f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -3948,19 +3783,16 @@ public class YGAlignContentTest {
     root.setHeight(150f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setFlexShrink(1f);
     root_child0_child0.setFlexBasisPercent(0f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexShrink(1f);
     root_child1.setFlexBasisPercent(0f);
@@ -3968,17 +3800,14 @@ public class YGAlignContentTest {
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setHeight(50f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setHeight(50f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setHeight(50f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -4071,14 +3900,12 @@ public class YGAlignContentTest {
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setAlignContent(YogaAlign.STRETCH);
     root_child0.setAlignItems(YogaAlign.CENTER);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
     root_child0_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(10f);
     root_child0_child0.setHeight(10f);
     root_child0.addChildAt(root_child0_child0, 0);

--- a/java/tests/com/facebook/yoga/YGAlignItemsTest.java
+++ b/java/tests/com/facebook/yoga/YGAlignItemsTest.java
@@ -36,7 +36,6 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
     root.setDirection(YogaDirection.LTR);
@@ -78,7 +77,6 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
@@ -121,7 +119,6 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
@@ -164,7 +161,6 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
@@ -208,13 +204,11 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
@@ -268,19 +262,16 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidth(50f);
     root_child1_child0.setHeight(10f);
     root_child1.addChildAt(root_child1_child0, 0);
@@ -344,39 +335,33 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
     root_child1.setFlexDirection(YogaFlexDirection.ROW);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWrap(YogaWrap.WRAP);
     root_child1.setWidth(50f);
     root_child1.setHeight(25f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidth(25f);
     root_child1_child0.setHeight(20f);
     root_child1.addChildAt(root_child1_child0, 0);
 
     final YogaNode root_child1_child1 = createNode(config);
-    root_child1_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child1.setWidth(25f);
     root_child1_child1.setHeight(10f);
     root_child1.addChildAt(root_child1_child1, 1);
 
     final YogaNode root_child1_child2 = createNode(config);
-    root_child1_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child2.setWidth(25f);
     root_child1_child2.setHeight(20f);
     root_child1.addChildAt(root_child1_child2, 2);
 
     final YogaNode root_child1_child3 = createNode(config);
-    root_child1_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child3.setWidth(25f);
     root_child1_child3.setHeight(10f);
     root_child1.addChildAt(root_child1_child3, 3);
@@ -470,41 +455,35 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
     root_child1.setFlexDirection(YogaFlexDirection.ROW);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWrap(YogaWrap.WRAP);
     root_child1.setWidth(50f);
     root_child1.setHeight(25f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidth(25f);
     root_child1_child0.setHeight(20f);
     root_child1.addChildAt(root_child1_child0, 0);
 
     final YogaNode root_child1_child1 = createNode(config);
     root_child1_child1.setAlignSelf(YogaAlign.BASELINE);
-    root_child1_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child1.setWidth(25f);
     root_child1_child1.setHeight(10f);
     root_child1.addChildAt(root_child1_child1, 1);
 
     final YogaNode root_child1_child2 = createNode(config);
-    root_child1_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child2.setWidth(25f);
     root_child1_child2.setHeight(20f);
     root_child1.addChildAt(root_child1_child2, 2);
 
     final YogaNode root_child1_child3 = createNode(config);
     root_child1_child3.setAlignSelf(YogaAlign.BASELINE);
-    root_child1_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child3.setWidth(25f);
     root_child1_child3.setHeight(10f);
     root_child1.addChildAt(root_child1_child3, 3);
@@ -598,40 +577,34 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
     root_child1.setFlexDirection(YogaFlexDirection.ROW);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWrap(YogaWrap.WRAP);
     root_child1.setWidth(50f);
     root_child1.setHeight(25f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidth(25f);
     root_child1_child0.setHeight(20f);
     root_child1.addChildAt(root_child1_child0, 0);
 
     final YogaNode root_child1_child1 = createNode(config);
-    root_child1_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child1.setWidth(25f);
     root_child1_child1.setHeight(10f);
     root_child1.addChildAt(root_child1_child1, 1);
 
     final YogaNode root_child1_child2 = createNode(config);
-    root_child1_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child2.setWidth(25f);
     root_child1_child2.setHeight(20f);
     root_child1.addChildAt(root_child1_child2, 2);
 
     final YogaNode root_child1_child3 = createNode(config);
     root_child1_child3.setAlignSelf(YogaAlign.BASELINE);
-    root_child1_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child3.setWidth(25f);
     root_child1_child3.setHeight(10f);
     root_child1.addChildAt(root_child1_child3, 3);
@@ -725,20 +698,17 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPosition(YogaEdge.TOP, 10f);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidth(50f);
     root_child1_child0.setHeight(10f);
     root_child1.addChildAt(root_child1_child0, 0);
@@ -802,20 +772,17 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setPosition(YogaEdge.TOP, 5f);
     root_child1.setWidth(50f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidth(50f);
     root_child1_child0.setHeight(10f);
     root_child1.addChildAt(root_child1_child0, 0);
@@ -879,25 +846,21 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(50f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidth(50f);
     root_child1_child0.setHeight(15f);
     root_child1.addChildAt(root_child1_child0, 0);
@@ -970,13 +933,11 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
@@ -1030,7 +991,6 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMargin(YogaEdge.LEFT, 5f);
     root_child0.setMargin(YogaEdge.TOP, 5f);
     root_child0.setMargin(YogaEdge.RIGHT, 5f);
@@ -1040,13 +1000,11 @@ public class YGAlignItemsTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setMargin(YogaEdge.LEFT, 1f);
     root_child1_child0.setMargin(YogaEdge.TOP, 1f);
     root_child1_child0.setMargin(YogaEdge.RIGHT, 1f);
@@ -1118,13 +1076,11 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setPadding(YogaEdge.LEFT, 5);
     root_child1.setPadding(YogaEdge.TOP, 5);
     root_child1.setPadding(YogaEdge.RIGHT, 5);
@@ -1134,7 +1090,6 @@ public class YGAlignItemsTest {
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidth(50f);
     root_child1_child0.setHeight(10f);
     root_child1.addChildAt(root_child1_child0, 0);
@@ -1199,37 +1154,31 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidth(50f);
     root_child1_child0.setHeight(10f);
     root_child1.addChildAt(root_child1_child0, 0);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root_child2.setHeight(20f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child2_child0 = createNode(config);
-    root_child2_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child2_child0.setWidth(50f);
     root_child2_child0.setHeight(10f);
     root_child2.addChildAt(root_child2_child0, 0);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root_child3.setHeight(50f);
     root.addChildAt(root_child3, 3);
@@ -1324,37 +1273,31 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(30f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidth(20f);
     root_child1_child0.setHeight(20f);
     root_child1.addChildAt(root_child1_child0, 0);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(40f);
     root_child2.setHeight(70f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child2_child0 = createNode(config);
-    root_child2_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child2_child0.setWidth(10f);
     root_child2_child0.setHeight(10f);
     root_child2.addChildAt(root_child2_child0, 0);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root_child3.setHeight(20f);
     root.addChildAt(root_child3, 3);
@@ -1449,37 +1392,31 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(30f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidth(20f);
     root_child1_child0.setHeight(20f);
     root_child1.addChildAt(root_child1_child0, 0);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(40f);
     root_child2.setHeight(70f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child2_child0 = createNode(config);
-    root_child2_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child2_child0.setWidth(10f);
     root_child2_child0.setHeight(10f);
     root_child2.addChildAt(root_child2_child0, 0);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root_child3.setHeight(20f);
     root.addChildAt(root_child3, 3);
@@ -1574,37 +1511,31 @@ public class YGAlignItemsTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidth(50f);
     root_child1_child0.setHeight(10f);
     root_child1.addChildAt(root_child1_child0, 0);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root_child2.setHeight(20f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child2_child0 = createNode(config);
-    root_child2_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child2_child0.setWidth(50f);
     root_child2_child0.setHeight(10f);
     root_child2.addChildAt(root_child2_child0, 0);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(50f);
     root_child3.setHeight(20f);
     root.addChildAt(root_child3, 3);
@@ -1699,11 +1630,9 @@ public class YGAlignItemsTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setAlignItems(YogaAlign.CENTER);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setMargin(YogaEdge.LEFT, 10f);
     root_child0_child0.setMargin(YogaEdge.RIGHT, 10f);
     root_child0_child0.setWidth(52f);
@@ -1760,11 +1689,9 @@ public class YGAlignItemsTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setAlignItems(YogaAlign.FLEX_END);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setMargin(YogaEdge.LEFT, 10f);
     root_child0_child0.setMargin(YogaEdge.RIGHT, 10f);
     root_child0_child0.setWidth(52f);
@@ -1821,11 +1748,9 @@ public class YGAlignItemsTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setAlignItems(YogaAlign.CENTER);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(72f);
     root_child0_child0.setHeight(72f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -1880,11 +1805,9 @@ public class YGAlignItemsTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setAlignItems(YogaAlign.FLEX_END);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(72f);
     root_child0_child0.setHeight(72f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -1939,18 +1862,15 @@ public class YGAlignItemsTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setJustifyContent(YogaJustify.CENTER);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexShrink(1f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setFlexShrink(1f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setWidth(20f);
     root_child0_child0_child0.setHeight(20f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -2014,18 +1934,15 @@ public class YGAlignItemsTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setJustifyContent(YogaJustify.CENTER);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexShrink(1f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setFlexShrink(1f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setWidth(20f);
     root_child0_child0_child0.setHeight(20f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -2088,17 +2005,14 @@ public class YGAlignItemsTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setAlignItems(YogaAlign.FLEX_START);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setFlexShrink(1f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setFlexGrow(1f);
     root_child0_child0_child0.setFlexShrink(1f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -2160,17 +2074,14 @@ public class YGAlignItemsTest {
     root.setHeight(500f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setFlexShrink(1f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setFlexGrow(1f);
     root_child0_child0_child0.setFlexShrink(1f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -2233,17 +2144,14 @@ public class YGAlignItemsTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setAlignItems(YogaAlign.FLEX_START);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setFlexShrink(1f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setFlexGrow(1f);
     root_child0_child0_child0.setFlexShrink(1f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);

--- a/java/tests/com/facebook/yoga/YGAlignSelfTest.java
+++ b/java/tests/com/facebook/yoga/YGAlignSelfTest.java
@@ -37,7 +37,6 @@ public class YGAlignSelfTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setAlignSelf(YogaAlign.CENTER);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
@@ -80,7 +79,6 @@ public class YGAlignSelfTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setAlignSelf(YogaAlign.FLEX_END);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
@@ -123,7 +121,6 @@ public class YGAlignSelfTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setAlignSelf(YogaAlign.FLEX_START);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
@@ -167,7 +164,6 @@ public class YGAlignSelfTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setAlignSelf(YogaAlign.FLEX_END);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
@@ -211,20 +207,17 @@ public class YGAlignSelfTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setAlignSelf(YogaAlign.BASELINE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
     root_child1.setAlignSelf(YogaAlign.BASELINE);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidth(50f);
     root_child1_child0.setHeight(10f);
     root_child1.addChildAt(root_child1_child0, 0);

--- a/java/tests/com/facebook/yoga/YGAndroidNewsFeed.java
+++ b/java/tests/com/facebook/yoga/YGAndroidNewsFeed.java
@@ -36,24 +36,20 @@ public class YGAndroidNewsFeed {
     root.setWidth(1080f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
     root_child0_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
     root_child0_child0_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0_child0 = createNode(config);
     root_child0_child0_child0_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0_child0_child0.setAlignContent(YogaAlign.STRETCH);
     root_child0_child0_child0_child0.setAlignItems(YogaAlign.FLEX_START);
-    root_child0_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0_child0.setMargin(YogaEdge.START, 36f);
     root_child0_child0_child0_child0.setMargin(YogaEdge.TOP, 24f);
     root_child0_child0_child0.addChildAt(root_child0_child0_child0_child0, 0);
@@ -61,19 +57,16 @@ public class YGAndroidNewsFeed {
     final YogaNode root_child0_child0_child0_child0_child0 = createNode(config);
     root_child0_child0_child0_child0_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0_child0_child0_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0_child0.addChildAt(root_child0_child0_child0_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0_child0_child0_child0 = createNode(config);
     root_child0_child0_child0_child0_child0_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child0_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0_child0_child0_child0.setWidth(120f);
     root_child0_child0_child0_child0_child0_child0.setHeight(120f);
     root_child0_child0_child0_child0_child0.addChildAt(root_child0_child0_child0_child0_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0_child0_child1 = createNode(config);
     root_child0_child0_child0_child0_child1.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child0_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0_child0_child1.setFlexShrink(1f);
     root_child0_child0_child0_child0_child1.setMargin(YogaEdge.RIGHT, 36f);
     root_child0_child0_child0_child0_child1.setPadding(YogaEdge.LEFT, 36);
@@ -85,26 +78,22 @@ public class YGAndroidNewsFeed {
     final YogaNode root_child0_child0_child0_child0_child1_child0 = createNode(config);
     root_child0_child0_child0_child0_child1_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0_child0_child0_child1_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child0_child0_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0_child0_child1_child0.setFlexShrink(1f);
     root_child0_child0_child0_child0_child1.addChildAt(root_child0_child0_child0_child0_child1_child0, 0);
 
     final YogaNode root_child0_child0_child0_child0_child1_child1 = createNode(config);
     root_child0_child0_child0_child0_child1_child1.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child0_child0_child1_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0_child0_child1_child1.setFlexShrink(1f);
     root_child0_child0_child0_child0_child1.addChildAt(root_child0_child0_child0_child0_child1_child1, 1);
 
     final YogaNode root_child0_child0_child1 = createNode(config);
     root_child0_child0_child1.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.addChildAt(root_child0_child0_child1, 1);
 
     final YogaNode root_child0_child0_child1_child0 = createNode(config);
     root_child0_child0_child1_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0_child1_child0.setAlignContent(YogaAlign.STRETCH);
     root_child0_child0_child1_child0.setAlignItems(YogaAlign.FLEX_START);
-    root_child0_child0_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child1_child0.setMargin(YogaEdge.START, 174f);
     root_child0_child0_child1_child0.setMargin(YogaEdge.TOP, 24f);
     root_child0_child0_child1.addChildAt(root_child0_child0_child1_child0, 0);
@@ -112,19 +101,16 @@ public class YGAndroidNewsFeed {
     final YogaNode root_child0_child0_child1_child0_child0 = createNode(config);
     root_child0_child0_child1_child0_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0_child1_child0_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child1_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child1_child0.addChildAt(root_child0_child0_child1_child0_child0, 0);
 
     final YogaNode root_child0_child0_child1_child0_child0_child0 = createNode(config);
     root_child0_child0_child1_child0_child0_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child1_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child1_child0_child0_child0.setWidth(72f);
     root_child0_child0_child1_child0_child0_child0.setHeight(72f);
     root_child0_child0_child1_child0_child0.addChildAt(root_child0_child0_child1_child0_child0_child0, 0);
 
     final YogaNode root_child0_child0_child1_child0_child1 = createNode(config);
     root_child0_child0_child1_child0_child1.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child1_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child1_child0_child1.setFlexShrink(1f);
     root_child0_child0_child1_child0_child1.setMargin(YogaEdge.RIGHT, 36f);
     root_child0_child0_child1_child0_child1.setPadding(YogaEdge.LEFT, 36);
@@ -136,13 +122,11 @@ public class YGAndroidNewsFeed {
     final YogaNode root_child0_child0_child1_child0_child1_child0 = createNode(config);
     root_child0_child0_child1_child0_child1_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0_child1_child0_child1_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child1_child0_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child1_child0_child1_child0.setFlexShrink(1f);
     root_child0_child0_child1_child0_child1.addChildAt(root_child0_child0_child1_child0_child1_child0, 0);
 
     final YogaNode root_child0_child0_child1_child0_child1_child1 = createNode(config);
     root_child0_child0_child1_child0_child1_child1.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child1_child0_child1_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child1_child0_child1_child1.setFlexShrink(1f);
     root_child0_child0_child1_child0_child1.addChildAt(root_child0_child0_child1_child0_child1_child1, 1);
     root.setDirection(YogaDirection.LTR);

--- a/java/tests/com/facebook/yoga/YGAspectRatioTest.java
+++ b/java/tests/com/facebook/yoga/YGAspectRatioTest.java
@@ -37,7 +37,6 @@ public class YGAspectRatioTest {
     root.setHeight(300f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setOverflow(YogaOverflow.SCROLL);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexShrink(1f);
@@ -46,11 +45,9 @@ public class YGAspectRatioTest {
 
     final YogaNode root_child0_child0 = createNode(config);
     root_child0_child0.setFlexDirection(YogaFlexDirection.ROW);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setFlexGrow(2f);
     root_child0_child0_child0.setFlexShrink(1f);
     root_child0_child0_child0.setFlexBasisPercent(0f);
@@ -58,19 +55,16 @@ public class YGAspectRatioTest {
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
 
     final YogaNode root_child0_child0_child1 = createNode(config);
-    root_child0_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child1.setWidth(5f);
     root_child0_child0.addChildAt(root_child0_child0_child1, 1);
 
     final YogaNode root_child0_child0_child2 = createNode(config);
-    root_child0_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child2.setFlexGrow(1f);
     root_child0_child0_child2.setFlexShrink(1f);
     root_child0_child0_child2.setFlexBasisPercent(0f);
     root_child0_child0.addChildAt(root_child0_child0_child2, 2);
 
     final YogaNode root_child0_child0_child2_child0 = createNode(config);
-    root_child0_child0_child2_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child2_child0.setFlexGrow(1f);
     root_child0_child0_child2_child0.setFlexShrink(1f);
     root_child0_child0_child2_child0.setFlexBasisPercent(0f);
@@ -78,12 +72,10 @@ public class YGAspectRatioTest {
     root_child0_child0_child2.addChildAt(root_child0_child0_child2_child0, 0);
 
     final YogaNode root_child0_child0_child2_child0_child0 = createNode(config);
-    root_child0_child0_child2_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child2_child0_child0.setWidth(5f);
     root_child0_child0_child2_child0.addChildAt(root_child0_child0_child2_child0_child0, 0);
 
     final YogaNode root_child0_child0_child2_child0_child1 = createNode(config);
-    root_child0_child0_child2_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child2_child0_child1.setFlexGrow(1f);
     root_child0_child0_child2_child0_child1.setFlexShrink(1f);
     root_child0_child0_child2_child0_child1.setFlexBasisPercent(0f);

--- a/java/tests/com/facebook/yoga/YGBorderTest.java
+++ b/java/tests/com/facebook/yoga/YGBorderTest.java
@@ -66,7 +66,6 @@ public class YGBorderTest {
     root.setBorder(YogaEdge.BOTTOM, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
@@ -112,7 +111,6 @@ public class YGBorderTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
@@ -158,7 +156,6 @@ public class YGBorderTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
     root.setDirection(YogaDirection.LTR);
@@ -204,7 +201,6 @@ public class YGBorderTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);

--- a/java/tests/com/facebook/yoga/YGDimensionTest.java
+++ b/java/tests/com/facebook/yoga/YGDimensionTest.java
@@ -34,7 +34,6 @@ public class YGDimensionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -74,11 +73,9 @@ public class YGDimensionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);

--- a/java/tests/com/facebook/yoga/YGDisplayTest.java
+++ b/java/tests/com/facebook/yoga/YGDisplayTest.java
@@ -37,12 +37,10 @@ public class YGDisplayTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setDisplay(YogaDisplay.NONE);
     root.addChildAt(root_child1, 1);
@@ -95,12 +93,10 @@ public class YGDisplayTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root_child1.setHeight(20f);
     root_child1.setDisplay(YogaDisplay.NONE);
@@ -154,7 +150,6 @@ public class YGDisplayTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMargin(YogaEdge.LEFT, 10f);
     root_child0.setMargin(YogaEdge.TOP, 10f);
     root_child0.setMargin(YogaEdge.RIGHT, 10f);
@@ -165,7 +160,6 @@ public class YGDisplayTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -217,14 +211,12 @@ public class YGDisplayTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexShrink(1f);
     root_child0.setFlexBasisPercent(0f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexShrink(1f);
     root_child1.setFlexBasisPercent(0f);
@@ -232,7 +224,6 @@ public class YGDisplayTest {
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setFlexGrow(1f);
     root_child1_child0.setFlexShrink(1f);
     root_child1_child0.setFlexBasisPercent(0f);
@@ -240,7 +231,6 @@ public class YGDisplayTest {
     root_child1.addChildAt(root_child1_child0, 0);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setFlexShrink(1f);
     root_child2.setFlexBasisPercent(0f);
@@ -314,12 +304,10 @@ public class YGDisplayTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setPosition(YogaEdge.TOP, 10f);
     root_child1.setDisplay(YogaDisplay.NONE);

--- a/java/tests/com/facebook/yoga/YGFlexDirectionTest.java
+++ b/java/tests/com/facebook/yoga/YGFlexDirectionTest.java
@@ -35,17 +35,14 @@ public class YGFlexDirectionTest {
     root.setWidth(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -106,17 +103,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -177,17 +171,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -249,17 +240,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -321,17 +309,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -393,17 +378,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -466,17 +448,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -539,17 +518,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -612,17 +588,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -685,17 +658,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -758,17 +728,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -831,17 +798,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -904,17 +868,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -977,17 +938,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1050,17 +1008,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1123,17 +1078,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1196,17 +1148,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1269,17 +1218,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1342,17 +1288,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1415,17 +1358,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1488,17 +1428,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1561,17 +1498,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1634,17 +1568,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1707,17 +1638,14 @@ public class YGFlexDirectionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1779,24 +1707,20 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPosition(YogaEdge.LEFT, 100f);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(10f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1868,24 +1792,20 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPosition(YogaEdge.START, 100f);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(10f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1957,24 +1877,20 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPosition(YogaEdge.RIGHT, 100f);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(10f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -2046,24 +1962,20 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPosition(YogaEdge.END, 100f);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(10f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -2135,24 +2047,20 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPosition(YogaEdge.TOP, 100f);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(10f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -2224,24 +2132,20 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPosition(YogaEdge.BOTTOM, 100f);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(10f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -2313,7 +2217,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -2326,12 +2229,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -2403,7 +2304,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -2416,12 +2316,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -2493,7 +2391,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -2506,12 +2403,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -2583,7 +2478,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -2596,12 +2490,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -2674,7 +2566,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -2687,12 +2578,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -2765,7 +2654,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -2778,12 +2666,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -2855,7 +2741,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -2868,12 +2753,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -2945,7 +2828,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -2958,12 +2840,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -3035,7 +2915,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -3048,12 +2927,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -3125,7 +3002,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -3138,12 +3014,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -3215,7 +3089,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -3228,12 +3101,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -3305,7 +3176,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -3318,12 +3188,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -3395,7 +3263,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -3408,12 +3275,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -3485,7 +3350,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -3498,12 +3362,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -3575,7 +3437,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -3588,12 +3449,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -3665,7 +3524,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -3678,12 +3536,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -3755,7 +3611,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -3768,12 +3623,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -3845,7 +3698,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -3858,12 +3710,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -3935,7 +3785,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -3948,12 +3797,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -4025,7 +3872,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -4038,12 +3884,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -4115,7 +3959,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -4128,12 +3971,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -4205,7 +4046,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.COLUMN_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -4218,12 +4058,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -4295,7 +4133,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -4308,12 +4145,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -4385,7 +4220,6 @@ public class YGFlexDirectionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW_REVERSE);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
@@ -4398,12 +4232,10 @@ public class YGFlexDirectionTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child2 = createNode(config);
-    root_child0_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child2.setWidth(10f);
     root_child0.addChildAt(root_child0_child2, 2);
     root.setDirection(YogaDirection.LTR);

--- a/java/tests/com/facebook/yoga/YGFlexTest.java
+++ b/java/tests/com/facebook/yoga/YGFlexTest.java
@@ -36,13 +36,11 @@ public class YGFlexTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasis(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -94,14 +92,12 @@ public class YGFlexTest {
     root.setHeight(500f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexShrink(1f);
     root_child0.setWidth(500f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexShrink(1f);
     root_child1.setWidth(500f);
     root_child1.setHeight(100f);
@@ -155,14 +151,12 @@ public class YGFlexTest {
     root.setHeight(500f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexShrink(1f);
     root_child0.setWidth(500f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexShrink(1f);
     root_child1.setWidth(500f);
@@ -217,13 +211,11 @@ public class YGFlexTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasis(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -274,13 +266,11 @@ public class YGFlexTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexShrink(1f);
     root_child0.setFlexBasis(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexBasis(50f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -332,13 +322,11 @@ public class YGFlexTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexShrink(1f);
     root_child0.setFlexBasis(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexBasis(50f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -388,20 +376,17 @@ public class YGFlexTest {
     root.setHeight(75f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexShrink(1f);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root_child2.setHeight(50f);
     root.addChildAt(root_child2, 2);
@@ -463,20 +448,17 @@ public class YGFlexTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasis(50f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
@@ -538,11 +520,9 @@ public class YGFlexTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setFlexShrink(1f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -594,18 +574,15 @@ public class YGFlexTest {
     root.setHeight(500f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(0.2f);
     root_child0.setFlexBasis(40f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(0.2f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(0.4f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);

--- a/java/tests/com/facebook/yoga/YGFlexWrapTest.java
+++ b/java/tests/com/facebook/yoga/YGFlexWrapTest.java
@@ -36,25 +36,21 @@ public class YGFlexWrapTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(30f);
     root_child0.setHeight(30f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(30f);
     root_child1.setHeight(30f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(30f);
     root_child2.setHeight(30f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(30f);
     root_child3.setHeight(30f);
     root.addChildAt(root_child3, 3);
@@ -127,25 +123,21 @@ public class YGFlexWrapTest {
     root.setWidth(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(30f);
     root_child0.setHeight(30f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(30f);
     root_child1.setHeight(30f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(30f);
     root_child2.setHeight(30f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(30f);
     root_child3.setHeight(30f);
     root.addChildAt(root_child3, 3);
@@ -219,25 +211,21 @@ public class YGFlexWrapTest {
     root.setWidth(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(30f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(30f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(30f);
     root_child2.setHeight(30f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(30f);
     root_child3.setHeight(30f);
     root.addChildAt(root_child3, 3);
@@ -311,25 +299,21 @@ public class YGFlexWrapTest {
     root.setWidth(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(30f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(30f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(30f);
     root_child2.setHeight(30f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(30f);
     root_child3.setHeight(30f);
     root.addChildAt(root_child3, 3);
@@ -402,14 +386,12 @@ public class YGFlexWrapTest {
     root.setWidth(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexBasis(50f);
     root_child0.setMinWidth(55f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexBasis(50f);
     root_child1.setMinWidth(55f);
     root_child1.setHeight(50f);
@@ -462,23 +444,19 @@ public class YGFlexWrapTest {
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setAlignItems(YogaAlign.FLEX_START);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setWidth(100f);
     root_child0_child0_child0.setHeight(100f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(100f);
     root_child1.setHeight(100f);
     root.addChildAt(root_child1, 1);
@@ -552,12 +530,10 @@ public class YGFlexWrapTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -609,31 +585,26 @@ public class YGFlexWrapTest {
     root.setWidth(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(30f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(30f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(30f);
     root_child2.setHeight(30f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(30f);
     root_child3.setHeight(40f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(30f);
     root_child4.setHeight(50f);
     root.addChildAt(root_child4, 4);
@@ -717,31 +688,26 @@ public class YGFlexWrapTest {
     root.setWidth(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(30f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(30f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(30f);
     root_child2.setHeight(30f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(30f);
     root_child3.setHeight(40f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(30f);
     root_child4.setHeight(50f);
     root.addChildAt(root_child4, 4);
@@ -824,31 +790,26 @@ public class YGFlexWrapTest {
     root.setWidth(300f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(30f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(30f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(30f);
     root_child2.setHeight(30f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(30f);
     root_child3.setHeight(40f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(30f);
     root_child4.setHeight(50f);
     root.addChildAt(root_child4, 4);
@@ -932,31 +893,26 @@ public class YGFlexWrapTest {
     root.setWidth(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(30f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(30f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(30f);
     root_child2.setHeight(30f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(30f);
     root_child3.setHeight(40f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(30f);
     root_child4.setHeight(50f);
     root.addChildAt(root_child4, 4);
@@ -1040,31 +996,26 @@ public class YGFlexWrapTest {
     root.setWidth(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(30f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(30f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(30f);
     root_child2.setHeight(30f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(30f);
     root_child3.setHeight(40f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(30f);
     root_child4.setHeight(50f);
     root.addChildAt(root_child4, 4);
@@ -1148,31 +1099,26 @@ public class YGFlexWrapTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(30f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(30f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(30f);
     root_child2.setHeight(30f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(30f);
     root_child3.setHeight(40f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(30f);
     root_child4.setHeight(50f);
     root.addChildAt(root_child4, 4);
@@ -1256,18 +1202,15 @@ public class YGFlexWrapTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(150f);
     root_child0_child0.setHeight(80f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(80f);
     root_child0_child1.setHeight(80f);
     root_child0.addChildAt(root_child0_child1, 1);
@@ -1331,18 +1274,15 @@ public class YGFlexWrapTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(150f);
     root_child0_child0.setHeight(80f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(80f);
     root_child0_child1.setHeight(80f);
     root_child0.addChildAt(root_child0_child1, 1);
@@ -1406,18 +1346,15 @@ public class YGFlexWrapTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(150f);
     root_child0_child0.setHeight(80f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(80f);
     root_child0_child1.setHeight(80f);
     root_child0.addChildAt(root_child0_child1, 1);
@@ -1483,14 +1420,12 @@ public class YGFlexWrapTest {
     root.setHeight(500f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(500f);
     root_child0.setMaxHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setMargin(YogaEdge.LEFT, 20f);
     root_child1.setMargin(YogaEdge.TOP, 20f);
     root_child1.setMargin(YogaEdge.RIGHT, 20f);
@@ -1500,7 +1435,6 @@ public class YGFlexWrapTest {
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(100f);
     root_child2.setHeight(100f);
     root.addChildAt(root_child2, 2);
@@ -1566,7 +1500,6 @@ public class YGFlexWrapTest {
     root.setHeight(500f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexShrink(1f);
     root_child0.setFlexBasisPercent(0f);
@@ -1576,7 +1509,6 @@ public class YGFlexWrapTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexShrink(1f);
     root_child1.setFlexBasisPercent(0f);
@@ -1589,7 +1521,6 @@ public class YGFlexWrapTest {
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(100f);
     root_child2.setHeight(100f);
     root.addChildAt(root_child2, 2);
@@ -1652,28 +1583,23 @@ public class YGFlexWrapTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setWidth(85f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setWidth(40f);
     root_child0_child0_child0.setHeight(40f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setMargin(YogaEdge.RIGHT, 10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child1_child0 = createNode(config);
-    root_child0_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1_child0.setWidth(40f);
     root_child0_child1_child0.setHeight(40f);
     root_child0_child1.addChildAt(root_child0_child1_child0, 0);
@@ -1756,28 +1682,23 @@ public class YGFlexWrapTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWrap(YogaWrap.WRAP);
     root_child0.setWidth(70f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setWidth(40f);
     root_child0_child0_child0.setHeight(40f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setMargin(YogaEdge.TOP, 10f);
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child0_child1_child0 = createNode(config);
-    root_child0_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1_child0.setWidth(40f);
     root_child0_child1_child0.setHeight(40f);
     root_child0_child1.addChildAt(root_child0_child1_child0, 0);

--- a/java/tests/com/facebook/yoga/YGGapTest.java
+++ b/java/tests/com/facebook/yoga/YGGapTest.java
@@ -39,21 +39,18 @@ public class YGGapTest {
     root.setGap(YogaGutter.ROW, 20f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexShrink(1f);
     root_child0.setFlexBasisPercent(0f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexShrink(1f);
     root_child1.setFlexBasisPercent(0f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setFlexShrink(1f);
     root_child2.setFlexBasisPercent(0f);
@@ -118,17 +115,14 @@ public class YGGapTest {
     root.setGap(YogaGutter.COLUMN, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -191,19 +185,16 @@ public class YGGapTest {
     root.setGap(YogaGutter.COLUMN, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexShrink(1f);
     root_child1.setFlexBasisPercent(0f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -266,7 +257,6 @@ public class YGGapTest {
     root.setGap(YogaGutter.COLUMN, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexShrink(1f);
     root_child0.setFlexBasisPercent(0f);
@@ -275,7 +265,6 @@ public class YGGapTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexShrink(1f);
     root_child1.setFlexBasisPercent(0f);
@@ -284,7 +273,6 @@ public class YGGapTest {
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setFlexShrink(1f);
     root_child2.setFlexBasisPercent(0f);
@@ -352,55 +340,46 @@ public class YGGapTest {
     root.setGap(YogaGutter.ROW, 20f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root_child2.setHeight(20f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(20f);
     root_child3.setHeight(20f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(20f);
     root_child4.setHeight(20f);
     root.addChildAt(root_child4, 4);
 
     final YogaNode root_child5 = createNode(config);
-    root_child5.setPositionType(YogaPositionType.RELATIVE);
     root_child5.setWidth(20f);
     root_child5.setHeight(20f);
     root.addChildAt(root_child5, 5);
 
     final YogaNode root_child6 = createNode(config);
-    root_child6.setPositionType(YogaPositionType.RELATIVE);
     root_child6.setWidth(20f);
     root_child6.setHeight(20f);
     root.addChildAt(root_child6, 6);
 
     final YogaNode root_child7 = createNode(config);
-    root_child7.setPositionType(YogaPositionType.RELATIVE);
     root_child7.setWidth(20f);
     root_child7.setHeight(20f);
     root.addChildAt(root_child7, 7);
 
     final YogaNode root_child8 = createNode(config);
-    root_child8.setPositionType(YogaPositionType.RELATIVE);
     root_child8.setWidth(20f);
     root_child8.setHeight(20f);
     root.addChildAt(root_child8, 8);
@@ -531,19 +510,16 @@ public class YGGapTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root_child2.setHeight(20f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(20f);
     root_child3.setHeight(20f);
     root.addChildAt(root_child3, 3);
@@ -617,17 +593,14 @@ public class YGGapTest {
     root.setGap(YogaGutter.COLUMN, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -691,17 +664,14 @@ public class YGGapTest {
     root.setGap(YogaGutter.COLUMN, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -765,17 +735,14 @@ public class YGGapTest {
     root.setGap(YogaGutter.COLUMN, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -839,17 +806,14 @@ public class YGGapTest {
     root.setGap(YogaGutter.COLUMN, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -913,17 +877,14 @@ public class YGGapTest {
     root.setGap(YogaGutter.COLUMN, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -987,17 +948,14 @@ public class YGGapTest {
     root.setGap(YogaGutter.COLUMN, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1062,37 +1020,31 @@ public class YGGapTest {
     root.setGap(YogaGutter.ROW, 20f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root_child2.setHeight(20f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(20f);
     root_child3.setHeight(20f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(20f);
     root_child4.setHeight(20f);
     root.addChildAt(root_child4, 4);
 
     final YogaNode root_child5 = createNode(config);
-    root_child5.setPositionType(YogaPositionType.RELATIVE);
     root_child5.setWidth(20f);
     root_child5.setHeight(20f);
     root.addChildAt(root_child5, 5);
@@ -1189,37 +1141,31 @@ public class YGGapTest {
     root.setGap(YogaGutter.ROW, 20f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root_child2.setHeight(20f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(20f);
     root_child3.setHeight(20f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(20f);
     root_child4.setHeight(20f);
     root.addChildAt(root_child4, 4);
 
     final YogaNode root_child5 = createNode(config);
-    root_child5.setPositionType(YogaPositionType.RELATIVE);
     root_child5.setWidth(20f);
     root_child5.setHeight(20f);
     root.addChildAt(root_child5, 5);
@@ -1316,37 +1262,31 @@ public class YGGapTest {
     root.setGap(YogaGutter.ROW, 20f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root_child2.setHeight(20f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(20f);
     root_child3.setHeight(20f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(20f);
     root_child4.setHeight(20f);
     root.addChildAt(root_child4, 4);
 
     final YogaNode root_child5 = createNode(config);
-    root_child5.setPositionType(YogaPositionType.RELATIVE);
     root_child5.setWidth(20f);
     root_child5.setHeight(20f);
     root.addChildAt(root_child5, 5);
@@ -1443,37 +1383,31 @@ public class YGGapTest {
     root.setGap(YogaGutter.ROW, 20f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root_child2.setHeight(20f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(20f);
     root_child3.setHeight(20f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(20f);
     root_child4.setHeight(20f);
     root.addChildAt(root_child4, 4);
 
     final YogaNode root_child5 = createNode(config);
-    root_child5.setPositionType(YogaPositionType.RELATIVE);
     root_child5.setWidth(20f);
     root_child5.setHeight(20f);
     root.addChildAt(root_child5, 5);
@@ -1570,37 +1504,31 @@ public class YGGapTest {
     root.setGap(YogaGutter.ROW, 20f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root_child2.setHeight(20f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(20f);
     root_child3.setHeight(20f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(20f);
     root_child4.setHeight(20f);
     root.addChildAt(root_child4, 4);
 
     final YogaNode root_child5 = createNode(config);
-    root_child5.setPositionType(YogaPositionType.RELATIVE);
     root_child5.setWidth(20f);
     root_child5.setHeight(20f);
     root.addChildAt(root_child5, 5);
@@ -1696,31 +1624,26 @@ public class YGGapTest {
     root.setGap(YogaGutter.COLUMN, 5f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setMinWidth(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setMinWidth(60f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setMinWidth(60f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setFlexGrow(1f);
     root_child3.setMinWidth(60f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setFlexGrow(1f);
     root_child4.setMinWidth(60f);
     root.addChildAt(root_child4, 4);
@@ -1803,17 +1726,14 @@ public class YGGapTest {
     root.setGap(YogaGutter.COLUMN, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(30f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1879,32 +1799,26 @@ public class YGGapTest {
     root.setGap(YogaGutter.ROW, 20f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(20f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(20f);
     root.addChildAt(root_child4, 4);
 
     final YogaNode root_child5 = createNode(config);
-    root_child5.setPositionType(YogaPositionType.RELATIVE);
     root_child5.setWidth(20f);
     root.addChildAt(root_child5, 5);
     root.setDirection(YogaDirection.LTR);
@@ -2000,32 +1914,26 @@ public class YGGapTest {
     root.setGap(YogaGutter.ROW, 20f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(20f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setWidth(20f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setWidth(20f);
     root.addChildAt(root_child4, 4);
 
     final YogaNode root_child5 = createNode(config);
-    root_child5.setPositionType(YogaPositionType.RELATIVE);
     root_child5.setWidth(20f);
     root.addChildAt(root_child5, 5);
     root.setDirection(YogaDirection.LTR);
@@ -2117,7 +2025,6 @@ public class YGGapTest {
     root.setGap(YogaGutter.ROW, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexShrink(1f);
     root_child0.setFlexBasisPercent(0f);
@@ -2126,7 +2033,6 @@ public class YGGapTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexShrink(1f);
     root_child1.setFlexBasisPercent(0f);
@@ -2135,7 +2041,6 @@ public class YGGapTest {
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setFlexShrink(1f);
     root_child2.setFlexBasisPercent(0f);
@@ -2203,21 +2108,18 @@ public class YGGapTest {
     root.setGap(YogaGutter.ROW, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMargin(YogaEdge.TOP, 2f);
     root_child0.setMargin(YogaEdge.BOTTOM, 2f);
     root_child0.setWidth(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setMargin(YogaEdge.TOP, 10f);
     root_child1.setMargin(YogaEdge.BOTTOM, 10f);
     root_child1.setWidth(60f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setMargin(YogaEdge.TOP, 15f);
     root_child2.setMargin(YogaEdge.BOTTOM, 15f);
     root_child2.setWidth(60f);
@@ -2280,17 +2182,14 @@ public class YGGapTest {
     root.setGap(YogaGutter.ROW, 10f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(20f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setHeight(30f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);

--- a/java/tests/com/facebook/yoga/YGJustifyContentTest.java
+++ b/java/tests/com/facebook/yoga/YGJustifyContentTest.java
@@ -37,17 +37,14 @@ public class YGJustifyContentTest {
     root.setHeight(102f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -110,17 +107,14 @@ public class YGJustifyContentTest {
     root.setHeight(102f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -183,17 +177,14 @@ public class YGJustifyContentTest {
     root.setHeight(102f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -256,17 +247,14 @@ public class YGJustifyContentTest {
     root.setHeight(102f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -329,17 +317,14 @@ public class YGJustifyContentTest {
     root.setHeight(102f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -400,17 +385,14 @@ public class YGJustifyContentTest {
     root.setHeight(102f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -472,17 +454,14 @@ public class YGJustifyContentTest {
     root.setHeight(102f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -544,17 +523,14 @@ public class YGJustifyContentTest {
     root.setHeight(102f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -616,17 +592,14 @@ public class YGJustifyContentTest {
     root.setHeight(102f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -688,17 +661,14 @@ public class YGJustifyContentTest {
     root.setHeight(102f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -761,7 +731,6 @@ public class YGJustifyContentTest {
     root.setMinWidth(50f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
@@ -806,7 +775,6 @@ public class YGJustifyContentTest {
     root.setMaxWidth(80f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
@@ -849,7 +817,6 @@ public class YGJustifyContentTest {
     root.setMinHeight(50f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
@@ -893,7 +860,6 @@ public class YGJustifyContentTest {
     root.setMaxHeight(80f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(20f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
@@ -936,17 +902,14 @@ public class YGJustifyContentTest {
     root.setHeight(102f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1009,17 +972,14 @@ public class YGJustifyContentTest {
     root.setHeight(102f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1083,14 +1043,12 @@ public class YGJustifyContentTest {
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
     root_child0_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0.setJustifyContent(YogaJustify.CENTER);
     root_child0_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setPadding(YogaEdge.LEFT, 100);
     root_child0_child0.setPadding(YogaEdge.RIGHT, 100);
     root_child0_child0.setMinWidth(400f);
@@ -1099,7 +1057,6 @@ public class YGJustifyContentTest {
     final YogaNode root_child0_child0_child0 = createNode(config);
     root_child0_child0_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setWidth(300f);
     root_child0_child0_child0.setHeight(100f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -1164,14 +1121,12 @@ public class YGJustifyContentTest {
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
     root_child0_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0.setJustifyContent(YogaJustify.CENTER);
     root_child0_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setPadding(YogaEdge.LEFT, 100);
     root_child0_child0.setPadding(YogaEdge.RIGHT, 100);
     root_child0_child0.setMinWidth(400f);
@@ -1180,7 +1135,6 @@ public class YGJustifyContentTest {
     final YogaNode root_child0_child0_child0 = createNode(config);
     root_child0_child0_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0_child0.setAlignContent(YogaAlign.STRETCH);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setWidth(199f);
     root_child0_child0_child0.setHeight(100f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -1244,18 +1198,15 @@ public class YGJustifyContentTest {
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0.setJustifyContent(YogaJustify.SPACE_BETWEEN);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMinWidth(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(50f);
     root_child0_child0.setHeight(50f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(50f);
     root_child0_child1.setHeight(50f);
     root_child0.addChildAt(root_child0_child1, 1);

--- a/java/tests/com/facebook/yoga/YGMarginTest.java
+++ b/java/tests/com/facebook/yoga/YGMarginTest.java
@@ -37,7 +37,6 @@ public class YGMarginTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMargin(YogaEdge.START, 10f);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
@@ -79,7 +78,6 @@ public class YGMarginTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMargin(YogaEdge.TOP, 10f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
@@ -123,7 +121,6 @@ public class YGMarginTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMargin(YogaEdge.END, 10f);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
@@ -166,7 +163,6 @@ public class YGMarginTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMargin(YogaEdge.BOTTOM, 10f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
@@ -209,7 +205,6 @@ public class YGMarginTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setMargin(YogaEdge.START, 10f);
     root_child0.setMargin(YogaEdge.END, 10f);
@@ -252,7 +247,6 @@ public class YGMarginTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setMargin(YogaEdge.TOP, 10f);
     root_child0.setMargin(YogaEdge.BOTTOM, 10f);
@@ -296,7 +290,6 @@ public class YGMarginTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setMargin(YogaEdge.TOP, 10f);
     root_child0.setMargin(YogaEdge.BOTTOM, 10f);
@@ -339,7 +332,6 @@ public class YGMarginTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setMargin(YogaEdge.START, 10f);
     root_child0.setMargin(YogaEdge.END, 10f);
@@ -383,13 +375,11 @@ public class YGMarginTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setMargin(YogaEdge.END, 10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -440,13 +430,11 @@ public class YGMarginTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setMargin(YogaEdge.BOTTOM, 10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -498,14 +486,12 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.BOTTOM);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -558,14 +544,12 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.TOP);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -618,7 +602,6 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.TOP);
     root_child0.setMarginAuto(YogaEdge.BOTTOM);
     root_child0.setWidth(50f);
@@ -626,7 +609,6 @@ public class YGMarginTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -679,7 +661,6 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.TOP);
     root_child0.setMarginAuto(YogaEdge.BOTTOM);
     root_child0.setWidth(50f);
@@ -687,7 +668,6 @@ public class YGMarginTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -740,21 +720,18 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.TOP);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setMarginAuto(YogaEdge.TOP);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root_child2.setHeight(50f);
     root.addChildAt(root_child2, 2);
@@ -818,21 +795,18 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.RIGHT);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setMarginAuto(YogaEdge.RIGHT);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root_child2.setHeight(50f);
     root.addChildAt(root_child2, 2);
@@ -896,7 +870,6 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.LEFT);
     root_child0.setMarginAuto(YogaEdge.RIGHT);
     root_child0.setWidth(50f);
@@ -904,7 +877,6 @@ public class YGMarginTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -956,7 +928,6 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.LEFT);
     root_child0.setMarginAuto(YogaEdge.RIGHT);
     root_child0.setWidth(50f);
@@ -964,7 +935,6 @@ public class YGMarginTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -1018,7 +988,6 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.START);
     root_child0.setMarginAuto(YogaEdge.END);
     root_child0.setWidth(50f);
@@ -1026,7 +995,6 @@ public class YGMarginTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -1078,7 +1046,6 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.START);
     root_child0.setMarginAuto(YogaEdge.END);
     root_child0.setWidth(50f);
@@ -1086,7 +1053,6 @@ public class YGMarginTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -1139,7 +1105,6 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.LEFT);
     root_child0.setMarginAuto(YogaEdge.RIGHT);
     root_child0.setWidth(50f);
@@ -1147,7 +1112,6 @@ public class YGMarginTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -1200,14 +1164,12 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.LEFT);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -1260,14 +1222,12 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.RIGHT);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -1320,7 +1280,6 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.LEFT);
     root_child0.setMarginAuto(YogaEdge.RIGHT);
     root_child0.setWidth(50f);
@@ -1328,7 +1287,6 @@ public class YGMarginTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -1380,7 +1338,6 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.TOP);
     root_child0.setMarginAuto(YogaEdge.BOTTOM);
     root_child0.setWidth(50f);
@@ -1388,7 +1345,6 @@ public class YGMarginTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -1440,7 +1396,6 @@ public class YGMarginTest {
     root.setHeight(250f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMargin(YogaEdge.TOP, 20f);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
@@ -1484,7 +1439,6 @@ public class YGMarginTest {
     root.setHeight(250f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMargin(YogaEdge.LEFT, 20f);
     root_child0.setWidth(100f);
     root_child0.setMaxWidth(100f);
@@ -1529,7 +1483,6 @@ public class YGMarginTest {
     root.setHeight(52f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.LEFT);
     root_child0.setMarginAuto(YogaEdge.RIGHT);
     root_child0.setWidth(72f);
@@ -1574,7 +1527,6 @@ public class YGMarginTest {
     root.setHeight(52f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.LEFT);
     root_child0.setWidth(72f);
     root_child0.setHeight(72f);
@@ -1618,7 +1570,6 @@ public class YGMarginTest {
     root.setHeight(52f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMargin(YogaEdge.LEFT, 10f);
     root_child0.setMarginAuto(YogaEdge.RIGHT);
     root_child0.setWidth(72f);
@@ -1663,7 +1614,6 @@ public class YGMarginTest {
     root.setHeight(52f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMarginAuto(YogaEdge.LEFT);
     root_child0.setMargin(YogaEdge.RIGHT, 10f);
     root_child0.setWidth(72f);
@@ -1708,7 +1658,6 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexShrink(1f);
     root_child0.setFlexBasisPercent(0f);
@@ -1716,7 +1665,6 @@ public class YGMarginTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
@@ -1769,7 +1717,6 @@ public class YGMarginTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexShrink(1f);
     root_child0.setFlexBasisPercent(0f);
@@ -1777,7 +1724,6 @@ public class YGMarginTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);

--- a/java/tests/com/facebook/yoga/YGMinMaxDimensionTest.java
+++ b/java/tests/com/facebook/yoga/YGMinMaxDimensionTest.java
@@ -36,7 +36,6 @@ public class YGMinMaxDimensionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMaxWidth(50f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
@@ -79,7 +78,6 @@ public class YGMinMaxDimensionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root_child0.setMaxHeight(50f);
     root.addChildAt(root_child0, 0);
@@ -122,13 +120,11 @@ public class YGMinMaxDimensionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setMinHeight(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -181,13 +177,11 @@ public class YGMinMaxDimensionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setMinWidth(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -240,7 +234,6 @@ public class YGMinMaxDimensionTest {
     root.setMaxHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(60f);
     root_child0.setHeight(60f);
     root.addChildAt(root_child0, 0);
@@ -284,7 +277,6 @@ public class YGMinMaxDimensionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(60f);
     root_child0.setHeight(60f);
     root.addChildAt(root_child0, 0);
@@ -327,19 +319,16 @@ public class YGMinMaxDimensionTest {
     root.setMaxHeight(110f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(50f);
     root_child0.setHeight(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(50f);
     root_child2.setHeight(50f);
     root.addChildAt(root_child2, 2);
@@ -402,13 +391,11 @@ public class YGMinMaxDimensionTest {
     root.setMaxHeight(500f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexShrink(1f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -462,11 +449,9 @@ public class YGMinMaxDimensionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setFlexBasis(0f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -517,7 +502,6 @@ public class YGMinMaxDimensionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasis(0f);
     root_child0.setHeight(100f);
@@ -560,12 +544,10 @@ public class YGMinMaxDimensionTest {
     root.setMaxHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -617,12 +599,10 @@ public class YGMinMaxDimensionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMaxWidth(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -675,12 +655,10 @@ public class YGMinMaxDimensionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMaxWidth(300f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setHeight(20f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -734,13 +712,11 @@ public class YGMinMaxDimensionTest {
     root.setMaxHeight(500f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasis(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(100f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -792,20 +768,17 @@ public class YGMinMaxDimensionTest {
     root.setMaxHeight(500f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setMinHeight(100f);
     root_child0.setMaxHeight(500f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setFlexBasis(200f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setHeight(100f);
     root_child0.addChildAt(root_child0_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -866,20 +839,17 @@ public class YGMinMaxDimensionTest {
     root.setHeight(500f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setMinHeight(100f);
     root_child0.setMaxHeight(500f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setFlexBasis(200f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setHeight(100f);
     root_child0.addChildAt(root_child0_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -941,12 +911,10 @@ public class YGMinMaxDimensionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setWidth(50f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -996,12 +964,10 @@ public class YGMinMaxDimensionTest {
     root.setMinHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -1052,19 +1018,16 @@ public class YGMinMaxDimensionTest {
 
     final YogaNode root_child0 = createNode(config);
     root_child0.setFlexDirection(YogaFlexDirection.ROW);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMaxWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexShrink(1f);
     root_child0_child0.setFlexBasis(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidth(50f);
     root_child0.addChildAt(root_child0_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -1125,13 +1088,11 @@ public class YGMinMaxDimensionTest {
     root.setMaxHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexShrink(1f);
     root_child0.setFlexBasis(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setHeight(50f);
     root.addChildAt(root_child1, 1);
     root.setDirection(YogaDirection.LTR);
@@ -1183,14 +1144,12 @@ public class YGMinMaxDimensionTest {
     root.setHeight(50f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasis(0f);
     root_child0.setMinWidth(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexBasisPercent(50f);
     root_child1.setMaxWidth(20f);
@@ -1348,7 +1307,6 @@ public class YGMinMaxDimensionTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setMinWidthPercent(10f);
     root_child0.setMaxWidthPercent(10f);
     root_child0.setMinHeightPercent(10f);

--- a/java/tests/com/facebook/yoga/YGPaddingTest.java
+++ b/java/tests/com/facebook/yoga/YGPaddingTest.java
@@ -66,7 +66,6 @@ public class YGPaddingTest {
     root.setPadding(YogaEdge.BOTTOM, 10);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
@@ -112,7 +111,6 @@ public class YGPaddingTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
@@ -158,7 +156,6 @@ public class YGPaddingTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
     root.setDirection(YogaDirection.LTR);
@@ -204,7 +201,6 @@ public class YGPaddingTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(10f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
@@ -248,7 +244,6 @@ public class YGPaddingTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPadding(YogaEdge.LEFT, 20);
     root_child0.setPadding(YogaEdge.TOP, 20);
     root_child0.setPadding(YogaEdge.RIGHT, 20);

--- a/java/tests/com/facebook/yoga/YGPercentageTest.java
+++ b/java/tests/com/facebook/yoga/YGPercentageTest.java
@@ -37,7 +37,6 @@ public class YGPercentageTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidthPercent(30f);
     root_child0.setHeightPercent(30f);
     root.addChildAt(root_child0, 0);
@@ -80,7 +79,6 @@ public class YGPercentageTest {
     root.setHeight(400f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPositionPercent(YogaEdge.LEFT, 10f);
     root_child0.setPositionPercent(YogaEdge.TOP, 20f);
     root_child0.setWidthPercent(45f);
@@ -125,7 +123,6 @@ public class YGPercentageTest {
     root.setHeight(500f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPositionPercent(YogaEdge.RIGHT, 20f);
     root_child0.setPositionPercent(YogaEdge.BOTTOM, 10f);
     root_child0.setWidthPercent(55f);
@@ -170,13 +167,11 @@ public class YGPercentageTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasisPercent(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexBasisPercent(25f);
     root.addChildAt(root_child1, 1);
@@ -228,13 +223,11 @@ public class YGPercentageTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasisPercent(50f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setFlexBasisPercent(25f);
     root.addChildAt(root_child1, 1);
@@ -287,13 +280,11 @@ public class YGPercentageTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setMinHeightPercent(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(2f);
     root_child1.setMinHeightPercent(10f);
     root.addChildAt(root_child1, 1);
@@ -346,14 +337,12 @@ public class YGPercentageTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasisPercent(10f);
     root_child0.setMaxHeightPercent(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(4f);
     root_child1.setFlexBasisPercent(10f);
     root_child1.setMaxHeightPercent(20f);
@@ -406,14 +395,12 @@ public class YGPercentageTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasisPercent(10f);
     root_child0.setMaxHeightPercent(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(4f);
     root_child1.setFlexBasisPercent(10f);
     root_child1.setMaxHeightPercent(20f);
@@ -467,14 +454,12 @@ public class YGPercentageTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasisPercent(15f);
     root_child0.setMaxWidthPercent(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(4f);
     root_child1.setFlexBasisPercent(10f);
     root_child1.setMaxWidthPercent(20f);
@@ -527,14 +512,12 @@ public class YGPercentageTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasisPercent(10f);
     root_child0.setMaxWidthPercent(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(4f);
     root_child1.setFlexBasisPercent(15f);
     root_child1.setMaxWidthPercent(20f);
@@ -588,14 +571,12 @@ public class YGPercentageTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasisPercent(15f);
     root_child0.setMinWidthPercent(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(4f);
     root_child1.setFlexBasisPercent(10f);
     root_child1.setMinWidthPercent(20f);
@@ -648,14 +629,12 @@ public class YGPercentageTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasisPercent(10f);
     root_child0.setMinWidthPercent(60f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(4f);
     root_child1.setFlexBasisPercent(15f);
     root_child1.setMinWidthPercent(20f);
@@ -708,7 +687,6 @@ public class YGPercentageTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasisPercent(10f);
     root_child0.setMargin(YogaEdge.LEFT, 5f);
@@ -723,7 +701,6 @@ public class YGPercentageTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setMargin(YogaEdge.LEFT, 5f);
     root_child0_child0.setMargin(YogaEdge.TOP, 5f);
     root_child0_child0.setMargin(YogaEdge.RIGHT, 5f);
@@ -736,7 +713,6 @@ public class YGPercentageTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setMarginPercent(YogaEdge.LEFT, 5f);
     root_child0_child0_child0.setMarginPercent(YogaEdge.TOP, 5f);
     root_child0_child0_child0.setMarginPercent(YogaEdge.RIGHT, 5f);
@@ -749,7 +725,6 @@ public class YGPercentageTest {
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(4f);
     root_child1.setFlexBasisPercent(15f);
     root_child1.setMinWidthPercent(20f);
@@ -822,7 +797,6 @@ public class YGPercentageTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setMarginPercent(YogaEdge.LEFT, 10f);
     root_child0.setMarginPercent(YogaEdge.TOP, 10f);
@@ -831,7 +805,6 @@ public class YGPercentageTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(10f);
     root_child0_child0.setHeight(10f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -883,7 +856,6 @@ public class YGPercentageTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setPaddingPercent(YogaEdge.LEFT, 10);
     root_child0.setPaddingPercent(YogaEdge.TOP, 10);
@@ -892,7 +864,6 @@ public class YGPercentageTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(10f);
     root_child0_child0.setHeight(10f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -986,7 +957,6 @@ public class YGPercentageTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidthPercent(50f);
     root_child0.setHeightPercent(50f);
     root.addChildAt(root_child0, 0);
@@ -1029,22 +999,18 @@ public class YGPercentageTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setWidthPercent(100f);
     root_child1.addChildAt(root_child1_child0, 0);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setWidth(100f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -1117,24 +1083,20 @@ public class YGPercentageTest {
     root.setHeight(200f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
     root_child0_child0.setFlexDirection(YogaFlexDirection.ROW);
     root_child0_child0.setJustifyContent(YogaJustify.CENTER);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setWidth(50f);
     root_child0_child0_child0.setHeight(50f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
 
     final YogaNode root_child0_child0_child1 = createNode(config);
-    root_child0_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child1.setWidth(50f);
     root_child0_child0_child1.setHeight(50f);
     root_child0_child0.addChildAt(root_child0_child0_child1, 1);
@@ -1214,12 +1176,10 @@ public class YGPercentageTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setWidthPercent(100f);
     root_child0.addChildAt(root_child0_child1, 1);
     root.setDirection(YogaDirection.LTR);

--- a/java/tests/com/facebook/yoga/YGRoundingTest.java
+++ b/java/tests/com/facebook/yoga/YGRoundingTest.java
@@ -37,17 +37,14 @@ public class YGRoundingTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -109,27 +106,22 @@ public class YGRoundingTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root.addChildAt(root_child2, 2);
 
     final YogaNode root_child3 = createNode(config);
-    root_child3.setPositionType(YogaPositionType.RELATIVE);
     root_child3.setFlexGrow(1f);
     root.addChildAt(root_child3, 3);
 
     final YogaNode root_child4 = createNode(config);
-    root_child4.setPositionType(YogaPositionType.RELATIVE);
     root_child4.setFlexGrow(1f);
     root.addChildAt(root_child4, 4);
     root.setDirection(YogaDirection.LTR);
@@ -211,18 +203,15 @@ public class YGRoundingTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexShrink(1f);
     root_child0.setFlexBasis(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexBasis(25f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexBasis(25f);
     root.addChildAt(root_child2, 2);
     root.setDirection(YogaDirection.LTR);
@@ -283,20 +272,17 @@ public class YGRoundingTest {
     root.setHeight(113f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasis(50f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
@@ -358,20 +344,17 @@ public class YGRoundingTest {
     root.setHeight(113.4f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(0.7f);
     root_child0.setFlexBasis(50.3f);
     root_child0.setHeight(20.3f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1.6f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1.1f);
     root_child2.setHeight(10.7f);
     root.addChildAt(root_child2, 2);
@@ -433,14 +416,12 @@ public class YGRoundingTest {
     root.setHeight(113.4f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(0.7f);
     root_child0.setFlexBasis(50.3f);
     root_child0.setHeight(20.3f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setFlexGrow(1f);
     root_child0_child0.setFlexBasis(0.3f);
     root_child0_child0.setPosition(YogaEdge.BOTTOM, 13.3f);
@@ -448,7 +429,6 @@ public class YGRoundingTest {
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child1 = createNode(config);
-    root_child0_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child1.setFlexGrow(4f);
     root_child0_child1.setFlexBasis(0.3f);
     root_child0_child1.setPosition(YogaEdge.TOP, 13.3f);
@@ -456,13 +436,11 @@ public class YGRoundingTest {
     root_child0.addChildAt(root_child0_child1, 1);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1.6f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1.1f);
     root_child2.setHeight(10.7f);
     root.addChildAt(root_child2, 2);
@@ -544,20 +522,17 @@ public class YGRoundingTest {
     root.setHeight(113.4f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasis(50f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
@@ -619,20 +594,17 @@ public class YGRoundingTest {
     root.setHeight(113.6f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasis(50f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
@@ -695,20 +667,17 @@ public class YGRoundingTest {
     root.setHeight(113.4f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasis(50f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
@@ -771,20 +740,17 @@ public class YGRoundingTest {
     root.setHeight(113.4f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setFlexBasis(50f);
     root_child0.setHeight(20f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
@@ -846,25 +812,21 @@ public class YGRoundingTest {
     root.setWidth(320f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setHeight(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setHeight(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setFlexGrow(1f);
     root_child1_child0.setHeight(10f);
     root_child1.addChildAt(root_child1_child0, 0);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setHeight(10f);
     root.addChildAt(root_child2, 2);
@@ -935,25 +897,21 @@ public class YGRoundingTest {
     root.setHeight(320f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setWidth(10f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setWidth(10f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setFlexGrow(1f);
     root_child1_child0.setWidth(10f);
     root_child1.addChildAt(root_child1_child0, 0);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setWidth(10f);
     root.addChildAt(root_child2, 2);
@@ -1026,43 +984,36 @@ public class YGRoundingTest {
     root.setHeight(320f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setFlexGrow(1f);
     root_child0.setHeightPercent(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child1 = createNode(config);
-    root_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1.setFlexGrow(1f);
     root_child1.setHeightPercent(100f);
     root.addChildAt(root_child1, 1);
 
     final YogaNode root_child1_child0 = createNode(config);
-    root_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child0.setFlexGrow(1f);
     root_child1_child0.setWidthPercent(100f);
     root_child1.addChildAt(root_child1_child0, 0);
 
     final YogaNode root_child1_child1 = createNode(config);
-    root_child1_child1.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child1.setFlexGrow(1f);
     root_child1_child1.setWidthPercent(100f);
     root_child1.addChildAt(root_child1_child1, 1);
 
     final YogaNode root_child1_child1_child0 = createNode(config);
-    root_child1_child1_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child1_child0.setFlexGrow(1f);
     root_child1_child1_child0.setWidthPercent(100f);
     root_child1_child1.addChildAt(root_child1_child1_child0, 0);
 
     final YogaNode root_child1_child2 = createNode(config);
-    root_child1_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child1_child2.setFlexGrow(1f);
     root_child1_child2.setWidthPercent(100f);
     root_child1.addChildAt(root_child1_child2, 2);
 
     final YogaNode root_child2 = createNode(config);
-    root_child2.setPositionType(YogaPositionType.RELATIVE);
     root_child2.setFlexGrow(1f);
     root_child2.setHeightPercent(100f);
     root.addChildAt(root_child2, 2);

--- a/java/tests/com/facebook/yoga/YGSizeOverflowTest.java
+++ b/java/tests/com/facebook/yoga/YGSizeOverflowTest.java
@@ -36,11 +36,9 @@ public class YGSizeOverflowTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(200f);
     root_child0_child0.setHeight(200f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -92,13 +90,11 @@ public class YGSizeOverflowTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root_child0.setHeight(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(200f);
     root_child0_child0.setHeight(200f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -150,12 +146,10 @@ public class YGSizeOverflowTest {
     root.setHeight(100f);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(100f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(200f);
     root_child0.addChildAt(root_child0_child0, 0);

--- a/java/tests/com/facebook/yoga/YGStaticPositionTest.java
+++ b/java/tests/com/facebook/yoga/YGStaticPositionTest.java
@@ -35,6 +35,7 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
+    root_child0.setPositionType(YogaPositionType.STATIC);
     root_child0.setPosition(YogaEdge.LEFT, 50f);
     root_child0.setPosition(YogaEdge.TOP, 50f);
     root_child0.setWidth(100f);
@@ -77,6 +78,7 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
+    root_child0.setPositionType(YogaPositionType.STATIC);
     root_child0.setPosition(YogaEdge.RIGHT, 50f);
     root_child0.setPosition(YogaEdge.BOTTOM, 50f);
     root_child0.setWidth(100f);
@@ -119,12 +121,12 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setMargin(YogaEdge.LEFT, 100f);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
@@ -194,30 +196,33 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setMargin(YogaEdge.LEFT, 100f);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0_child0.setMargin(YogaEdge.LEFT, 100f);
     root_child0_child0_child0.setWidth(100f);
     root_child0_child0_child0.setHeight(100f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0_child0_child0.setMargin(YogaEdge.LEFT, 100f);
     root_child0_child0_child0_child0.setWidth(100f);
     root_child0_child0_child0_child0.setHeight(100f);
     root_child0_child0_child0.addChildAt(root_child0_child0_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0_child0_child0_child0.setMargin(YogaEdge.LEFT, 100f);
     root_child0_child0_child0_child0_child0.setWidth(100f);
     root_child0_child0_child0_child0_child0.setHeight(100f);
@@ -317,12 +322,12 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -389,18 +394,17 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setWidthPercent(50f);
     root_child0_child0_child0.setHeight(50f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -461,17 +465,18 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0_child0.setWidthPercent(50f);
     root_child0_child0_child0.setHeight(50f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -532,12 +537,12 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -604,18 +609,17 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setWidth(50f);
     root_child0_child0_child0.setHeightPercent(50f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -676,17 +680,18 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0_child0.setWidth(50f);
     root_child0_child0_child0.setHeightPercent(50f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -747,12 +752,12 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -820,18 +825,17 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setPositionPercent(YogaEdge.LEFT, 50f);
     root_child0_child0_child0.setWidth(50f);
     root_child0_child0_child0.setHeight(50f);
@@ -893,17 +897,18 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0_child0.setPositionPercent(YogaEdge.LEFT, 50f);
     root_child0_child0_child0.setWidth(50f);
     root_child0_child0_child0.setHeight(50f);
@@ -965,12 +970,12 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -1038,18 +1043,17 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setPositionPercent(YogaEdge.RIGHT, 50f);
     root_child0_child0_child0.setWidth(50f);
     root_child0_child0_child0.setHeight(50f);
@@ -1111,17 +1115,18 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0_child0.setPositionPercent(YogaEdge.RIGHT, 50f);
     root_child0_child0_child0.setWidth(50f);
     root_child0_child0_child0.setHeight(50f);
@@ -1183,12 +1188,12 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -1256,18 +1261,17 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setPositionPercent(YogaEdge.TOP, 50f);
     root_child0_child0_child0.setWidth(50f);
     root_child0_child0_child0.setHeight(50f);
@@ -1329,17 +1333,18 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0_child0.setPositionPercent(YogaEdge.TOP, 50f);
     root_child0_child0_child0.setWidth(50f);
     root_child0_child0_child0.setHeight(50f);
@@ -1401,12 +1406,12 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -1474,18 +1479,17 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setPositionPercent(YogaEdge.BOTTOM, 50f);
     root_child0_child0_child0.setWidth(50f);
     root_child0_child0_child0.setHeight(50f);
@@ -1547,17 +1551,18 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0_child0.setPositionPercent(YogaEdge.BOTTOM, 50f);
     root_child0_child0_child0.setWidth(50f);
     root_child0_child0_child0.setHeight(50f);
@@ -1619,12 +1624,12 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -1695,18 +1700,17 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setMarginPercent(YogaEdge.LEFT, 50f);
     root_child0_child0_child0.setMarginPercent(YogaEdge.TOP, 50f);
     root_child0_child0_child0.setMarginPercent(YogaEdge.RIGHT, 50f);
@@ -1771,17 +1775,18 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0_child0.setMarginPercent(YogaEdge.LEFT, 50f);
     root_child0_child0_child0.setMarginPercent(YogaEdge.TOP, 50f);
     root_child0_child0_child0.setMarginPercent(YogaEdge.RIGHT, 50f);
@@ -1846,12 +1851,12 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -1922,18 +1927,17 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setPaddingPercent(YogaEdge.LEFT, 50);
     root_child0_child0_child0.setPaddingPercent(YogaEdge.TOP, 50);
     root_child0_child0_child0.setPaddingPercent(YogaEdge.RIGHT, 50);
@@ -1998,17 +2002,18 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0_child0.setPaddingPercent(YogaEdge.LEFT, 50);
     root_child0_child0_child0.setPaddingPercent(YogaEdge.TOP, 50);
     root_child0_child0_child0.setPaddingPercent(YogaEdge.RIGHT, 50);
@@ -2073,12 +2078,12 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -2145,18 +2150,17 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setWidth(50f);
     root_child0_child0_child0.setHeight(50f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -2217,17 +2221,18 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setWidth(200f);
     root_child0.setHeight(200f);
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0_child0.setWidth(50f);
     root_child0_child0_child0.setHeight(50f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -2288,7 +2293,6 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPadding(YogaEdge.LEFT, 100);
     root_child0.setPadding(YogaEdge.TOP, 100);
     root_child0.setPadding(YogaEdge.RIGHT, 100);
@@ -2298,6 +2302,7 @@ public class YGStaticPositionTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -2364,7 +2369,6 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPadding(YogaEdge.LEFT, 100);
     root_child0.setPadding(YogaEdge.TOP, 100);
     root_child0.setPadding(YogaEdge.RIGHT, 100);
@@ -2374,12 +2378,12 @@ public class YGStaticPositionTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
-    root_child0_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0_child0.setWidthPercent(50f);
     root_child0_child0_child0.setHeight(50f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -2440,7 +2444,6 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPadding(YogaEdge.LEFT, 100);
     root_child0.setPadding(YogaEdge.TOP, 100);
     root_child0.setPadding(YogaEdge.RIGHT, 100);
@@ -2450,11 +2453,13 @@ public class YGStaticPositionTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidth(100f);
     root_child0_child0.setHeight(100f);
     root_child0.addChildAt(root_child0_child0, 0);
 
     final YogaNode root_child0_child0_child0 = createNode(config);
+    root_child0_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0_child0.setWidthPercent(50f);
     root_child0_child0_child0.setHeight(50f);
     root_child0_child0.addChildAt(root_child0_child0_child0, 0);
@@ -2515,7 +2520,6 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPadding(YogaEdge.LEFT, 100);
     root_child0.setPadding(YogaEdge.TOP, 100);
     root_child0.setPadding(YogaEdge.RIGHT, 100);
@@ -2576,7 +2580,6 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPadding(YogaEdge.LEFT, 100);
     root_child0.setPadding(YogaEdge.TOP, 100);
     root_child0.setPadding(YogaEdge.RIGHT, 100);
@@ -2586,7 +2589,6 @@ public class YGStaticPositionTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
-    root_child0_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0_child0.setWidthPercent(50f);
     root_child0_child0.setHeight(50f);
     root_child0.addChildAt(root_child0_child0, 0);
@@ -2637,7 +2639,6 @@ public class YGStaticPositionTest {
     root.setPositionType(YogaPositionType.ABSOLUTE);
 
     final YogaNode root_child0 = createNode(config);
-    root_child0.setPositionType(YogaPositionType.RELATIVE);
     root_child0.setPadding(YogaEdge.LEFT, 100);
     root_child0.setPadding(YogaEdge.TOP, 100);
     root_child0.setPadding(YogaEdge.RIGHT, 100);
@@ -2647,6 +2648,7 @@ public class YGStaticPositionTest {
     root.addChildAt(root_child0, 0);
 
     final YogaNode root_child0_child0 = createNode(config);
+    root_child0_child0.setPositionType(YogaPositionType.STATIC);
     root_child0_child0.setWidthPercent(50f);
     root_child0_child0.setHeight(50f);
     root_child0.addChildAt(root_child0_child0, 0);

--- a/java/tests/com/facebook/yoga/YogaNodeStylePropertiesTest.java
+++ b/java/tests/com/facebook/yoga/YogaNodeStylePropertiesTest.java
@@ -191,7 +191,7 @@ public class YogaNodeStylePropertiesTest {
   public void testPositionTypeDefault() {
     final YogaNode node = createNode();
 
-    assertEquals(YogaPositionType.STATIC, node.getPositionType());
+    assertEquals(YogaPositionType.RELATIVE, node.getPositionType());
   }
 
   @Test

--- a/javascript/tests/generated/YGAbsolutePositionTest.test.ts
+++ b/javascript/tests/generated/YGAbsolutePositionTest.test.ts
@@ -248,7 +248,6 @@ test('do_not_clamp_height_of_absolute_node_to_height_of_its_overflow_hidden_pare
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
@@ -1205,7 +1204,6 @@ test('percent_absolute_position_infinite_height', () => {
     root.setWidth(300);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(300);
     root.insertChild(root_child0, 0);
 
@@ -1317,7 +1315,6 @@ test('absolute_layout_percentage_height_based_on_padded_parent_and_align_items_c
     root = Yoga.Node.create(config);
     root.setJustifyContent(Justify.Center);
     root.setAlignItems(Align.Center);
-    root.setPositionType(PositionType.Relative);
     root.setPadding(Edge.Top, 20);
     root.setPadding(Edge.Bottom, 20);
     root.setWidth(100);

--- a/javascript/tests/generated/YGAlignContentTest.test.ts
+++ b/javascript/tests/generated/YGAlignContentTest.test.ts
@@ -39,13 +39,11 @@ test('align_content_flex_start_nowrap', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
@@ -105,31 +103,26 @@ test('align_content_flex_start_wrap', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root_child3.setHeight(10);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root_child4.setHeight(10);
     root.insertChild(root_child4, 4);
@@ -219,13 +212,11 @@ test('align_content_flex_start_wrap_singleline', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
@@ -289,25 +280,21 @@ test('align_content_flex_start_wrapped_negative_space', () => {
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setJustifyContent(Justify.Center);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("80%");
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth("80%");
     root_child0_child1.setHeight(20);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth("80%");
     root_child0_child2.setHeight(20);
     root_child0.insertChild(root_child0_child2, 2);
@@ -391,7 +378,6 @@ test('align_content_flex_start_wrapped_negative_space_gap', () => {
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setJustifyContent(Justify.Center);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setHeight(10);
     root_child0.setGap(Gutter.Column, 10);
@@ -399,19 +385,16 @@ test('align_content_flex_start_wrapped_negative_space_gap', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("80%");
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth("80%");
     root_child0_child1.setHeight(20);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth("80%");
     root_child0_child2.setHeight(20);
     root_child0.insertChild(root_child0_child2, 2);
@@ -490,29 +473,24 @@ test('align_content_flex_start_without_height_on_children', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root_child3.setHeight(10);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -600,14 +578,12 @@ test('align_content_flex_start_with_flex', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis("0%");
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexBasis("0%");
     root_child1.setWidth(50);
@@ -615,12 +591,10 @@ test('align_content_flex_start_with_flex', () => {
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setFlexGrow(1);
     root_child3.setFlexShrink(1);
     root_child3.setFlexBasis("0%");
@@ -628,7 +602,6 @@ test('align_content_flex_start_with_flex', () => {
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -717,13 +690,11 @@ test('align_content_flex_end_nowrap', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
@@ -784,31 +755,26 @@ test('align_content_flex_end_wrap', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root_child3.setHeight(10);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root_child4.setHeight(10);
     root.insertChild(root_child4, 4);
@@ -899,13 +865,11 @@ test('align_content_flex_end_wrap_singleline', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
@@ -970,25 +934,21 @@ test('align_content_flex_end_wrapped_negative_space', () => {
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setJustifyContent(Justify.Center);
     root_child0.setAlignContent(Align.FlexEnd);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("80%");
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth("80%");
     root_child0_child1.setHeight(20);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth("80%");
     root_child0_child2.setHeight(20);
     root_child0.insertChild(root_child0_child2, 2);
@@ -1073,7 +1033,6 @@ test('align_content_flex_end_wrapped_negative_space_gap', () => {
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setJustifyContent(Justify.Center);
     root_child0.setAlignContent(Align.FlexEnd);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setHeight(10);
     root_child0.setGap(Gutter.Column, 10);
@@ -1081,19 +1040,16 @@ test('align_content_flex_end_wrapped_negative_space_gap', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("80%");
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth("80%");
     root_child0_child1.setHeight(20);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth("80%");
     root_child0_child2.setHeight(20);
     root_child0.insertChild(root_child0_child2, 2);
@@ -1173,13 +1129,11 @@ test('align_content_center_nowrap', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
@@ -1240,31 +1194,26 @@ test('align_content_center_wrap', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root_child3.setHeight(10);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root_child4.setHeight(10);
     root.insertChild(root_child4, 4);
@@ -1355,13 +1304,11 @@ test('align_content_center_wrap_singleline', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
@@ -1426,25 +1373,21 @@ test('align_content_center_wrapped_negative_space', () => {
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setJustifyContent(Justify.Center);
     root_child0.setAlignContent(Align.Center);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("80%");
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth("80%");
     root_child0_child1.setHeight(20);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth("80%");
     root_child0_child2.setHeight(20);
     root_child0.insertChild(root_child0_child2, 2);
@@ -1529,7 +1472,6 @@ test('align_content_center_wrapped_negative_space_gap', () => {
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setJustifyContent(Justify.Center);
     root_child0.setAlignContent(Align.Center);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setHeight(10);
     root_child0.setGap(Gutter.Column, 10);
@@ -1537,19 +1479,16 @@ test('align_content_center_wrapped_negative_space_gap', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("80%");
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth("80%");
     root_child0_child1.setHeight(20);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth("80%");
     root_child0_child2.setHeight(20);
     root_child0.insertChild(root_child0_child2, 2);
@@ -1629,13 +1568,11 @@ test('align_content_space_between_nowrap', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
@@ -1696,31 +1633,26 @@ test('align_content_space_between_wrap', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root_child3.setHeight(10);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root_child4.setHeight(10);
     root.insertChild(root_child4, 4);
@@ -1811,13 +1743,11 @@ test('align_content_space_between_wrap_singleline', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
@@ -1882,25 +1812,21 @@ test('align_content_space_between_wrapped_negative_space', () => {
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setJustifyContent(Justify.Center);
     root_child0.setAlignContent(Align.SpaceBetween);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("80%");
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth("80%");
     root_child0_child1.setHeight(20);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth("80%");
     root_child0_child2.setHeight(20);
     root_child0.insertChild(root_child0_child2, 2);
@@ -1985,7 +1911,6 @@ test('align_content_space_between_wrapped_negative_space_gap', () => {
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setJustifyContent(Justify.Center);
     root_child0.setAlignContent(Align.SpaceBetween);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setHeight(10);
     root_child0.setGap(Gutter.Column, 10);
@@ -1993,19 +1918,16 @@ test('align_content_space_between_wrapped_negative_space_gap', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("80%");
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth("80%");
     root_child0_child1.setHeight(20);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth("80%");
     root_child0_child2.setHeight(20);
     root_child0.insertChild(root_child0_child2, 2);
@@ -2085,13 +2007,11 @@ test('align_content_space_around_nowrap', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
@@ -2152,31 +2072,26 @@ test('align_content_space_around_wrap', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root_child3.setHeight(10);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root_child4.setHeight(10);
     root.insertChild(root_child4, 4);
@@ -2267,13 +2182,11 @@ test('align_content_space_around_wrap_singleline', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
@@ -2338,25 +2251,21 @@ test('align_content_space_around_wrapped_negative_space', () => {
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setJustifyContent(Justify.Center);
     root_child0.setAlignContent(Align.SpaceAround);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("80%");
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth("80%");
     root_child0_child1.setHeight(20);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth("80%");
     root_child0_child2.setHeight(20);
     root_child0.insertChild(root_child0_child2, 2);
@@ -2441,7 +2350,6 @@ test('align_content_space_around_wrapped_negative_space_gap', () => {
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setJustifyContent(Justify.Center);
     root_child0.setAlignContent(Align.SpaceAround);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setHeight(10);
     root_child0.setGap(Gutter.Column, 10);
@@ -2449,19 +2357,16 @@ test('align_content_space_around_wrapped_negative_space_gap', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("80%");
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth("80%");
     root_child0_child1.setHeight(20);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth("80%");
     root_child0_child2.setHeight(20);
     root_child0.insertChild(root_child0_child2, 2);
@@ -2541,13 +2446,11 @@ test('align_content_space_evenly_nowrap', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
@@ -2608,31 +2511,26 @@ test('align_content_space_evenly_wrap', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root_child3.setHeight(10);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root_child4.setHeight(10);
     root.insertChild(root_child4, 4);
@@ -2723,13 +2621,11 @@ test('align_content_space_evenly_wrap_singleline', () => {
     root.setHeight(120);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
@@ -2794,25 +2690,21 @@ test('align_content_space_evenly_wrapped_negative_space', () => {
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setJustifyContent(Justify.Center);
     root_child0.setAlignContent(Align.SpaceEvenly);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("80%");
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth("80%");
     root_child0_child1.setHeight(20);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth("80%");
     root_child0_child2.setHeight(20);
     root_child0.insertChild(root_child0_child2, 2);
@@ -2897,7 +2789,6 @@ test('align_content_space_evenly_wrapped_negative_space_gap', () => {
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setJustifyContent(Justify.Center);
     root_child0.setAlignContent(Align.SpaceEvenly);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setHeight(10);
     root_child0.setGap(Gutter.Column, 10);
@@ -2905,19 +2796,16 @@ test('align_content_space_evenly_wrapped_negative_space_gap', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("80%");
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth("80%");
     root_child0_child1.setHeight(20);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth("80%");
     root_child0_child2.setHeight(20);
     root_child0.insertChild(root_child0_child2, 2);
@@ -2997,27 +2885,22 @@ test('align_content_stretch', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3107,27 +2990,22 @@ test('align_content_stretch_row', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3217,34 +3095,28 @@ test('align_content_stretch_row_with_children', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setFlexShrink(1);
     root_child0_child0.setFlexBasis("0%");
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3344,12 +3216,10 @@ test('align_content_stretch_row_with_flex', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexShrink(1);
     root_child1.setFlexBasis("0%");
@@ -3357,12 +3227,10 @@ test('align_content_stretch_row_with_flex', () => {
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setFlexGrow(1);
     root_child3.setFlexShrink(1);
     root_child3.setFlexBasis("0%");
@@ -3370,7 +3238,6 @@ test('align_content_stretch_row_with_flex', () => {
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3460,12 +3327,10 @@ test('align_content_stretch_row_with_flex_no_shrink', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexShrink(1);
     root_child1.setFlexBasis("0%");
@@ -3473,19 +3338,16 @@ test('align_content_stretch_row_with_flex_no_shrink', () => {
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setFlexGrow(1);
     root_child3.setFlexBasis("0%");
     root_child3.setWidth(50);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3575,12 +3437,10 @@ test('align_content_stretch_row_with_margin', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setMargin(Edge.Left, 10);
     root_child1.setMargin(Edge.Top, 10);
     root_child1.setMargin(Edge.Right, 10);
@@ -3589,12 +3449,10 @@ test('align_content_stretch_row_with_margin', () => {
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setMargin(Edge.Left, 10);
     root_child3.setMargin(Edge.Top, 10);
     root_child3.setMargin(Edge.Right, 10);
@@ -3603,7 +3461,6 @@ test('align_content_stretch_row_with_margin', () => {
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3693,12 +3550,10 @@ test('align_content_stretch_row_with_padding', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setPadding(Edge.Left, 10);
     root_child1.setPadding(Edge.Top, 10);
     root_child1.setPadding(Edge.Right, 10);
@@ -3707,12 +3562,10 @@ test('align_content_stretch_row_with_padding', () => {
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setPadding(Edge.Left, 10);
     root_child3.setPadding(Edge.Top, 10);
     root_child3.setPadding(Edge.Right, 10);
@@ -3721,7 +3574,6 @@ test('align_content_stretch_row_with_padding', () => {
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3811,12 +3663,10 @@ test('align_content_stretch_row_with_single_row', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3876,28 +3726,23 @@ test('align_content_stretch_row_with_fixed_height', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(60);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3987,28 +3832,23 @@ test('align_content_stretch_row_with_max_height', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setMaxHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -4098,28 +3938,23 @@ test('align_content_stretch_row_with_min_height', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setMinHeight(80);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(50);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -4208,19 +4043,16 @@ test('align_content_stretch_column', () => {
     root.setHeight(150);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setFlexShrink(1);
     root_child0_child0.setFlexBasis("0%");
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexShrink(1);
     root_child1.setFlexBasis("0%");
@@ -4228,17 +4060,14 @@ test('align_content_stretch_column', () => {
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setHeight(50);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setHeight(50);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setHeight(50);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -4337,14 +4166,12 @@ test('align_content_stretch_is_not_overriding_align_items', () => {
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setAlignContent(Align.Stretch);
     root_child0.setAlignItems(Align.Center);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
     root_child0_child0.setAlignContent(Align.Stretch);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(10);
     root_child0_child0.setHeight(10);
     root_child0.insertChild(root_child0_child0, 0);

--- a/javascript/tests/generated/YGAlignItemsTest.test.ts
+++ b/javascript/tests/generated/YGAlignItemsTest.test.ts
@@ -38,7 +38,6 @@ test('align_items_stretch', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -86,7 +85,6 @@ test('align_items_center', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
@@ -135,7 +133,6 @@ test('align_items_flex_start', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
@@ -184,7 +181,6 @@ test('align_items_flex_end', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
@@ -234,13 +230,11 @@ test('align_baseline', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
@@ -300,19 +294,16 @@ test('align_baseline_child', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth(50);
     root_child1_child0.setHeight(10);
     root_child1.insertChild(root_child1_child0, 0);
@@ -382,39 +373,33 @@ test('align_baseline_child_multiline', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(60);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
     root_child1.setFlexDirection(FlexDirection.Row);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexWrap(Wrap.Wrap);
     root_child1.setWidth(50);
     root_child1.setHeight(25);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth(25);
     root_child1_child0.setHeight(20);
     root_child1.insertChild(root_child1_child0, 0);
 
     const root_child1_child1 = Yoga.Node.create(config);
-    root_child1_child1.setPositionType(PositionType.Relative);
     root_child1_child1.setWidth(25);
     root_child1_child1.setHeight(10);
     root_child1.insertChild(root_child1_child1, 1);
 
     const root_child1_child2 = Yoga.Node.create(config);
-    root_child1_child2.setPositionType(PositionType.Relative);
     root_child1_child2.setWidth(25);
     root_child1_child2.setHeight(20);
     root_child1.insertChild(root_child1_child2, 2);
 
     const root_child1_child3 = Yoga.Node.create(config);
-    root_child1_child3.setPositionType(PositionType.Relative);
     root_child1_child3.setWidth(25);
     root_child1_child3.setHeight(10);
     root_child1.insertChild(root_child1_child3, 3);
@@ -514,41 +499,35 @@ test('align_baseline_child_multiline_override', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(60);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
     root_child1.setFlexDirection(FlexDirection.Row);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexWrap(Wrap.Wrap);
     root_child1.setWidth(50);
     root_child1.setHeight(25);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth(25);
     root_child1_child0.setHeight(20);
     root_child1.insertChild(root_child1_child0, 0);
 
     const root_child1_child1 = Yoga.Node.create(config);
     root_child1_child1.setAlignSelf(Align.Baseline);
-    root_child1_child1.setPositionType(PositionType.Relative);
     root_child1_child1.setWidth(25);
     root_child1_child1.setHeight(10);
     root_child1.insertChild(root_child1_child1, 1);
 
     const root_child1_child2 = Yoga.Node.create(config);
-    root_child1_child2.setPositionType(PositionType.Relative);
     root_child1_child2.setWidth(25);
     root_child1_child2.setHeight(20);
     root_child1.insertChild(root_child1_child2, 2);
 
     const root_child1_child3 = Yoga.Node.create(config);
     root_child1_child3.setAlignSelf(Align.Baseline);
-    root_child1_child3.setPositionType(PositionType.Relative);
     root_child1_child3.setWidth(25);
     root_child1_child3.setHeight(10);
     root_child1.insertChild(root_child1_child3, 3);
@@ -648,40 +627,34 @@ test('align_baseline_child_multiline_no_override_on_secondline', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(60);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
     root_child1.setFlexDirection(FlexDirection.Row);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexWrap(Wrap.Wrap);
     root_child1.setWidth(50);
     root_child1.setHeight(25);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth(25);
     root_child1_child0.setHeight(20);
     root_child1.insertChild(root_child1_child0, 0);
 
     const root_child1_child1 = Yoga.Node.create(config);
-    root_child1_child1.setPositionType(PositionType.Relative);
     root_child1_child1.setWidth(25);
     root_child1_child1.setHeight(10);
     root_child1.insertChild(root_child1_child1, 1);
 
     const root_child1_child2 = Yoga.Node.create(config);
-    root_child1_child2.setPositionType(PositionType.Relative);
     root_child1_child2.setWidth(25);
     root_child1_child2.setHeight(20);
     root_child1.insertChild(root_child1_child2, 2);
 
     const root_child1_child3 = Yoga.Node.create(config);
     root_child1_child3.setAlignSelf(Align.Baseline);
-    root_child1_child3.setPositionType(PositionType.Relative);
     root_child1_child3.setWidth(25);
     root_child1_child3.setHeight(10);
     root_child1.insertChild(root_child1_child3, 3);
@@ -781,20 +754,17 @@ test('align_baseline_child_top', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPosition(Edge.Top, 10);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth(50);
     root_child1_child0.setHeight(10);
     root_child1.insertChild(root_child1_child0, 0);
@@ -864,20 +834,17 @@ test('align_baseline_child_top2', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setPosition(Edge.Top, 5);
     root_child1.setWidth(50);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth(50);
     root_child1_child0.setHeight(10);
     root_child1.insertChild(root_child1_child0, 0);
@@ -947,25 +914,21 @@ test('align_baseline_double_nested_child', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(50);
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth(50);
     root_child1_child0.setHeight(15);
     root_child1.insertChild(root_child1_child0, 0);
@@ -1044,13 +1007,11 @@ test('align_baseline_column', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
@@ -1110,7 +1071,6 @@ test('align_baseline_child_margin', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Left, 5);
     root_child0.setMargin(Edge.Top, 5);
     root_child0.setMargin(Edge.Right, 5);
@@ -1120,13 +1080,11 @@ test('align_baseline_child_margin', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setMargin(Edge.Left, 1);
     root_child1_child0.setMargin(Edge.Top, 1);
     root_child1_child0.setMargin(Edge.Right, 1);
@@ -1204,13 +1162,11 @@ test('align_baseline_child_padding', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setPadding(Edge.Left, 5);
     root_child1.setPadding(Edge.Top, 5);
     root_child1.setPadding(Edge.Right, 5);
@@ -1220,7 +1176,6 @@ test('align_baseline_child_padding', () => {
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth(50);
     root_child1_child0.setHeight(10);
     root_child1.insertChild(root_child1_child0, 0);
@@ -1291,37 +1246,31 @@ test('align_baseline_multiline', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth(50);
     root_child1_child0.setHeight(10);
     root_child1.insertChild(root_child1_child0, 0);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root_child2.setHeight(20);
     root.insertChild(root_child2, 2);
 
     const root_child2_child0 = Yoga.Node.create(config);
-    root_child2_child0.setPositionType(PositionType.Relative);
     root_child2_child0.setWidth(50);
     root_child2_child0.setHeight(10);
     root_child2.insertChild(root_child2_child0, 0);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root_child3.setHeight(50);
     root.insertChild(root_child3, 3);
@@ -1421,37 +1370,31 @@ test.skip('align_baseline_multiline_column', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(30);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth(20);
     root_child1_child0.setHeight(20);
     root_child1.insertChild(root_child1_child0, 0);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(40);
     root_child2.setHeight(70);
     root.insertChild(root_child2, 2);
 
     const root_child2_child0 = Yoga.Node.create(config);
-    root_child2_child0.setPositionType(PositionType.Relative);
     root_child2_child0.setWidth(10);
     root_child2_child0.setHeight(10);
     root_child2.insertChild(root_child2_child0, 0);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root_child3.setHeight(20);
     root.insertChild(root_child3, 3);
@@ -1551,37 +1494,31 @@ test.skip('align_baseline_multiline_column2', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(30);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth(20);
     root_child1_child0.setHeight(20);
     root_child1.insertChild(root_child1_child0, 0);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(40);
     root_child2.setHeight(70);
     root.insertChild(root_child2, 2);
 
     const root_child2_child0 = Yoga.Node.create(config);
-    root_child2_child0.setPositionType(PositionType.Relative);
     root_child2_child0.setWidth(10);
     root_child2_child0.setHeight(10);
     root_child2.insertChild(root_child2_child0, 0);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root_child3.setHeight(20);
     root.insertChild(root_child3, 3);
@@ -1682,37 +1619,31 @@ test('align_baseline_multiline_row_and_column', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth(50);
     root_child1_child0.setHeight(10);
     root_child1.insertChild(root_child1_child0, 0);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root_child2.setHeight(20);
     root.insertChild(root_child2, 2);
 
     const root_child2_child0 = Yoga.Node.create(config);
-    root_child2_child0.setPositionType(PositionType.Relative);
     root_child2_child0.setWidth(50);
     root_child2_child0.setHeight(10);
     root_child2.insertChild(root_child2_child0, 0);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(50);
     root_child3.setHeight(20);
     root.insertChild(root_child3, 3);
@@ -1813,11 +1744,9 @@ test('align_items_center_child_with_margin_bigger_than_parent', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setAlignItems(Align.Center);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setMargin(Edge.Left, 10);
     root_child0_child0.setMargin(Edge.Right, 10);
     root_child0_child0.setWidth(52);
@@ -1880,11 +1809,9 @@ test('align_items_flex_end_child_with_margin_bigger_than_parent', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setAlignItems(Align.FlexEnd);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setMargin(Edge.Left, 10);
     root_child0_child0.setMargin(Edge.Right, 10);
     root_child0_child0.setWidth(52);
@@ -1947,11 +1874,9 @@ test('align_items_center_child_without_margin_bigger_than_parent', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setAlignItems(Align.Center);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(72);
     root_child0_child0.setHeight(72);
     root_child0.insertChild(root_child0_child0, 0);
@@ -2012,11 +1937,9 @@ test('align_items_flex_end_child_without_margin_bigger_than_parent', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setAlignItems(Align.FlexEnd);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(72);
     root_child0_child0.setHeight(72);
     root_child0.insertChild(root_child0_child0, 0);
@@ -2077,18 +2000,15 @@ test('align_center_should_size_based_on_content', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setJustifyContent(Justify.Center);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexShrink(1);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setFlexShrink(1);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setWidth(20);
     root_child0_child0_child0.setHeight(20);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -2158,18 +2078,15 @@ test('align_stretch_should_size_based_on_parent', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setJustifyContent(Justify.Center);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexShrink(1);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setFlexShrink(1);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setWidth(20);
     root_child0_child0_child0.setHeight(20);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -2238,17 +2155,14 @@ test('align_flex_start_with_shrinking_children', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setAlignItems(Align.FlexStart);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setFlexShrink(1);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setFlexGrow(1);
     root_child0_child0_child0.setFlexShrink(1);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -2316,17 +2230,14 @@ test('align_flex_start_with_stretching_children', () => {
     root.setHeight(500);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setFlexShrink(1);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setFlexGrow(1);
     root_child0_child0_child0.setFlexShrink(1);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -2395,17 +2306,14 @@ test('align_flex_start_with_shrinking_children_with_stretch', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setAlignItems(Align.FlexStart);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setFlexShrink(1);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setFlexGrow(1);
     root_child0_child0_child0.setFlexShrink(1);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);

--- a/javascript/tests/generated/YGAlignSelfTest.test.ts
+++ b/javascript/tests/generated/YGAlignSelfTest.test.ts
@@ -39,7 +39,6 @@ test('align_self_center', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setAlignSelf(Align.Center);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
@@ -88,7 +87,6 @@ test('align_self_flex_end', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setAlignSelf(Align.FlexEnd);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
@@ -137,7 +135,6 @@ test('align_self_flex_start', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setAlignSelf(Align.FlexStart);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
@@ -187,7 +184,6 @@ test('align_self_flex_end_override_flex_start', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setAlignSelf(Align.FlexEnd);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
@@ -237,20 +233,17 @@ test('align_self_baseline', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setAlignSelf(Align.Baseline);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
     root_child1.setAlignSelf(Align.Baseline);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth(50);
     root_child1_child0.setHeight(10);
     root_child1.insertChild(root_child1_child0, 0);

--- a/javascript/tests/generated/YGAndroidNewsFeed.test.ts
+++ b/javascript/tests/generated/YGAndroidNewsFeed.test.ts
@@ -38,24 +38,20 @@ test('android_news_feed', () => {
     root.setWidth(1080);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
     root_child0_child0.setAlignContent(Align.Stretch);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
     root_child0_child0_child0.setAlignContent(Align.Stretch);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
 
     const root_child0_child0_child0_child0 = Yoga.Node.create(config);
     root_child0_child0_child0_child0.setFlexDirection(FlexDirection.Row);
     root_child0_child0_child0_child0.setAlignContent(Align.Stretch);
     root_child0_child0_child0_child0.setAlignItems(Align.FlexStart);
-    root_child0_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0_child0.setMargin(Edge.Start, 36);
     root_child0_child0_child0_child0.setMargin(Edge.Top, 24);
     root_child0_child0_child0.insertChild(root_child0_child0_child0_child0, 0);
@@ -63,19 +59,16 @@ test('android_news_feed', () => {
     const root_child0_child0_child0_child0_child0 = Yoga.Node.create(config);
     root_child0_child0_child0_child0_child0.setFlexDirection(FlexDirection.Row);
     root_child0_child0_child0_child0_child0.setAlignContent(Align.Stretch);
-    root_child0_child0_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0_child0.insertChild(root_child0_child0_child0_child0_child0, 0);
 
     const root_child0_child0_child0_child0_child0_child0 = Yoga.Node.create(config);
     root_child0_child0_child0_child0_child0_child0.setAlignContent(Align.Stretch);
-    root_child0_child0_child0_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0_child0_child0_child0.setWidth(120);
     root_child0_child0_child0_child0_child0_child0.setHeight(120);
     root_child0_child0_child0_child0_child0.insertChild(root_child0_child0_child0_child0_child0_child0, 0);
 
     const root_child0_child0_child0_child0_child1 = Yoga.Node.create(config);
     root_child0_child0_child0_child0_child1.setAlignContent(Align.Stretch);
-    root_child0_child0_child0_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child0_child0_child0_child1.setFlexShrink(1);
     root_child0_child0_child0_child0_child1.setMargin(Edge.Right, 36);
     root_child0_child0_child0_child0_child1.setPadding(Edge.Left, 36);
@@ -87,26 +80,22 @@ test('android_news_feed', () => {
     const root_child0_child0_child0_child0_child1_child0 = Yoga.Node.create(config);
     root_child0_child0_child0_child0_child1_child0.setFlexDirection(FlexDirection.Row);
     root_child0_child0_child0_child0_child1_child0.setAlignContent(Align.Stretch);
-    root_child0_child0_child0_child0_child1_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0_child0_child1_child0.setFlexShrink(1);
     root_child0_child0_child0_child0_child1.insertChild(root_child0_child0_child0_child0_child1_child0, 0);
 
     const root_child0_child0_child0_child0_child1_child1 = Yoga.Node.create(config);
     root_child0_child0_child0_child0_child1_child1.setAlignContent(Align.Stretch);
-    root_child0_child0_child0_child0_child1_child1.setPositionType(PositionType.Relative);
     root_child0_child0_child0_child0_child1_child1.setFlexShrink(1);
     root_child0_child0_child0_child0_child1.insertChild(root_child0_child0_child0_child0_child1_child1, 1);
 
     const root_child0_child0_child1 = Yoga.Node.create(config);
     root_child0_child0_child1.setAlignContent(Align.Stretch);
-    root_child0_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child0.insertChild(root_child0_child0_child1, 1);
 
     const root_child0_child0_child1_child0 = Yoga.Node.create(config);
     root_child0_child0_child1_child0.setFlexDirection(FlexDirection.Row);
     root_child0_child0_child1_child0.setAlignContent(Align.Stretch);
     root_child0_child0_child1_child0.setAlignItems(Align.FlexStart);
-    root_child0_child0_child1_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child1_child0.setMargin(Edge.Start, 174);
     root_child0_child0_child1_child0.setMargin(Edge.Top, 24);
     root_child0_child0_child1.insertChild(root_child0_child0_child1_child0, 0);
@@ -114,19 +103,16 @@ test('android_news_feed', () => {
     const root_child0_child0_child1_child0_child0 = Yoga.Node.create(config);
     root_child0_child0_child1_child0_child0.setFlexDirection(FlexDirection.Row);
     root_child0_child0_child1_child0_child0.setAlignContent(Align.Stretch);
-    root_child0_child0_child1_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child1_child0.insertChild(root_child0_child0_child1_child0_child0, 0);
 
     const root_child0_child0_child1_child0_child0_child0 = Yoga.Node.create(config);
     root_child0_child0_child1_child0_child0_child0.setAlignContent(Align.Stretch);
-    root_child0_child0_child1_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child1_child0_child0_child0.setWidth(72);
     root_child0_child0_child1_child0_child0_child0.setHeight(72);
     root_child0_child0_child1_child0_child0.insertChild(root_child0_child0_child1_child0_child0_child0, 0);
 
     const root_child0_child0_child1_child0_child1 = Yoga.Node.create(config);
     root_child0_child0_child1_child0_child1.setAlignContent(Align.Stretch);
-    root_child0_child0_child1_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child0_child1_child0_child1.setFlexShrink(1);
     root_child0_child0_child1_child0_child1.setMargin(Edge.Right, 36);
     root_child0_child0_child1_child0_child1.setPadding(Edge.Left, 36);
@@ -138,13 +124,11 @@ test('android_news_feed', () => {
     const root_child0_child0_child1_child0_child1_child0 = Yoga.Node.create(config);
     root_child0_child0_child1_child0_child1_child0.setFlexDirection(FlexDirection.Row);
     root_child0_child0_child1_child0_child1_child0.setAlignContent(Align.Stretch);
-    root_child0_child0_child1_child0_child1_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child1_child0_child1_child0.setFlexShrink(1);
     root_child0_child0_child1_child0_child1.insertChild(root_child0_child0_child1_child0_child1_child0, 0);
 
     const root_child0_child0_child1_child0_child1_child1 = Yoga.Node.create(config);
     root_child0_child0_child1_child0_child1_child1.setAlignContent(Align.Stretch);
-    root_child0_child0_child1_child0_child1_child1.setPositionType(PositionType.Relative);
     root_child0_child0_child1_child0_child1_child1.setFlexShrink(1);
     root_child0_child0_child1_child0_child1.insertChild(root_child0_child0_child1_child0_child1_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);

--- a/javascript/tests/generated/YGAspectRatioTest.test.ts
+++ b/javascript/tests/generated/YGAspectRatioTest.test.ts
@@ -38,7 +38,6 @@ test.skip('aspect_ratio_does_not_stretch_cross_axis_dim', () => {
     root.setHeight(300);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setOverflow(Overflow.Scroll);
     root_child0.setFlexGrow(1);
     root_child0.setFlexShrink(1);
@@ -47,11 +46,9 @@ test.skip('aspect_ratio_does_not_stretch_cross_axis_dim', () => {
 
     const root_child0_child0 = Yoga.Node.create(config);
     root_child0_child0.setFlexDirection(FlexDirection.Row);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setFlexGrow(2);
     root_child0_child0_child0.setFlexShrink(1);
     root_child0_child0_child0.setFlexBasis("0%");
@@ -59,19 +56,16 @@ test.skip('aspect_ratio_does_not_stretch_cross_axis_dim', () => {
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
 
     const root_child0_child0_child1 = Yoga.Node.create(config);
-    root_child0_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child0_child1.setWidth(5);
     root_child0_child0.insertChild(root_child0_child0_child1, 1);
 
     const root_child0_child0_child2 = Yoga.Node.create(config);
-    root_child0_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child0_child2.setFlexGrow(1);
     root_child0_child0_child2.setFlexShrink(1);
     root_child0_child0_child2.setFlexBasis("0%");
     root_child0_child0.insertChild(root_child0_child0_child2, 2);
 
     const root_child0_child0_child2_child0 = Yoga.Node.create(config);
-    root_child0_child0_child2_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child2_child0.setFlexGrow(1);
     root_child0_child0_child2_child0.setFlexShrink(1);
     root_child0_child0_child2_child0.setFlexBasis("0%");
@@ -79,12 +73,10 @@ test.skip('aspect_ratio_does_not_stretch_cross_axis_dim', () => {
     root_child0_child0_child2.insertChild(root_child0_child0_child2_child0, 0);
 
     const root_child0_child0_child2_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child2_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child2_child0_child0.setWidth(5);
     root_child0_child0_child2_child0.insertChild(root_child0_child0_child2_child0_child0, 0);
 
     const root_child0_child0_child2_child0_child1 = Yoga.Node.create(config);
-    root_child0_child0_child2_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child0_child2_child0_child1.setFlexGrow(1);
     root_child0_child0_child2_child0_child1.setFlexShrink(1);
     root_child0_child0_child2_child0_child1.setFlexBasis("0%");

--- a/javascript/tests/generated/YGBorderTest.test.ts
+++ b/javascript/tests/generated/YGBorderTest.test.ts
@@ -74,7 +74,6 @@ test('border_container_match_child', () => {
     root.setBorder(Edge.Bottom, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
@@ -126,7 +125,6 @@ test('border_flex_child', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
@@ -178,7 +176,6 @@ test('border_stretch_child', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -230,7 +227,6 @@ test('border_center_child', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);

--- a/javascript/tests/generated/YGDimensionTest.test.ts
+++ b/javascript/tests/generated/YGDimensionTest.test.ts
@@ -36,7 +36,6 @@ test('wrap_child', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -82,11 +81,9 @@ test('wrap_grandchild', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);

--- a/javascript/tests/generated/YGDisplayTest.test.ts
+++ b/javascript/tests/generated/YGDisplayTest.test.ts
@@ -39,12 +39,10 @@ test('display_none', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setDisplay(Display.None);
     root.insertChild(root_child1, 1);
@@ -103,12 +101,10 @@ test('display_none_fixed_size', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root_child1.setHeight(20);
     root_child1.setDisplay(Display.None);
@@ -168,7 +164,6 @@ test('display_none_with_margin', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Left, 10);
     root_child0.setMargin(Edge.Top, 10);
     root_child0.setMargin(Edge.Right, 10);
@@ -179,7 +174,6 @@ test('display_none_with_margin', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -237,14 +231,12 @@ test('display_none_with_child', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexShrink(1);
     root_child0.setFlexBasis("0%");
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexShrink(1);
     root_child1.setFlexBasis("0%");
@@ -252,7 +244,6 @@ test('display_none_with_child', () => {
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setFlexGrow(1);
     root_child1_child0.setFlexShrink(1);
     root_child1_child0.setFlexBasis("0%");
@@ -260,7 +251,6 @@ test('display_none_with_child', () => {
     root_child1.insertChild(root_child1_child0, 0);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setFlexShrink(1);
     root_child2.setFlexBasis("0%");
@@ -340,12 +330,10 @@ test('display_none_with_position', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setPosition(Edge.Top, 10);
     root_child1.setDisplay(Display.None);

--- a/javascript/tests/generated/YGFlexDirectionTest.test.ts
+++ b/javascript/tests/generated/YGFlexDirectionTest.test.ts
@@ -37,17 +37,14 @@ test('flex_direction_column_no_height', () => {
     root.setWidth(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -114,17 +111,14 @@ test('flex_direction_row_no_width', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -191,17 +185,14 @@ test('flex_direction_column', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -269,17 +260,14 @@ test('flex_direction_row', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -347,17 +335,14 @@ test('flex_direction_column_reverse', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -425,17 +410,14 @@ test('flex_direction_row_reverse', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -504,17 +486,14 @@ test('flex_direction_row_reverse_margin_left', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -583,17 +562,14 @@ test('flex_direction_row_reverse_margin_start', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -662,17 +638,14 @@ test('flex_direction_row_reverse_margin_right', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -741,17 +714,14 @@ test('flex_direction_row_reverse_margin_end', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -820,17 +790,14 @@ test('flex_direction_column_reverse_margin_top', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -899,17 +866,14 @@ test('flex_direction_column_reverse_margin_bottom', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -978,17 +942,14 @@ test('flex_direction_row_reverse_padding_left', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1057,17 +1018,14 @@ test('flex_direction_row_reverse_padding_start', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1136,17 +1094,14 @@ test('flex_direction_row_reverse_padding_right', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1215,17 +1170,14 @@ test('flex_direction_row_reverse_padding_end', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1294,17 +1246,14 @@ test('flex_direction_column_reverse_padding_top', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1373,17 +1322,14 @@ test('flex_direction_column_reverse_padding_bottom', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1452,17 +1398,14 @@ test('flex_direction_row_reverse_border_left', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1531,17 +1474,14 @@ test('flex_direction_row_reverse_border_start', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1610,17 +1550,14 @@ test('flex_direction_row_reverse_border_right', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1689,17 +1626,14 @@ test('flex_direction_row_reverse_border_end', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1768,17 +1702,14 @@ test('flex_direction_column_reverse_border_top', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1847,17 +1778,14 @@ test('flex_direction_column_reverse_border_bottom', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1925,24 +1853,20 @@ test('flex_direction_row_reverse_pos_left', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPosition(Edge.Left, 100);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(10);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -2020,24 +1944,20 @@ test('flex_direction_row_reverse_pos_start', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPosition(Edge.Start, 100);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(10);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -2115,24 +2035,20 @@ test('flex_direction_row_reverse_pos_right', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPosition(Edge.Right, 100);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(10);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -2210,24 +2126,20 @@ test('flex_direction_row_reverse_pos_end', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPosition(Edge.End, 100);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(10);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -2305,24 +2217,20 @@ test('flex_direction_column_reverse_pos_top', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.ColumnReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPosition(Edge.Top, 100);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(10);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -2400,24 +2308,20 @@ test('flex_direction_column_reverse_pos_bottom', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.ColumnReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPosition(Edge.Bottom, 100);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(10);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -2495,7 +2399,6 @@ test('flex_direction_row_reverse_inner_pos_left', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -2508,12 +2411,10 @@ test('flex_direction_row_reverse_inner_pos_left', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -2591,7 +2492,6 @@ test('flex_direction_row_reverse_inner_pos_right', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -2604,12 +2504,10 @@ test('flex_direction_row_reverse_inner_pos_right', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -2687,7 +2585,6 @@ test('flex_direction_col_reverse_inner_pos_top', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.ColumnReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -2700,12 +2597,10 @@ test('flex_direction_col_reverse_inner_pos_top', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -2783,7 +2678,6 @@ test('flex_direction_col_reverse_inner_pos_bottom', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.ColumnReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -2796,12 +2690,10 @@ test('flex_direction_col_reverse_inner_pos_bottom', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -2879,7 +2771,6 @@ test.skip('flex_direction_row_reverse_inner_pos_start', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -2892,12 +2783,10 @@ test.skip('flex_direction_row_reverse_inner_pos_start', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -2975,7 +2864,6 @@ test.skip('flex_direction_row_reverse_inner_pos_end', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -2988,12 +2876,10 @@ test.skip('flex_direction_row_reverse_inner_pos_end', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3071,7 +2957,6 @@ test('flex_direction_row_reverse_inner_margin_left', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -3084,12 +2969,10 @@ test('flex_direction_row_reverse_inner_margin_left', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3167,7 +3050,6 @@ test('flex_direction_row_reverse_inner_margin_right', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -3180,12 +3062,10 @@ test('flex_direction_row_reverse_inner_margin_right', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3263,7 +3143,6 @@ test('flex_direction_col_reverse_inner_margin_top', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.ColumnReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -3276,12 +3155,10 @@ test('flex_direction_col_reverse_inner_margin_top', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3359,7 +3236,6 @@ test('flex_direction_col_reverse_inner_margin_bottom', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.ColumnReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -3372,12 +3248,10 @@ test('flex_direction_col_reverse_inner_margin_bottom', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3455,7 +3329,6 @@ test('flex_direction_row_reverse_inner_marign_start', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -3468,12 +3341,10 @@ test('flex_direction_row_reverse_inner_marign_start', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3551,7 +3422,6 @@ test('flex_direction_row_reverse_inner_margin_end', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -3564,12 +3434,10 @@ test('flex_direction_row_reverse_inner_margin_end', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3647,7 +3515,6 @@ test('flex_direction_row_reverse_inner_border_left', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -3660,12 +3527,10 @@ test('flex_direction_row_reverse_inner_border_left', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3743,7 +3608,6 @@ test('flex_direction_row_reverse_inner_border_right', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -3756,12 +3620,10 @@ test('flex_direction_row_reverse_inner_border_right', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3839,7 +3701,6 @@ test('flex_direction_col_reverse_inner_border_top', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.ColumnReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -3852,12 +3713,10 @@ test('flex_direction_col_reverse_inner_border_top', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -3935,7 +3794,6 @@ test('flex_direction_col_reverse_inner_border_bottom', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.ColumnReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -3948,12 +3806,10 @@ test('flex_direction_col_reverse_inner_border_bottom', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -4031,7 +3887,6 @@ test('flex_direction_row_reverse_inner_border_start', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -4044,12 +3899,10 @@ test('flex_direction_row_reverse_inner_border_start', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -4127,7 +3980,6 @@ test('flex_direction_row_reverse_inner_border_end', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -4140,12 +3992,10 @@ test('flex_direction_row_reverse_inner_border_end', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -4223,7 +4073,6 @@ test('flex_direction_row_reverse_inner_padding_left', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -4236,12 +4085,10 @@ test('flex_direction_row_reverse_inner_padding_left', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -4319,7 +4166,6 @@ test('flex_direction_row_reverse_inner_padding_right', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -4332,12 +4178,10 @@ test('flex_direction_row_reverse_inner_padding_right', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -4415,7 +4259,6 @@ test('flex_direction_col_reverse_inner_padding_top', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.ColumnReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -4428,12 +4271,10 @@ test('flex_direction_col_reverse_inner_padding_top', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -4511,7 +4352,6 @@ test('flex_direction_col_reverse_inner_padding_bottom', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.ColumnReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -4524,12 +4364,10 @@ test('flex_direction_col_reverse_inner_padding_bottom', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -4607,7 +4445,6 @@ test('flex_direction_row_reverse_inner_padding_start', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -4620,12 +4457,10 @@ test('flex_direction_row_reverse_inner_padding_start', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -4703,7 +4538,6 @@ test('flex_direction_row_reverse_inner_padding_end', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.RowReverse);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
@@ -4716,12 +4550,10 @@ test('flex_direction_row_reverse_inner_padding_end', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child2 = Yoga.Node.create(config);
-    root_child0_child2.setPositionType(PositionType.Relative);
     root_child0_child2.setWidth(10);
     root_child0.insertChild(root_child0_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);

--- a/javascript/tests/generated/YGFlexTest.test.ts
+++ b/javascript/tests/generated/YGFlexTest.test.ts
@@ -38,13 +38,11 @@ test('flex_basis_flex_grow_column', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -102,14 +100,12 @@ test('flex_shrink_flex_grow_row', () => {
     root.setHeight(500);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexShrink(1);
     root_child0.setWidth(500);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexShrink(1);
     root_child1.setWidth(500);
     root_child1.setHeight(100);
@@ -169,14 +165,12 @@ test('flex_shrink_flex_grow_child_flex_shrink_other_child', () => {
     root.setHeight(500);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexShrink(1);
     root_child0.setWidth(500);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexShrink(1);
     root_child1.setWidth(500);
@@ -237,13 +231,11 @@ test('flex_basis_flex_grow_row', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -300,13 +292,11 @@ test('flex_basis_flex_shrink_column', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexShrink(1);
     root_child0.setFlexBasis(100);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexBasis(50);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -364,13 +354,11 @@ test('flex_basis_flex_shrink_row', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexShrink(1);
     root_child0.setFlexBasis(100);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexBasis(50);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -426,20 +414,17 @@ test('flex_shrink_to_zero', () => {
     root.setHeight(75);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexShrink(1);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root_child2.setHeight(50);
     root.insertChild(root_child2, 2);
@@ -507,20 +492,17 @@ test('flex_basis_overrides_main_size', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis(50);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
@@ -588,11 +570,9 @@ test('flex_grow_shrink_at_most', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setFlexShrink(1);
     root_child0.insertChild(root_child0_child0, 0);
@@ -650,18 +630,15 @@ test('flex_grow_less_than_factor_one', () => {
     root.setHeight(500);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(0.2);
     root_child0.setFlexBasis(40);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(0.2);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(0.4);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);

--- a/javascript/tests/generated/YGFlexWrapTest.test.ts
+++ b/javascript/tests/generated/YGFlexWrapTest.test.ts
@@ -38,25 +38,21 @@ test('wrap_column', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(30);
     root_child0.setHeight(30);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(30);
     root_child1.setHeight(30);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(30);
     root_child2.setHeight(30);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(30);
     root_child3.setHeight(30);
     root.insertChild(root_child3, 3);
@@ -135,25 +131,21 @@ test('wrap_row', () => {
     root.setWidth(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(30);
     root_child0.setHeight(30);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(30);
     root_child1.setHeight(30);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(30);
     root_child2.setHeight(30);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(30);
     root_child3.setHeight(30);
     root.insertChild(root_child3, 3);
@@ -233,25 +225,21 @@ test('wrap_row_align_items_flex_end', () => {
     root.setWidth(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(30);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(30);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(30);
     root_child2.setHeight(30);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(30);
     root_child3.setHeight(30);
     root.insertChild(root_child3, 3);
@@ -331,25 +319,21 @@ test('wrap_row_align_items_center', () => {
     root.setWidth(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(30);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(30);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(30);
     root_child2.setHeight(30);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(30);
     root_child3.setHeight(30);
     root.insertChild(root_child3, 3);
@@ -428,14 +412,12 @@ test('flex_wrap_children_with_min_main_overriding_flex_basis', () => {
     root.setWidth(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexBasis(50);
     root_child0.setMinWidth(55);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexBasis(50);
     root_child1.setMinWidth(55);
     root_child1.setHeight(50);
@@ -494,23 +476,19 @@ test('flex_wrap_wrap_to_child_height', () => {
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setAlignItems(Align.FlexStart);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setWidth(100);
     root_child0_child0_child0.setHeight(100);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(100);
     root_child1.setHeight(100);
     root.insertChild(root_child1, 1);
@@ -590,12 +568,10 @@ test('flex_wrap_align_stretch_fits_one_row', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -653,31 +629,26 @@ test('wrap_reverse_row_align_content_flex_start', () => {
     root.setWidth(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(30);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(30);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(30);
     root_child2.setHeight(30);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(30);
     root_child3.setHeight(40);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(30);
     root_child4.setHeight(50);
     root.insertChild(root_child4, 4);
@@ -767,31 +738,26 @@ test('wrap_reverse_row_align_content_center', () => {
     root.setWidth(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(30);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(30);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(30);
     root_child2.setHeight(30);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(30);
     root_child3.setHeight(40);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(30);
     root_child4.setHeight(50);
     root.insertChild(root_child4, 4);
@@ -880,31 +846,26 @@ test('wrap_reverse_row_single_line_different_size', () => {
     root.setWidth(300);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(30);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(30);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(30);
     root_child2.setHeight(30);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(30);
     root_child3.setHeight(40);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(30);
     root_child4.setHeight(50);
     root.insertChild(root_child4, 4);
@@ -994,31 +955,26 @@ test('wrap_reverse_row_align_content_stretch', () => {
     root.setWidth(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(30);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(30);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(30);
     root_child2.setHeight(30);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(30);
     root_child3.setHeight(40);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(30);
     root_child4.setHeight(50);
     root.insertChild(root_child4, 4);
@@ -1108,31 +1064,26 @@ test('wrap_reverse_row_align_content_space_around', () => {
     root.setWidth(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(30);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(30);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(30);
     root_child2.setHeight(30);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(30);
     root_child3.setHeight(40);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(30);
     root_child4.setHeight(50);
     root.insertChild(root_child4, 4);
@@ -1222,31 +1173,26 @@ test('wrap_reverse_column_fixed_size', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(30);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(30);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(30);
     root_child2.setHeight(30);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(30);
     root_child3.setHeight(40);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(30);
     root_child4.setHeight(50);
     root.insertChild(root_child4, 4);
@@ -1336,18 +1282,15 @@ test('wrapped_row_within_align_items_center', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(150);
     root_child0_child0.setHeight(80);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(80);
     root_child0_child1.setHeight(80);
     root_child0.insertChild(root_child0_child1, 1);
@@ -1417,18 +1360,15 @@ test('wrapped_row_within_align_items_flex_start', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(150);
     root_child0_child0.setHeight(80);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(80);
     root_child0_child1.setHeight(80);
     root_child0.insertChild(root_child0_child1, 1);
@@ -1498,18 +1438,15 @@ test('wrapped_row_within_align_items_flex_end', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(150);
     root_child0_child0.setHeight(80);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(80);
     root_child0_child1.setHeight(80);
     root_child0.insertChild(root_child0_child1, 1);
@@ -1581,14 +1518,12 @@ test('wrapped_column_max_height', () => {
     root.setHeight(500);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(500);
     root_child0.setMaxHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setMargin(Edge.Left, 20);
     root_child1.setMargin(Edge.Top, 20);
     root_child1.setMargin(Edge.Right, 20);
@@ -1598,7 +1533,6 @@ test('wrapped_column_max_height', () => {
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(100);
     root_child2.setHeight(100);
     root.insertChild(root_child2, 2);
@@ -1670,7 +1604,6 @@ test('wrapped_column_max_height_flex', () => {
     root.setHeight(500);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexShrink(1);
     root_child0.setFlexBasis("0%");
@@ -1680,7 +1613,6 @@ test('wrapped_column_max_height_flex', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexShrink(1);
     root_child1.setFlexBasis("0%");
@@ -1693,7 +1625,6 @@ test('wrapped_column_max_height_flex', () => {
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(100);
     root_child2.setHeight(100);
     root.insertChild(root_child2, 2);
@@ -1762,28 +1693,23 @@ test('wrap_nodes_with_content_sizing_overflowing_margin', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setWidth(85);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setWidth(40);
     root_child0_child0_child0.setHeight(40);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setMargin(Edge.Right, 10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child1_child0 = Yoga.Node.create(config);
-    root_child0_child1_child0.setPositionType(PositionType.Relative);
     root_child0_child1_child0.setWidth(40);
     root_child0_child1_child0.setHeight(40);
     root_child0_child1.insertChild(root_child0_child1_child0, 0);
@@ -1872,28 +1798,23 @@ test('wrap_nodes_with_content_sizing_margin_cross', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexWrap(Wrap.Wrap);
     root_child0.setWidth(70);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setWidth(40);
     root_child0_child0_child0.setHeight(40);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setMargin(Edge.Top, 10);
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child0_child1_child0 = Yoga.Node.create(config);
-    root_child0_child1_child0.setPositionType(PositionType.Relative);
     root_child0_child1_child0.setWidth(40);
     root_child0_child1_child0.setHeight(40);
     root_child0_child1.insertChild(root_child0_child1_child0, 0);

--- a/javascript/tests/generated/YGGapTest.test.ts
+++ b/javascript/tests/generated/YGGapTest.test.ts
@@ -41,21 +41,18 @@ test('column_gap_flexible', () => {
     root.setGap(Gutter.Row, 20);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexShrink(1);
     root_child0.setFlexBasis("0%");
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexShrink(1);
     root_child1.setFlexBasis("0%");
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setFlexShrink(1);
     root_child2.setFlexBasis("0%");
@@ -126,17 +123,14 @@ test('column_gap_inflexible', () => {
     root.setGap(Gutter.Column, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -205,19 +199,16 @@ test('column_gap_mixed_flexible', () => {
     root.setGap(Gutter.Column, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexShrink(1);
     root_child1.setFlexBasis("0%");
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -286,7 +277,6 @@ test('column_gap_child_margins', () => {
     root.setGap(Gutter.Column, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexShrink(1);
     root_child0.setFlexBasis("0%");
@@ -295,7 +285,6 @@ test('column_gap_child_margins', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexShrink(1);
     root_child1.setFlexBasis("0%");
@@ -304,7 +293,6 @@ test('column_gap_child_margins', () => {
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setFlexShrink(1);
     root_child2.setFlexBasis("0%");
@@ -378,55 +366,46 @@ test('column_row_gap_wrapping', () => {
     root.setGap(Gutter.Row, 20);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root_child2.setHeight(20);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(20);
     root_child3.setHeight(20);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(20);
     root_child4.setHeight(20);
     root.insertChild(root_child4, 4);
 
     const root_child5 = Yoga.Node.create(config);
-    root_child5.setPositionType(PositionType.Relative);
     root_child5.setWidth(20);
     root_child5.setHeight(20);
     root.insertChild(root_child5, 5);
 
     const root_child6 = Yoga.Node.create(config);
-    root_child6.setPositionType(PositionType.Relative);
     root_child6.setWidth(20);
     root_child6.setHeight(20);
     root.insertChild(root_child6, 6);
 
     const root_child7 = Yoga.Node.create(config);
-    root_child7.setPositionType(PositionType.Relative);
     root_child7.setWidth(20);
     root_child7.setHeight(20);
     root.insertChild(root_child7, 7);
 
     const root_child8 = Yoga.Node.create(config);
-    root_child8.setPositionType(PositionType.Relative);
     root_child8.setWidth(20);
     root_child8.setHeight(20);
     root.insertChild(root_child8, 8);
@@ -563,19 +542,16 @@ test('column_gap_start_index', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root_child2.setHeight(20);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(20);
     root_child3.setHeight(20);
     root.insertChild(root_child3, 3);
@@ -655,17 +631,14 @@ test('column_gap_justify_flex_start', () => {
     root.setGap(Gutter.Column, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -735,17 +708,14 @@ test('column_gap_justify_center', () => {
     root.setGap(Gutter.Column, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -815,17 +785,14 @@ test('column_gap_justify_flex_end', () => {
     root.setGap(Gutter.Column, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -895,17 +862,14 @@ test('column_gap_justify_space_between', () => {
     root.setGap(Gutter.Column, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -975,17 +939,14 @@ test('column_gap_justify_space_around', () => {
     root.setGap(Gutter.Column, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1055,17 +1016,14 @@ test('column_gap_justify_space_evenly', () => {
     root.setGap(Gutter.Column, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1136,37 +1094,31 @@ test('column_gap_wrap_align_flex_start', () => {
     root.setGap(Gutter.Row, 20);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root_child2.setHeight(20);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(20);
     root_child3.setHeight(20);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(20);
     root_child4.setHeight(20);
     root.insertChild(root_child4, 4);
 
     const root_child5 = Yoga.Node.create(config);
-    root_child5.setPositionType(PositionType.Relative);
     root_child5.setWidth(20);
     root_child5.setHeight(20);
     root.insertChild(root_child5, 5);
@@ -1269,37 +1221,31 @@ test('column_gap_wrap_align_center', () => {
     root.setGap(Gutter.Row, 20);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root_child2.setHeight(20);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(20);
     root_child3.setHeight(20);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(20);
     root_child4.setHeight(20);
     root.insertChild(root_child4, 4);
 
     const root_child5 = Yoga.Node.create(config);
-    root_child5.setPositionType(PositionType.Relative);
     root_child5.setWidth(20);
     root_child5.setHeight(20);
     root.insertChild(root_child5, 5);
@@ -1402,37 +1348,31 @@ test('column_gap_wrap_align_flex_end', () => {
     root.setGap(Gutter.Row, 20);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root_child2.setHeight(20);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(20);
     root_child3.setHeight(20);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(20);
     root_child4.setHeight(20);
     root.insertChild(root_child4, 4);
 
     const root_child5 = Yoga.Node.create(config);
-    root_child5.setPositionType(PositionType.Relative);
     root_child5.setWidth(20);
     root_child5.setHeight(20);
     root.insertChild(root_child5, 5);
@@ -1535,37 +1475,31 @@ test('column_gap_wrap_align_space_between', () => {
     root.setGap(Gutter.Row, 20);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root_child2.setHeight(20);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(20);
     root_child3.setHeight(20);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(20);
     root_child4.setHeight(20);
     root.insertChild(root_child4, 4);
 
     const root_child5 = Yoga.Node.create(config);
-    root_child5.setPositionType(PositionType.Relative);
     root_child5.setWidth(20);
     root_child5.setHeight(20);
     root.insertChild(root_child5, 5);
@@ -1668,37 +1602,31 @@ test('column_gap_wrap_align_space_around', () => {
     root.setGap(Gutter.Row, 20);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root_child2.setHeight(20);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(20);
     root_child3.setHeight(20);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(20);
     root_child4.setHeight(20);
     root.insertChild(root_child4, 4);
 
     const root_child5 = Yoga.Node.create(config);
-    root_child5.setPositionType(PositionType.Relative);
     root_child5.setWidth(20);
     root_child5.setHeight(20);
     root.insertChild(root_child5, 5);
@@ -1800,31 +1728,26 @@ test('column_gap_wrap_align_stretch', () => {
     root.setGap(Gutter.Column, 5);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setMinWidth(60);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setMinWidth(60);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setMinWidth(60);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setFlexGrow(1);
     root_child3.setMinWidth(60);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setFlexGrow(1);
     root_child4.setMinWidth(60);
     root.insertChild(root_child4, 4);
@@ -1913,17 +1836,14 @@ test('column_gap_determines_parent_width', () => {
     root.setGap(Gutter.Column, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(30);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1995,32 +1915,26 @@ test('row_gap_align_items_stretch', () => {
     root.setGap(Gutter.Row, 20);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(20);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(20);
     root.insertChild(root_child4, 4);
 
     const root_child5 = Yoga.Node.create(config);
-    root_child5.setPositionType(PositionType.Relative);
     root_child5.setWidth(20);
     root.insertChild(root_child5, 5);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -2122,32 +2036,26 @@ test('row_gap_align_items_end', () => {
     root.setGap(Gutter.Row, 20);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(20);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setWidth(20);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setWidth(20);
     root.insertChild(root_child4, 4);
 
     const root_child5 = Yoga.Node.create(config);
-    root_child5.setPositionType(PositionType.Relative);
     root_child5.setWidth(20);
     root.insertChild(root_child5, 5);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -2245,7 +2153,6 @@ test('row_gap_column_child_margins', () => {
     root.setGap(Gutter.Row, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexShrink(1);
     root_child0.setFlexBasis("0%");
@@ -2254,7 +2161,6 @@ test('row_gap_column_child_margins', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexShrink(1);
     root_child1.setFlexBasis("0%");
@@ -2263,7 +2169,6 @@ test('row_gap_column_child_margins', () => {
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setFlexShrink(1);
     root_child2.setFlexBasis("0%");
@@ -2337,21 +2242,18 @@ test('row_gap_row_wrap_child_margins', () => {
     root.setGap(Gutter.Row, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Top, 2);
     root_child0.setMargin(Edge.Bottom, 2);
     root_child0.setWidth(60);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setMargin(Edge.Top, 10);
     root_child1.setMargin(Edge.Bottom, 10);
     root_child1.setWidth(60);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setMargin(Edge.Top, 15);
     root_child2.setMargin(Edge.Bottom, 15);
     root_child2.setWidth(60);
@@ -2420,17 +2322,14 @@ test('row_gap_determines_parent_height', () => {
     root.setGap(Gutter.Row, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(20);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setHeight(30);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);

--- a/javascript/tests/generated/YGJustifyContentTest.test.ts
+++ b/javascript/tests/generated/YGJustifyContentTest.test.ts
@@ -39,17 +39,14 @@ test('justify_content_row_flex_start', () => {
     root.setHeight(102);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -118,17 +115,14 @@ test('justify_content_row_flex_end', () => {
     root.setHeight(102);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -197,17 +191,14 @@ test('justify_content_row_center', () => {
     root.setHeight(102);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -276,17 +267,14 @@ test('justify_content_row_space_between', () => {
     root.setHeight(102);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -355,17 +343,14 @@ test('justify_content_row_space_around', () => {
     root.setHeight(102);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -432,17 +417,14 @@ test('justify_content_column_flex_start', () => {
     root.setHeight(102);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -510,17 +492,14 @@ test('justify_content_column_flex_end', () => {
     root.setHeight(102);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -588,17 +567,14 @@ test('justify_content_column_center', () => {
     root.setHeight(102);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -666,17 +642,14 @@ test('justify_content_column_space_between', () => {
     root.setHeight(102);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -744,17 +717,14 @@ test('justify_content_column_space_around', () => {
     root.setHeight(102);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -823,7 +793,6 @@ test('justify_content_row_min_width_and_margin', () => {
     root.setMinWidth(50);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
@@ -874,7 +843,6 @@ test('justify_content_row_max_width_and_margin', () => {
     root.setMaxWidth(80);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
@@ -923,7 +891,6 @@ test('justify_content_column_min_height_and_margin', () => {
     root.setMinHeight(50);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
@@ -973,7 +940,6 @@ test('justify_content_colunn_max_height_and_margin', () => {
     root.setMaxHeight(80);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(20);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
@@ -1022,17 +988,14 @@ test('justify_content_column_space_evenly', () => {
     root.setHeight(102);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1101,17 +1064,14 @@ test('justify_content_row_space_evenly', () => {
     root.setHeight(102);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1181,14 +1141,12 @@ test('justify_content_min_width_with_padding_child_width_greater_than_parent', (
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setAlignContent(Align.Stretch);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
     root_child0_child0.setFlexDirection(FlexDirection.Row);
     root_child0_child0.setJustifyContent(Justify.Center);
     root_child0_child0.setAlignContent(Align.Stretch);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setPadding(Edge.Left, 100);
     root_child0_child0.setPadding(Edge.Right, 100);
     root_child0_child0.setMinWidth(400);
@@ -1197,7 +1155,6 @@ test('justify_content_min_width_with_padding_child_width_greater_than_parent', (
     const root_child0_child0_child0 = Yoga.Node.create(config);
     root_child0_child0_child0.setFlexDirection(FlexDirection.Row);
     root_child0_child0_child0.setAlignContent(Align.Stretch);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setWidth(300);
     root_child0_child0_child0.setHeight(100);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -1268,14 +1225,12 @@ test('justify_content_min_width_with_padding_child_width_lower_than_parent', () 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setAlignContent(Align.Stretch);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
     root_child0_child0.setFlexDirection(FlexDirection.Row);
     root_child0_child0.setJustifyContent(Justify.Center);
     root_child0_child0.setAlignContent(Align.Stretch);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setPadding(Edge.Left, 100);
     root_child0_child0.setPadding(Edge.Right, 100);
     root_child0_child0.setMinWidth(400);
@@ -1284,7 +1239,6 @@ test('justify_content_min_width_with_padding_child_width_lower_than_parent', () 
     const root_child0_child0_child0 = Yoga.Node.create(config);
     root_child0_child0_child0.setFlexDirection(FlexDirection.Row);
     root_child0_child0_child0.setAlignContent(Align.Stretch);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setWidth(199);
     root_child0_child0_child0.setHeight(100);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -1354,18 +1308,15 @@ test('justify_content_space_between_indefinite_container_dim_with_free_space', (
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
     root_child0.setJustifyContent(Justify.SpaceBetween);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMinWidth(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(50);
     root_child0_child0.setHeight(50);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(50);
     root_child0_child1.setHeight(50);
     root_child0.insertChild(root_child0_child1, 1);

--- a/javascript/tests/generated/YGMarginTest.test.ts
+++ b/javascript/tests/generated/YGMarginTest.test.ts
@@ -39,7 +39,6 @@ test('margin_start', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Start, 10);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
@@ -87,7 +86,6 @@ test('margin_top', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Top, 10);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
@@ -137,7 +135,6 @@ test('margin_end', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.End, 10);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
@@ -186,7 +183,6 @@ test('margin_bottom', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Bottom, 10);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
@@ -235,7 +231,6 @@ test('margin_and_flex_row', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setMargin(Edge.Start, 10);
     root_child0.setMargin(Edge.End, 10);
@@ -284,7 +279,6 @@ test('margin_and_flex_column', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setMargin(Edge.Top, 10);
     root_child0.setMargin(Edge.Bottom, 10);
@@ -334,7 +328,6 @@ test('margin_and_stretch_row', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setMargin(Edge.Top, 10);
     root_child0.setMargin(Edge.Bottom, 10);
@@ -383,7 +376,6 @@ test('margin_and_stretch_column', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setMargin(Edge.Start, 10);
     root_child0.setMargin(Edge.End, 10);
@@ -433,13 +425,11 @@ test('margin_with_sibling_row', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setMargin(Edge.End, 10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -496,13 +486,11 @@ test('margin_with_sibling_column', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setMargin(Edge.Bottom, 10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -560,14 +548,12 @@ test('margin_auto_bottom', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Bottom, 'auto');
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -626,14 +612,12 @@ test('margin_auto_top', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Top, 'auto');
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -692,7 +676,6 @@ test('margin_auto_bottom_and_top', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Top, 'auto');
     root_child0.setMargin(Edge.Bottom, 'auto');
     root_child0.setWidth(50);
@@ -700,7 +683,6 @@ test('margin_auto_bottom_and_top', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -759,7 +741,6 @@ test('margin_auto_bottom_and_top_justify_center', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Top, 'auto');
     root_child0.setMargin(Edge.Bottom, 'auto');
     root_child0.setWidth(50);
@@ -767,7 +748,6 @@ test('margin_auto_bottom_and_top_justify_center', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -826,21 +806,18 @@ test('margin_auto_mutiple_children_column', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Top, 'auto');
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setMargin(Edge.Top, 'auto');
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root_child2.setHeight(50);
     root.insertChild(root_child2, 2);
@@ -910,21 +887,18 @@ test('margin_auto_mutiple_children_row', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Right, 'auto');
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setMargin(Edge.Right, 'auto');
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root_child2.setHeight(50);
     root.insertChild(root_child2, 2);
@@ -994,7 +968,6 @@ test('margin_auto_left_and_right_column', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Left, 'auto');
     root_child0.setMargin(Edge.Right, 'auto');
     root_child0.setWidth(50);
@@ -1002,7 +975,6 @@ test('margin_auto_left_and_right_column', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -1060,7 +1032,6 @@ test('margin_auto_left_and_right', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Left, 'auto');
     root_child0.setMargin(Edge.Right, 'auto');
     root_child0.setWidth(50);
@@ -1068,7 +1039,6 @@ test('margin_auto_left_and_right', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -1128,7 +1098,6 @@ test('margin_auto_start_and_end_column', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Start, 'auto');
     root_child0.setMargin(Edge.End, 'auto');
     root_child0.setWidth(50);
@@ -1136,7 +1105,6 @@ test('margin_auto_start_and_end_column', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -1194,7 +1162,6 @@ test('margin_auto_start_and_end', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Start, 'auto');
     root_child0.setMargin(Edge.End, 'auto');
     root_child0.setWidth(50);
@@ -1202,7 +1169,6 @@ test('margin_auto_start_and_end', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -1261,7 +1227,6 @@ test('margin_auto_left_and_right_column_and_center', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Left, 'auto');
     root_child0.setMargin(Edge.Right, 'auto');
     root_child0.setWidth(50);
@@ -1269,7 +1234,6 @@ test('margin_auto_left_and_right_column_and_center', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -1328,14 +1292,12 @@ test('margin_auto_left', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Left, 'auto');
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -1394,14 +1356,12 @@ test('margin_auto_right', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Right, 'auto');
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -1460,7 +1420,6 @@ test('margin_auto_left_and_right_stretch', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Left, 'auto');
     root_child0.setMargin(Edge.Right, 'auto');
     root_child0.setWidth(50);
@@ -1468,7 +1427,6 @@ test('margin_auto_left_and_right_stretch', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -1526,7 +1484,6 @@ test('margin_auto_top_and_bottom_stretch', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Top, 'auto');
     root_child0.setMargin(Edge.Bottom, 'auto');
     root_child0.setWidth(50);
@@ -1534,7 +1491,6 @@ test('margin_auto_top_and_bottom_stretch', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -1592,7 +1548,6 @@ test('margin_should_not_be_part_of_max_height', () => {
     root.setHeight(250);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Top, 20);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
@@ -1642,7 +1597,6 @@ test('margin_should_not_be_part_of_max_width', () => {
     root.setHeight(250);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Left, 20);
     root_child0.setWidth(100);
     root_child0.setMaxWidth(100);
@@ -1693,7 +1647,6 @@ test('margin_auto_left_right_child_bigger_than_parent', () => {
     root.setHeight(52);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Left, 'auto');
     root_child0.setMargin(Edge.Right, 'auto');
     root_child0.setWidth(72);
@@ -1744,7 +1697,6 @@ test('margin_auto_left_child_bigger_than_parent', () => {
     root.setHeight(52);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Left, 'auto');
     root_child0.setWidth(72);
     root_child0.setHeight(72);
@@ -1794,7 +1746,6 @@ test('margin_fix_left_auto_right_child_bigger_than_parent', () => {
     root.setHeight(52);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Left, 10);
     root_child0.setMargin(Edge.Right, 'auto');
     root_child0.setWidth(72);
@@ -1845,7 +1796,6 @@ test('margin_auto_left_fix_right_child_bigger_than_parent', () => {
     root.setHeight(52);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMargin(Edge.Left, 'auto');
     root_child0.setMargin(Edge.Right, 10);
     root_child0.setWidth(72);
@@ -1896,7 +1846,6 @@ test('margin_auto_top_stretching_child', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexShrink(1);
     root_child0.setFlexBasis("0%");
@@ -1904,7 +1853,6 @@ test('margin_auto_top_stretching_child', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
@@ -1963,7 +1911,6 @@ test('margin_auto_left_stretching_child', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexShrink(1);
     root_child0.setFlexBasis("0%");
@@ -1971,7 +1918,6 @@ test('margin_auto_left_stretching_child', () => {
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);

--- a/javascript/tests/generated/YGMinMaxDimensionTest.test.ts
+++ b/javascript/tests/generated/YGMinMaxDimensionTest.test.ts
@@ -38,7 +38,6 @@ test('max_width', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMaxWidth(50);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
@@ -87,7 +86,6 @@ test('max_height', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root_child0.setMaxHeight(50);
     root.insertChild(root_child0, 0);
@@ -135,13 +133,11 @@ test.skip('min_height', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setMinHeight(60);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -199,13 +195,11 @@ test.skip('min_width', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setMinWidth(60);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -264,7 +258,6 @@ test('justify_content_min_max', () => {
     root.setMaxHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(60);
     root_child0.setHeight(60);
     root.insertChild(root_child0, 0);
@@ -314,7 +307,6 @@ test('align_items_min_max', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(60);
     root_child0.setHeight(60);
     root.insertChild(root_child0, 0);
@@ -363,19 +355,16 @@ test('justify_content_overflow_min_max', () => {
     root.setMaxHeight(110);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(50);
     root_child0.setHeight(50);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(50);
     root_child2.setHeight(50);
     root.insertChild(root_child2, 2);
@@ -444,13 +433,11 @@ test('flex_grow_to_min', () => {
     root.setMaxHeight(500);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexShrink(1);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -510,11 +497,9 @@ test('flex_grow_in_at_most_container', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setFlexBasis(0);
     root_child0.insertChild(root_child0_child0, 0);
@@ -571,7 +556,6 @@ test('flex_grow_child', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis(0);
     root_child0.setHeight(100);
@@ -620,12 +604,10 @@ test('flex_grow_within_constrained_min_max_column', () => {
     root.setMaxHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -683,12 +665,10 @@ test('flex_grow_within_max_width', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMaxWidth(100);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
@@ -747,12 +727,10 @@ test('flex_grow_within_constrained_max_width', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMaxWidth(300);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setHeight(20);
     root_child0.insertChild(root_child0_child0, 0);
@@ -812,13 +790,11 @@ test('flex_root_ignored', () => {
     root.setMaxHeight(500);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis(200);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(100);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -876,20 +852,17 @@ test('flex_grow_root_minimized', () => {
     root.setMaxHeight(500);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setMinHeight(100);
     root_child0.setMaxHeight(500);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setFlexBasis(200);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setHeight(100);
     root_child0.insertChild(root_child0_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -956,20 +929,17 @@ test('flex_grow_height_maximized', () => {
     root.setHeight(500);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setMinHeight(100);
     root_child0.setMaxHeight(500);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setFlexBasis(200);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setHeight(100);
     root_child0.insertChild(root_child0_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1037,12 +1007,10 @@ test('flex_grow_within_constrained_min_row', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setWidth(50);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1098,12 +1066,10 @@ test('flex_grow_within_constrained_min_column', () => {
     root.setMinHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1160,19 +1126,16 @@ test('flex_grow_within_constrained_max_row', () => {
 
     const root_child0 = Yoga.Node.create(config);
     root_child0.setFlexDirection(FlexDirection.Row);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMaxWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexShrink(1);
     root_child0_child0.setFlexBasis(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth(50);
     root_child0.insertChild(root_child0_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1239,13 +1202,11 @@ test('flex_grow_within_constrained_max_column', () => {
     root.setMaxHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexShrink(1);
     root_child0.setFlexBasis(100);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setHeight(50);
     root.insertChild(root_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1303,14 +1264,12 @@ test('child_min_max_width_flexing', () => {
     root.setHeight(50);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis(0);
     root_child0.setMinWidth(60);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexBasis("50%");
     root_child1.setMaxWidth(20);
@@ -1498,7 +1457,6 @@ test('min_max_percent_no_width_height', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setMinWidth("10%");
     root_child0.setMaxWidth("10%");
     root_child0.setMinHeight("10%");

--- a/javascript/tests/generated/YGPaddingTest.test.ts
+++ b/javascript/tests/generated/YGPaddingTest.test.ts
@@ -74,7 +74,6 @@ test('padding_container_match_child', () => {
     root.setPadding(Edge.Bottom, 10);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
@@ -126,7 +125,6 @@ test('padding_flex_child', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
@@ -178,7 +176,6 @@ test('padding_stretch_child', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -230,7 +227,6 @@ test('padding_center_child', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(10);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
@@ -280,7 +276,6 @@ test('child_with_padding_align_end', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPadding(Edge.Left, 20);
     root_child0.setPadding(Edge.Top, 20);
     root_child0.setPadding(Edge.Right, 20);

--- a/javascript/tests/generated/YGPercentageTest.test.ts
+++ b/javascript/tests/generated/YGPercentageTest.test.ts
@@ -39,7 +39,6 @@ test('percentage_width_height', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth("30%");
     root_child0.setHeight("30%");
     root.insertChild(root_child0, 0);
@@ -88,7 +87,6 @@ test('percentage_position_left_top', () => {
     root.setHeight(400);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPosition(Edge.Left, "10%");
     root_child0.setPosition(Edge.Top, "20%");
     root_child0.setWidth("45%");
@@ -139,7 +137,6 @@ test('percentage_position_bottom_right', () => {
     root.setHeight(500);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPosition(Edge.Right, "20%");
     root_child0.setPosition(Edge.Bottom, "10%");
     root_child0.setWidth("55%");
@@ -190,13 +187,11 @@ test('percentage_flex_basis', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis("50%");
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexBasis("25%");
     root.insertChild(root_child1, 1);
@@ -254,13 +249,11 @@ test('percentage_flex_basis_cross', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis("50%");
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setFlexBasis("25%");
     root.insertChild(root_child1, 1);
@@ -318,13 +311,11 @@ test.skip('percentage_flex_basis_cross_min_height', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setMinHeight("60%");
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(2);
     root_child1.setMinHeight("10%");
     root.insertChild(root_child1, 1);
@@ -383,14 +374,12 @@ test('percentage_flex_basis_main_max_height', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis("10%");
     root_child0.setMaxHeight("60%");
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(4);
     root_child1.setFlexBasis("10%");
     root_child1.setMaxHeight("20%");
@@ -449,14 +438,12 @@ test('percentage_flex_basis_cross_max_height', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis("10%");
     root_child0.setMaxHeight("60%");
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(4);
     root_child1.setFlexBasis("10%");
     root_child1.setMaxHeight("20%");
@@ -516,14 +503,12 @@ test('percentage_flex_basis_main_max_width', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis("15%");
     root_child0.setMaxWidth("60%");
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(4);
     root_child1.setFlexBasis("10%");
     root_child1.setMaxWidth("20%");
@@ -582,14 +567,12 @@ test('percentage_flex_basis_cross_max_width', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis("10%");
     root_child0.setMaxWidth("60%");
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(4);
     root_child1.setFlexBasis("15%");
     root_child1.setMaxWidth("20%");
@@ -649,14 +632,12 @@ test('percentage_flex_basis_main_min_width', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis("15%");
     root_child0.setMinWidth("60%");
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(4);
     root_child1.setFlexBasis("10%");
     root_child1.setMinWidth("20%");
@@ -715,14 +696,12 @@ test('percentage_flex_basis_cross_min_width', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis("10%");
     root_child0.setMinWidth("60%");
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(4);
     root_child1.setFlexBasis("15%");
     root_child1.setMinWidth("20%");
@@ -781,7 +760,6 @@ test('percentage_multiple_nested_with_padding_margin_and_percentage_values', () 
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis("10%");
     root_child0.setMargin(Edge.Left, 5);
@@ -796,7 +774,6 @@ test('percentage_multiple_nested_with_padding_margin_and_percentage_values', () 
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setMargin(Edge.Left, 5);
     root_child0_child0.setMargin(Edge.Top, 5);
     root_child0_child0.setMargin(Edge.Right, 5);
@@ -809,7 +786,6 @@ test('percentage_multiple_nested_with_padding_margin_and_percentage_values', () 
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setMargin(Edge.Left, "5%");
     root_child0_child0_child0.setMargin(Edge.Top, "5%");
     root_child0_child0_child0.setMargin(Edge.Right, "5%");
@@ -822,7 +798,6 @@ test('percentage_multiple_nested_with_padding_margin_and_percentage_values', () 
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(4);
     root_child1.setFlexBasis("15%");
     root_child1.setMinWidth("20%");
@@ -901,7 +876,6 @@ test('percentage_margin_should_calculate_based_only_on_width', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setMargin(Edge.Left, "10%");
     root_child0.setMargin(Edge.Top, "10%");
@@ -910,7 +884,6 @@ test('percentage_margin_should_calculate_based_only_on_width', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(10);
     root_child0_child0.setHeight(10);
     root_child0.insertChild(root_child0_child0, 0);
@@ -968,7 +941,6 @@ test('percentage_padding_should_calculate_based_only_on_width', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setPadding(Edge.Left, "10%");
     root_child0.setPadding(Edge.Top, "10%");
@@ -977,7 +949,6 @@ test('percentage_padding_should_calculate_based_only_on_width', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(10);
     root_child0_child0.setHeight(10);
     root_child0.insertChild(root_child0_child0, 0);
@@ -1083,7 +1054,6 @@ test('percentage_width_height_undefined_parent_size', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth("50%");
     root_child0.setHeight("50%");
     root.insertChild(root_child0, 0);
@@ -1132,22 +1102,18 @@ test('percent_within_flex_grow', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setWidth("100%");
     root_child1.insertChild(root_child1_child0, 0);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setWidth(100);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -1226,24 +1192,20 @@ test('percentage_container_in_wrapping_container', () => {
     root.setHeight(200);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
     root_child0_child0.setFlexDirection(FlexDirection.Row);
     root_child0_child0.setJustifyContent(Justify.Center);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("100%");
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setWidth(50);
     root_child0_child0_child0.setHeight(50);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
 
     const root_child0_child0_child1 = Yoga.Node.create(config);
-    root_child0_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child0_child1.setWidth(50);
     root_child0_child0_child1.setHeight(50);
     root_child0_child0.insertChild(root_child0_child0_child1, 1);
@@ -1329,12 +1291,10 @@ test('percent_absolute_position', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("100%");
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setWidth("100%");
     root_child0.insertChild(root_child0_child1, 1);
     root.calculateLayout(undefined, undefined, Direction.LTR);

--- a/javascript/tests/generated/YGRoundingTest.test.ts
+++ b/javascript/tests/generated/YGRoundingTest.test.ts
@@ -39,17 +39,14 @@ test('rounding_flex_basis_flex_grow_row_width_of_100', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -117,27 +114,22 @@ test('rounding_flex_basis_flex_grow_row_prime_number_width', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root.insertChild(root_child2, 2);
 
     const root_child3 = Yoga.Node.create(config);
-    root_child3.setPositionType(PositionType.Relative);
     root_child3.setFlexGrow(1);
     root.insertChild(root_child3, 3);
 
     const root_child4 = Yoga.Node.create(config);
-    root_child4.setPositionType(PositionType.Relative);
     root_child4.setFlexGrow(1);
     root.insertChild(root_child4, 4);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -225,18 +217,15 @@ test('rounding_flex_basis_flex_shrink_row', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexShrink(1);
     root_child0.setFlexBasis(100);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexBasis(25);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexBasis(25);
     root.insertChild(root_child2, 2);
     root.calculateLayout(undefined, undefined, Direction.LTR);
@@ -303,20 +292,17 @@ test('rounding_flex_basis_overrides_main_size', () => {
     root.setHeight(113);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis(50);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
@@ -384,20 +370,17 @@ test('rounding_total_fractial', () => {
     root.setHeight(113.4);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(0.7);
     root_child0.setFlexBasis(50.3);
     root_child0.setHeight(20.3);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1.6);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1.1);
     root_child2.setHeight(10.7);
     root.insertChild(root_child2, 2);
@@ -465,14 +448,12 @@ test('rounding_total_fractial_nested', () => {
     root.setHeight(113.4);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(0.7);
     root_child0.setFlexBasis(50.3);
     root_child0.setHeight(20.3);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setFlexGrow(1);
     root_child0_child0.setFlexBasis(0.3);
     root_child0_child0.setPosition(Edge.Bottom, 13.3);
@@ -480,7 +461,6 @@ test('rounding_total_fractial_nested', () => {
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child1 = Yoga.Node.create(config);
-    root_child0_child1.setPositionType(PositionType.Relative);
     root_child0_child1.setFlexGrow(4);
     root_child0_child1.setFlexBasis(0.3);
     root_child0_child1.setPosition(Edge.Top, 13.3);
@@ -488,13 +468,11 @@ test('rounding_total_fractial_nested', () => {
     root_child0.insertChild(root_child0_child1, 1);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1.6);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1.1);
     root_child2.setHeight(10.7);
     root.insertChild(root_child2, 2);
@@ -582,20 +560,17 @@ test('rounding_fractial_input_1', () => {
     root.setHeight(113.4);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis(50);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
@@ -663,20 +638,17 @@ test('rounding_fractial_input_2', () => {
     root.setHeight(113.6);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis(50);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
@@ -745,20 +717,17 @@ test('rounding_fractial_input_3', () => {
     root.setHeight(113.4);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis(50);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
@@ -827,20 +796,17 @@ test('rounding_fractial_input_4', () => {
     root.setHeight(113.4);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setFlexBasis(50);
     root_child0.setHeight(20);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
@@ -908,25 +874,21 @@ test('rounding_inner_node_controversy_horizontal', () => {
     root.setWidth(320);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setHeight(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setHeight(10);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setFlexGrow(1);
     root_child1_child0.setHeight(10);
     root_child1.insertChild(root_child1_child0, 0);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setHeight(10);
     root.insertChild(root_child2, 2);
@@ -1003,25 +965,21 @@ test('rounding_inner_node_controversy_vertical', () => {
     root.setHeight(320);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setWidth(10);
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setWidth(10);
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setFlexGrow(1);
     root_child1_child0.setWidth(10);
     root_child1.insertChild(root_child1_child0, 0);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setWidth(10);
     root.insertChild(root_child2, 2);
@@ -1100,43 +1058,36 @@ test('rounding_inner_node_controversy_combined', () => {
     root.setHeight(320);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setFlexGrow(1);
     root_child0.setHeight("100%");
     root.insertChild(root_child0, 0);
 
     const root_child1 = Yoga.Node.create(config);
-    root_child1.setPositionType(PositionType.Relative);
     root_child1.setFlexGrow(1);
     root_child1.setHeight("100%");
     root.insertChild(root_child1, 1);
 
     const root_child1_child0 = Yoga.Node.create(config);
-    root_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child0.setFlexGrow(1);
     root_child1_child0.setWidth("100%");
     root_child1.insertChild(root_child1_child0, 0);
 
     const root_child1_child1 = Yoga.Node.create(config);
-    root_child1_child1.setPositionType(PositionType.Relative);
     root_child1_child1.setFlexGrow(1);
     root_child1_child1.setWidth("100%");
     root_child1.insertChild(root_child1_child1, 1);
 
     const root_child1_child1_child0 = Yoga.Node.create(config);
-    root_child1_child1_child0.setPositionType(PositionType.Relative);
     root_child1_child1_child0.setFlexGrow(1);
     root_child1_child1_child0.setWidth("100%");
     root_child1_child1.insertChild(root_child1_child1_child0, 0);
 
     const root_child1_child2 = Yoga.Node.create(config);
-    root_child1_child2.setPositionType(PositionType.Relative);
     root_child1_child2.setFlexGrow(1);
     root_child1_child2.setWidth("100%");
     root_child1.insertChild(root_child1_child2, 2);
 
     const root_child2 = Yoga.Node.create(config);
-    root_child2.setPositionType(PositionType.Relative);
     root_child2.setFlexGrow(1);
     root_child2.setHeight("100%");
     root.insertChild(root_child2, 2);

--- a/javascript/tests/generated/YGSizeOverflowTest.test.ts
+++ b/javascript/tests/generated/YGSizeOverflowTest.test.ts
@@ -38,11 +38,9 @@ test('nested_overflowing_child', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(200);
     root_child0_child0.setHeight(200);
     root_child0.insertChild(root_child0_child0, 0);
@@ -100,13 +98,11 @@ test('nested_overflowing_child_in_constraint_parent', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root_child0.setHeight(100);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(200);
     root_child0_child0.setHeight(200);
     root_child0.insertChild(root_child0_child0, 0);
@@ -164,12 +160,10 @@ test('parent_wrap_child_size_overflowing_parent', () => {
     root.setHeight(100);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(100);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(200);
     root_child0.insertChild(root_child0_child0, 0);

--- a/javascript/tests/generated/YGStaticPositionTest.test.ts
+++ b/javascript/tests/generated/YGStaticPositionTest.test.ts
@@ -36,6 +36,7 @@ test.skip('static_position_insets_have_no_effect_left_top', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
+    root_child0.setPositionType(PositionType.Static);
     root_child0.setPosition(Edge.Left, 50);
     root_child0.setPosition(Edge.Top, 50);
     root_child0.setWidth(100);
@@ -83,6 +84,7 @@ test.skip('static_position_insets_have_no_effect_right_bottom', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
+    root_child0.setPositionType(PositionType.Static);
     root_child0.setPosition(Edge.Right, 50);
     root_child0.setPosition(Edge.Bottom, 50);
     root_child0.setWidth(100);
@@ -130,12 +132,12 @@ test.skip('static_position_absolute_child_insets_relative_to_positioned_ancestor
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setMargin(Edge.Left, 100);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
@@ -210,30 +212,33 @@ test.skip('static_position_absolute_child_insets_relative_to_positioned_ancestor
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setMargin(Edge.Left, 100);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0_child0.setMargin(Edge.Left, 100);
     root_child0_child0_child0.setWidth(100);
     root_child0_child0_child0.setHeight(100);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
 
     const root_child0_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0_child0_child0.setMargin(Edge.Left, 100);
     root_child0_child0_child0_child0.setWidth(100);
     root_child0_child0_child0_child0.setHeight(100);
     root_child0_child0_child0.insertChild(root_child0_child0_child0_child0, 0);
 
     const root_child0_child0_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0_child0_child0_child0.setMargin(Edge.Left, 100);
     root_child0_child0_child0_child0_child0.setWidth(100);
     root_child0_child0_child0_child0_child0.setHeight(100);
@@ -338,12 +343,12 @@ test.skip('static_position_absolute_child_width_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
@@ -415,18 +420,17 @@ test.skip('static_position_relative_child_width_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setWidth("50%");
     root_child0_child0_child0.setHeight(50);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -492,17 +496,18 @@ test.skip('static_position_static_child_width_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0_child0.setWidth("50%");
     root_child0_child0_child0.setHeight(50);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -568,12 +573,12 @@ test.skip('static_position_absolute_child_height_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
@@ -645,18 +650,17 @@ test.skip('static_position_relative_child_height_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setWidth(50);
     root_child0_child0_child0.setHeight("50%");
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -722,17 +726,18 @@ test.skip('static_position_static_child_height_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0_child0.setWidth(50);
     root_child0_child0_child0.setHeight("50%");
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -798,12 +803,12 @@ test.skip('static_position_absolute_child_left_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
@@ -876,18 +881,17 @@ test.skip('static_position_relative_child_left_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setPosition(Edge.Left, "50%");
     root_child0_child0_child0.setWidth(50);
     root_child0_child0_child0.setHeight(50);
@@ -954,17 +958,18 @@ test.skip('static_position_static_child_left_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0_child0.setPosition(Edge.Left, "50%");
     root_child0_child0_child0.setWidth(50);
     root_child0_child0_child0.setHeight(50);
@@ -1031,12 +1036,12 @@ test.skip('static_position_absolute_child_right_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
@@ -1109,18 +1114,17 @@ test.skip('static_position_relative_child_right_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setPosition(Edge.Right, "50%");
     root_child0_child0_child0.setWidth(50);
     root_child0_child0_child0.setHeight(50);
@@ -1187,17 +1191,18 @@ test.skip('static_position_static_child_right_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0_child0.setPosition(Edge.Right, "50%");
     root_child0_child0_child0.setWidth(50);
     root_child0_child0_child0.setHeight(50);
@@ -1264,12 +1269,12 @@ test.skip('static_position_absolute_child_top_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
@@ -1342,18 +1347,17 @@ test.skip('static_position_relative_child_top_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setPosition(Edge.Top, "50%");
     root_child0_child0_child0.setWidth(50);
     root_child0_child0_child0.setHeight(50);
@@ -1420,17 +1424,18 @@ test.skip('static_position_static_child_top_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0_child0.setPosition(Edge.Top, "50%");
     root_child0_child0_child0.setWidth(50);
     root_child0_child0_child0.setHeight(50);
@@ -1497,12 +1502,12 @@ test.skip('static_position_absolute_child_bottom_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
@@ -1575,18 +1580,17 @@ test.skip('static_position_relative_child_bottom_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setPosition(Edge.Bottom, "50%");
     root_child0_child0_child0.setWidth(50);
     root_child0_child0_child0.setHeight(50);
@@ -1653,17 +1657,18 @@ test.skip('static_position_static_child_bottom_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0_child0.setPosition(Edge.Bottom, "50%");
     root_child0_child0_child0.setWidth(50);
     root_child0_child0_child0.setHeight(50);
@@ -1730,12 +1735,12 @@ test.skip('static_position_absolute_child_margin_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
@@ -1811,18 +1816,17 @@ test.skip('static_position_relative_child_margin_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setMargin(Edge.Left, "50%");
     root_child0_child0_child0.setMargin(Edge.Top, "50%");
     root_child0_child0_child0.setMargin(Edge.Right, "50%");
@@ -1892,17 +1896,18 @@ test.skip('static_position_static_child_margin_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0_child0.setMargin(Edge.Left, "50%");
     root_child0_child0_child0.setMargin(Edge.Top, "50%");
     root_child0_child0_child0.setMargin(Edge.Right, "50%");
@@ -1972,12 +1977,12 @@ test.skip('static_position_absolute_child_padding_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
@@ -2053,18 +2058,17 @@ test.skip('static_position_relative_child_padding_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setPadding(Edge.Left, "50%");
     root_child0_child0_child0.setPadding(Edge.Top, "50%");
     root_child0_child0_child0.setPadding(Edge.Right, "50%");
@@ -2134,17 +2138,18 @@ test.skip('static_position_static_child_padding_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0_child0.setPadding(Edge.Left, "50%");
     root_child0_child0_child0.setPadding(Edge.Top, "50%");
     root_child0_child0_child0.setPadding(Edge.Right, "50%");
@@ -2214,12 +2219,12 @@ test.skip('static_position_absolute_child_border_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
@@ -2291,18 +2296,17 @@ test.skip('static_position_relative_child_border_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setWidth(50);
     root_child0_child0_child0.setHeight(50);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -2368,17 +2372,18 @@ test.skip('static_position_static_child_border_percentage', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setWidth(200);
     root_child0.setHeight(200);
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0_child0.setWidth(50);
     root_child0_child0_child0.setHeight(50);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -2444,7 +2449,6 @@ test.skip('static_position_absolute_child_containing_block_padding_box', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPadding(Edge.Left, 100);
     root_child0.setPadding(Edge.Top, 100);
     root_child0.setPadding(Edge.Right, 100);
@@ -2454,6 +2458,7 @@ test.skip('static_position_absolute_child_containing_block_padding_box', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
@@ -2525,7 +2530,6 @@ test.skip('static_position_relative_child_containing_block_padding_box', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPadding(Edge.Left, 100);
     root_child0.setPadding(Edge.Top, 100);
     root_child0.setPadding(Edge.Right, 100);
@@ -2535,12 +2539,12 @@ test.skip('static_position_relative_child_containing_block_padding_box', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0_child0.setWidth("50%");
     root_child0_child0_child0.setHeight(50);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -2606,7 +2610,6 @@ test.skip('static_position_static_child_containing_block_padding_box', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPadding(Edge.Left, 100);
     root_child0.setPadding(Edge.Top, 100);
     root_child0.setPadding(Edge.Right, 100);
@@ -2616,11 +2619,13 @@ test.skip('static_position_static_child_containing_block_padding_box', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth(100);
     root_child0_child0.setHeight(100);
     root_child0.insertChild(root_child0_child0, 0);
 
     const root_child0_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0_child0.setWidth("50%");
     root_child0_child0_child0.setHeight(50);
     root_child0_child0.insertChild(root_child0_child0_child0, 0);
@@ -2686,7 +2691,6 @@ test.skip('static_position_absolute_child_containing_block_content_box', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPadding(Edge.Left, 100);
     root_child0.setPadding(Edge.Top, 100);
     root_child0.setPadding(Edge.Right, 100);
@@ -2752,7 +2756,6 @@ test.skip('static_position_relative_child_containing_block_content_box', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPadding(Edge.Left, 100);
     root_child0.setPadding(Edge.Top, 100);
     root_child0.setPadding(Edge.Right, 100);
@@ -2762,7 +2765,6 @@ test.skip('static_position_relative_child_containing_block_content_box', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
-    root_child0_child0.setPositionType(PositionType.Relative);
     root_child0_child0.setWidth("50%");
     root_child0_child0.setHeight(50);
     root_child0.insertChild(root_child0_child0, 0);
@@ -2818,7 +2820,6 @@ test.skip('static_position_static_child_containing_block_content_box', () => {
     root.setPositionType(PositionType.Absolute);
 
     const root_child0 = Yoga.Node.create(config);
-    root_child0.setPositionType(PositionType.Relative);
     root_child0.setPadding(Edge.Left, 100);
     root_child0.setPadding(Edge.Top, 100);
     root_child0.setPadding(Edge.Right, 100);
@@ -2828,6 +2829,7 @@ test.skip('static_position_static_child_containing_block_content_box', () => {
     root.insertChild(root_child0, 0);
 
     const root_child0_child0 = Yoga.Node.create(config);
+    root_child0_child0.setPositionType(PositionType.Static);
     root_child0_child0.setWidth("50%");
     root_child0_child0.setHeight(50);
     root_child0.insertChild(root_child0_child0, 0);

--- a/tests/YGDefaultValuesTest.cpp
+++ b/tests/YGDefaultValuesTest.cpp
@@ -20,7 +20,7 @@ TEST(YogaTest, assert_default_values) {
   ASSERT_EQ(YGAlignFlexStart, YGNodeStyleGetAlignContent(root));
   ASSERT_EQ(YGAlignStretch, YGNodeStyleGetAlignItems(root));
   ASSERT_EQ(YGAlignAuto, YGNodeStyleGetAlignSelf(root));
-  ASSERT_EQ(YGPositionTypeStatic, YGNodeStyleGetPositionType(root));
+  ASSERT_EQ(YGPositionTypeRelative, YGNodeStyleGetPositionType(root));
   ASSERT_EQ(YGWrapNoWrap, YGNodeStyleGetFlexWrap(root));
   ASSERT_EQ(YGOverflowVisible, YGNodeStyleGetOverflow(root));
   ASSERT_FLOAT_EQ(0, YGNodeStyleGetFlexGrow(root));

--- a/tests/generated/YGAbsolutePositionTest.cpp
+++ b/tests/generated/YGAbsolutePositionTest.cpp
@@ -211,7 +211,6 @@ TEST(YogaTest, do_not_clamp_height_of_absolute_node_to_height_of_its_overflow_hi
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -1083,7 +1082,6 @@ TEST(YogaTest, percent_absolute_position_infinite_height) {
   YGNodeStyleSetWidth(root, 300);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 300);
   YGNodeInsertChild(root, root_child0, 0);
 
@@ -1185,7 +1183,6 @@ TEST(YogaTest, absolute_layout_percentage_height_based_on_padded_parent_and_alig
   const YGNodeRef root = YGNodeNewWithConfig(config);
   YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
   YGNodeStyleSetAlignItems(root, YGAlignCenter);
-  YGNodeStyleSetPositionType(root, YGPositionTypeRelative);
   YGNodeStyleSetPadding(root, YGEdgeTop, 20);
   YGNodeStyleSetPadding(root, YGEdgeBottom, 20);
   YGNodeStyleSetWidth(root, 100);

--- a/tests/generated/YGAlignContentTest.cpp
+++ b/tests/generated/YGAlignContentTest.cpp
@@ -22,13 +22,11 @@ TEST(YogaTest, align_content_flex_start_nowrap) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
@@ -83,31 +81,26 @@ TEST(YogaTest, align_content_flex_start_wrap) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeStyleSetHeight(root_child3, 10);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeStyleSetHeight(root_child4, 10);
   YGNodeInsertChild(root, root_child4, 4);
@@ -192,13 +185,11 @@ TEST(YogaTest, align_content_flex_start_wrap_singleline) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
@@ -257,25 +248,21 @@ TEST(YogaTest, align_content_flex_start_wrapped_negative_space) {
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 80);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 20);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child2, 80);
   YGNodeStyleSetHeight(root_child0_child2, 20);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
@@ -354,7 +341,6 @@ TEST(YogaTest, align_content_flex_start_wrapped_negative_space_gap) {
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeStyleSetGap(root_child0, YGGutterColumn, 10);
@@ -362,19 +348,16 @@ TEST(YogaTest, align_content_flex_start_wrapped_negative_space_gap) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 80);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 20);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child2, 80);
   YGNodeStyleSetHeight(root_child0_child2, 20);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
@@ -448,29 +431,24 @@ TEST(YogaTest, align_content_flex_start_without_height_on_children) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeStyleSetHeight(root_child3, 10);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -553,14 +531,12 @@ TEST(YogaTest, align_content_flex_start_with_flex) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 0);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1, 0);
   YGNodeStyleSetWidth(root_child1, 50);
@@ -568,12 +544,10 @@ TEST(YogaTest, align_content_flex_start_with_flex) {
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child3, 1);
   YGNodeStyleSetFlexShrink(root_child3, 1);
   YGNodeStyleSetFlexBasisPercent(root_child3, 0);
@@ -581,7 +555,6 @@ TEST(YogaTest, align_content_flex_start_with_flex) {
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -665,13 +638,11 @@ TEST(YogaTest, align_content_flex_end_nowrap) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
@@ -727,31 +698,26 @@ TEST(YogaTest, align_content_flex_end_wrap) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeStyleSetHeight(root_child3, 10);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeStyleSetHeight(root_child4, 10);
   YGNodeInsertChild(root, root_child4, 4);
@@ -837,13 +803,11 @@ TEST(YogaTest, align_content_flex_end_wrap_singleline) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
@@ -903,25 +867,21 @@ TEST(YogaTest, align_content_flex_end_wrapped_negative_space) {
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
   YGNodeStyleSetAlignContent(root_child0, YGAlignFlexEnd);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 80);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 20);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child2, 80);
   YGNodeStyleSetHeight(root_child0_child2, 20);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
@@ -1001,7 +961,6 @@ TEST(YogaTest, align_content_flex_end_wrapped_negative_space_gap) {
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
   YGNodeStyleSetAlignContent(root_child0, YGAlignFlexEnd);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeStyleSetGap(root_child0, YGGutterColumn, 10);
@@ -1009,19 +968,16 @@ TEST(YogaTest, align_content_flex_end_wrapped_negative_space_gap) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 80);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 20);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child2, 80);
   YGNodeStyleSetHeight(root_child0_child2, 20);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
@@ -1096,13 +1052,11 @@ TEST(YogaTest, align_content_center_nowrap) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1158,31 +1112,26 @@ TEST(YogaTest, align_content_center_wrap) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeStyleSetHeight(root_child3, 10);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeStyleSetHeight(root_child4, 10);
   YGNodeInsertChild(root, root_child4, 4);
@@ -1268,13 +1217,11 @@ TEST(YogaTest, align_content_center_wrap_singleline) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1334,25 +1281,21 @@ TEST(YogaTest, align_content_center_wrapped_negative_space) {
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
   YGNodeStyleSetAlignContent(root_child0, YGAlignCenter);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 80);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 20);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child2, 80);
   YGNodeStyleSetHeight(root_child0_child2, 20);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
@@ -1432,7 +1375,6 @@ TEST(YogaTest, align_content_center_wrapped_negative_space_gap) {
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
   YGNodeStyleSetAlignContent(root_child0, YGAlignCenter);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeStyleSetGap(root_child0, YGGutterColumn, 10);
@@ -1440,19 +1382,16 @@ TEST(YogaTest, align_content_center_wrapped_negative_space_gap) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 80);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 20);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child2, 80);
   YGNodeStyleSetHeight(root_child0_child2, 20);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
@@ -1527,13 +1466,11 @@ TEST(YogaTest, align_content_space_between_nowrap) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1589,31 +1526,26 @@ TEST(YogaTest, align_content_space_between_wrap) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeStyleSetHeight(root_child3, 10);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeStyleSetHeight(root_child4, 10);
   YGNodeInsertChild(root, root_child4, 4);
@@ -1699,13 +1631,11 @@ TEST(YogaTest, align_content_space_between_wrap_singleline) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1765,25 +1695,21 @@ TEST(YogaTest, align_content_space_between_wrapped_negative_space) {
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
   YGNodeStyleSetAlignContent(root_child0, YGAlignSpaceBetween);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 80);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 20);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child2, 80);
   YGNodeStyleSetHeight(root_child0_child2, 20);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
@@ -1863,7 +1789,6 @@ TEST(YogaTest, align_content_space_between_wrapped_negative_space_gap) {
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
   YGNodeStyleSetAlignContent(root_child0, YGAlignSpaceBetween);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeStyleSetGap(root_child0, YGGutterColumn, 10);
@@ -1871,19 +1796,16 @@ TEST(YogaTest, align_content_space_between_wrapped_negative_space_gap) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 80);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 20);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child2, 80);
   YGNodeStyleSetHeight(root_child0_child2, 20);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
@@ -1958,13 +1880,11 @@ TEST(YogaTest, align_content_space_around_nowrap) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
@@ -2020,31 +1940,26 @@ TEST(YogaTest, align_content_space_around_wrap) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeStyleSetHeight(root_child3, 10);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeStyleSetHeight(root_child4, 10);
   YGNodeInsertChild(root, root_child4, 4);
@@ -2130,13 +2045,11 @@ TEST(YogaTest, align_content_space_around_wrap_singleline) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
@@ -2196,25 +2109,21 @@ TEST(YogaTest, align_content_space_around_wrapped_negative_space) {
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
   YGNodeStyleSetAlignContent(root_child0, YGAlignSpaceAround);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 80);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 20);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child2, 80);
   YGNodeStyleSetHeight(root_child0_child2, 20);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
@@ -2294,7 +2203,6 @@ TEST(YogaTest, align_content_space_around_wrapped_negative_space_gap) {
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
   YGNodeStyleSetAlignContent(root_child0, YGAlignSpaceAround);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeStyleSetGap(root_child0, YGGutterColumn, 10);
@@ -2302,19 +2210,16 @@ TEST(YogaTest, align_content_space_around_wrapped_negative_space_gap) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 80);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 20);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child2, 80);
   YGNodeStyleSetHeight(root_child0_child2, 20);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
@@ -2389,13 +2294,11 @@ TEST(YogaTest, align_content_space_evenly_nowrap) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
@@ -2451,31 +2354,26 @@ TEST(YogaTest, align_content_space_evenly_wrap) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeStyleSetHeight(root_child3, 10);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeStyleSetHeight(root_child4, 10);
   YGNodeInsertChild(root, root_child4, 4);
@@ -2561,13 +2459,11 @@ TEST(YogaTest, align_content_space_evenly_wrap_singleline) {
   YGNodeStyleSetHeight(root, 120);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
@@ -2627,25 +2523,21 @@ TEST(YogaTest, align_content_space_evenly_wrapped_negative_space) {
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
   YGNodeStyleSetAlignContent(root_child0, YGAlignSpaceEvenly);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 80);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 20);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child2, 80);
   YGNodeStyleSetHeight(root_child0_child2, 20);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
@@ -2725,7 +2617,6 @@ TEST(YogaTest, align_content_space_evenly_wrapped_negative_space_gap) {
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
   YGNodeStyleSetAlignContent(root_child0, YGAlignSpaceEvenly);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeStyleSetGap(root_child0, YGGutterColumn, 10);
@@ -2733,19 +2624,16 @@ TEST(YogaTest, align_content_space_evenly_wrapped_negative_space_gap) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 80);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 20);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child2, 80);
   YGNodeStyleSetHeight(root_child0_child2, 20);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
@@ -2820,27 +2708,22 @@ TEST(YogaTest, align_content_stretch) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2925,27 +2808,22 @@ TEST(YogaTest, align_content_stretch_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3030,34 +2908,28 @@ TEST(YogaTest, align_content_stretch_row_with_children) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0_child0, 0);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3152,12 +3024,10 @@ TEST(YogaTest, align_content_stretch_row_with_flex) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexShrink(root_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1, 0);
@@ -3165,12 +3035,10 @@ TEST(YogaTest, align_content_stretch_row_with_flex) {
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child3, 1);
   YGNodeStyleSetFlexShrink(root_child3, 1);
   YGNodeStyleSetFlexBasisPercent(root_child3, 0);
@@ -3178,7 +3046,6 @@ TEST(YogaTest, align_content_stretch_row_with_flex) {
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3263,12 +3130,10 @@ TEST(YogaTest, align_content_stretch_row_with_flex_no_shrink) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexShrink(root_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1, 0);
@@ -3276,19 +3141,16 @@ TEST(YogaTest, align_content_stretch_row_with_flex_no_shrink) {
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child3, 1);
   YGNodeStyleSetFlexBasisPercent(root_child3, 0);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3373,12 +3235,10 @@ TEST(YogaTest, align_content_stretch_row_with_margin) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child1, YGEdgeLeft, 10);
   YGNodeStyleSetMargin(root_child1, YGEdgeTop, 10);
   YGNodeStyleSetMargin(root_child1, YGEdgeRight, 10);
@@ -3387,12 +3247,10 @@ TEST(YogaTest, align_content_stretch_row_with_margin) {
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child3, YGEdgeLeft, 10);
   YGNodeStyleSetMargin(root_child3, YGEdgeTop, 10);
   YGNodeStyleSetMargin(root_child3, YGEdgeRight, 10);
@@ -3401,7 +3259,6 @@ TEST(YogaTest, align_content_stretch_row_with_margin) {
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3486,12 +3343,10 @@ TEST(YogaTest, align_content_stretch_row_with_padding) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetPadding(root_child1, YGEdgeLeft, 10);
   YGNodeStyleSetPadding(root_child1, YGEdgeTop, 10);
   YGNodeStyleSetPadding(root_child1, YGEdgeRight, 10);
@@ -3500,12 +3355,10 @@ TEST(YogaTest, align_content_stretch_row_with_padding) {
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetPadding(root_child3, YGEdgeLeft, 10);
   YGNodeStyleSetPadding(root_child3, YGEdgeTop, 10);
   YGNodeStyleSetPadding(root_child3, YGEdgeRight, 10);
@@ -3514,7 +3367,6 @@ TEST(YogaTest, align_content_stretch_row_with_padding) {
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3599,12 +3451,10 @@ TEST(YogaTest, align_content_stretch_row_with_single_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3659,28 +3509,23 @@ TEST(YogaTest, align_content_stretch_row_with_fixed_height) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 60);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3765,28 +3610,23 @@ TEST(YogaTest, align_content_stretch_row_with_max_height) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetMaxHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3871,28 +3711,23 @@ TEST(YogaTest, align_content_stretch_row_with_min_height) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetMinHeight(root_child1, 80);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3976,19 +3811,16 @@ TEST(YogaTest, align_content_stretch_column) {
   YGNodeStyleSetHeight(root, 150);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0_child0, 0);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexShrink(root_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1, 0);
@@ -3996,17 +3828,14 @@ TEST(YogaTest, align_content_stretch_column) {
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child3, 50);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -4100,14 +3929,12 @@ TEST(YogaTest, align_content_stretch_is_not_overriding_align_items) {
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root_child0, YGAlignStretch);
   YGNodeStyleSetAlignItems(root_child0, YGAlignCenter);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignContent(root_child0_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 10);
   YGNodeStyleSetHeight(root_child0_child0, 10);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);

--- a/tests/generated/YGAlignItemsTest.cpp
+++ b/tests/generated/YGAlignItemsTest.cpp
@@ -21,7 +21,6 @@ TEST(YogaTest, align_items_stretch) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -64,7 +63,6 @@ TEST(YogaTest, align_items_center) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -108,7 +106,6 @@ TEST(YogaTest, align_items_flex_start) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -152,7 +149,6 @@ TEST(YogaTest, align_items_flex_end) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -197,13 +193,11 @@ TEST(YogaTest, align_baseline) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
@@ -258,19 +252,16 @@ TEST(YogaTest, align_baseline_child) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child0, 50);
   YGNodeStyleSetHeight(root_child1_child0, 10);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
@@ -335,39 +326,33 @@ TEST(YogaTest, align_baseline_child_multiline) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child1, YGFlexDirectionRow);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child1, YGWrapWrap);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 25);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child0, 25);
   YGNodeStyleSetHeight(root_child1_child0, 20);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
 
   const YGNodeRef root_child1_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child1, 25);
   YGNodeStyleSetHeight(root_child1_child1, 10);
   YGNodeInsertChild(root_child1, root_child1_child1, 1);
 
   const YGNodeRef root_child1_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child2, 25);
   YGNodeStyleSetHeight(root_child1_child2, 20);
   YGNodeInsertChild(root_child1, root_child1_child2, 2);
 
   const YGNodeRef root_child1_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child3, 25);
   YGNodeStyleSetHeight(root_child1_child3, 10);
   YGNodeInsertChild(root_child1, root_child1_child3, 3);
@@ -462,41 +447,35 @@ TEST(YogaTest, align_baseline_child_multiline_override) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child1, YGFlexDirectionRow);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child1, YGWrapWrap);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 25);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child0, 25);
   YGNodeStyleSetHeight(root_child1_child0, 20);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
 
   const YGNodeRef root_child1_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignSelf(root_child1_child1, YGAlignBaseline);
-  YGNodeStyleSetPositionType(root_child1_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child1, 25);
   YGNodeStyleSetHeight(root_child1_child1, 10);
   YGNodeInsertChild(root_child1, root_child1_child1, 1);
 
   const YGNodeRef root_child1_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child2, 25);
   YGNodeStyleSetHeight(root_child1_child2, 20);
   YGNodeInsertChild(root_child1, root_child1_child2, 2);
 
   const YGNodeRef root_child1_child3 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignSelf(root_child1_child3, YGAlignBaseline);
-  YGNodeStyleSetPositionType(root_child1_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child3, 25);
   YGNodeStyleSetHeight(root_child1_child3, 10);
   YGNodeInsertChild(root_child1, root_child1_child3, 3);
@@ -591,40 +570,34 @@ TEST(YogaTest, align_baseline_child_multiline_no_override_on_secondline) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child1, YGFlexDirectionRow);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child1, YGWrapWrap);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 25);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child0, 25);
   YGNodeStyleSetHeight(root_child1_child0, 20);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
 
   const YGNodeRef root_child1_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child1, 25);
   YGNodeStyleSetHeight(root_child1_child1, 10);
   YGNodeInsertChild(root_child1, root_child1_child1, 1);
 
   const YGNodeRef root_child1_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child2, 25);
   YGNodeStyleSetHeight(root_child1_child2, 20);
   YGNodeInsertChild(root_child1, root_child1_child2, 2);
 
   const YGNodeRef root_child1_child3 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignSelf(root_child1_child3, YGAlignBaseline);
-  YGNodeStyleSetPositionType(root_child1_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child3, 25);
   YGNodeStyleSetHeight(root_child1_child3, 10);
   YGNodeInsertChild(root_child1, root_child1_child3, 3);
@@ -719,20 +692,17 @@ TEST(YogaTest, align_baseline_child_top) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPosition(root_child0, YGEdgeTop, 10);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child0, 50);
   YGNodeStyleSetHeight(root_child1_child0, 10);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
@@ -797,20 +767,17 @@ TEST(YogaTest, align_baseline_child_top2) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetPosition(root_child1, YGEdgeTop, 5);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child0, 50);
   YGNodeStyleSetHeight(root_child1_child0, 10);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
@@ -875,25 +842,21 @@ TEST(YogaTest, align_baseline_double_nested_child) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child0, 50);
   YGNodeStyleSetHeight(root_child1_child0, 15);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
@@ -967,13 +930,11 @@ TEST(YogaTest, align_baseline_column) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1028,7 +989,6 @@ TEST(YogaTest, align_baseline_child_margin) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0, YGEdgeLeft, 5);
   YGNodeStyleSetMargin(root_child0, YGEdgeTop, 5);
   YGNodeStyleSetMargin(root_child0, YGEdgeRight, 5);
@@ -1038,13 +998,11 @@ TEST(YogaTest, align_baseline_child_margin) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child1_child0, YGEdgeLeft, 1);
   YGNodeStyleSetMargin(root_child1_child0, YGEdgeTop, 1);
   YGNodeStyleSetMargin(root_child1_child0, YGEdgeRight, 1);
@@ -1117,13 +1075,11 @@ TEST(YogaTest, align_baseline_child_padding) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetPadding(root_child1, YGEdgeLeft, 5);
   YGNodeStyleSetPadding(root_child1, YGEdgeTop, 5);
   YGNodeStyleSetPadding(root_child1, YGEdgeRight, 5);
@@ -1133,7 +1089,6 @@ TEST(YogaTest, align_baseline_child_padding) {
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child0, 50);
   YGNodeStyleSetHeight(root_child1_child0, 10);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
@@ -1199,37 +1154,31 @@ TEST(YogaTest, align_baseline_multiline) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child0, 50);
   YGNodeStyleSetHeight(root_child1_child0, 10);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeStyleSetHeight(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child2_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2_child0, 50);
   YGNodeStyleSetHeight(root_child2_child0, 10);
   YGNodeInsertChild(root_child2, root_child2_child0, 0);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeStyleSetHeight(root_child3, 50);
   YGNodeInsertChild(root, root_child3, 3);
@@ -1326,37 +1275,31 @@ TEST(YogaTest, align_baseline_multiline_column) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 30);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child0, 20);
   YGNodeStyleSetHeight(root_child1_child0, 20);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 40);
   YGNodeStyleSetHeight(root_child2, 70);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child2_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2_child0, 10);
   YGNodeStyleSetHeight(root_child2_child0, 10);
   YGNodeInsertChild(root_child2, root_child2_child0, 0);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeStyleSetHeight(root_child3, 20);
   YGNodeInsertChild(root, root_child3, 3);
@@ -1453,37 +1396,31 @@ TEST(YogaTest, align_baseline_multiline_column2) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 30);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child0, 20);
   YGNodeStyleSetHeight(root_child1_child0, 20);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 40);
   YGNodeStyleSetHeight(root_child2, 70);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child2_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2_child0, 10);
   YGNodeStyleSetHeight(root_child2_child0, 10);
   YGNodeInsertChild(root_child2, root_child2_child0, 0);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeStyleSetHeight(root_child3, 20);
   YGNodeInsertChild(root, root_child3, 3);
@@ -1579,37 +1516,31 @@ TEST(YogaTest, align_baseline_multiline_row_and_column) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child0, 50);
   YGNodeStyleSetHeight(root_child1_child0, 10);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeStyleSetHeight(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child2_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2_child0, 50);
   YGNodeStyleSetHeight(root_child2_child0, 10);
   YGNodeInsertChild(root_child2, root_child2_child0, 0);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 50);
   YGNodeStyleSetHeight(root_child3, 20);
   YGNodeInsertChild(root, root_child3, 3);
@@ -1705,11 +1636,9 @@ TEST(YogaTest, align_items_center_child_with_margin_bigger_than_parent) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignItems(root_child0, YGAlignCenter);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0_child0, YGEdgeLeft, 10);
   YGNodeStyleSetMargin(root_child0_child0, YGEdgeRight, 10);
   YGNodeStyleSetWidth(root_child0_child0, 52);
@@ -1767,11 +1696,9 @@ TEST(YogaTest, align_items_flex_end_child_with_margin_bigger_than_parent) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignItems(root_child0, YGAlignFlexEnd);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0_child0, YGEdgeLeft, 10);
   YGNodeStyleSetMargin(root_child0_child0, YGEdgeRight, 10);
   YGNodeStyleSetWidth(root_child0_child0, 52);
@@ -1829,11 +1756,9 @@ TEST(YogaTest, align_items_center_child_without_margin_bigger_than_parent) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignItems(root_child0, YGAlignCenter);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 72);
   YGNodeStyleSetHeight(root_child0_child0, 72);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -1889,11 +1814,9 @@ TEST(YogaTest, align_items_flex_end_child_without_margin_bigger_than_parent) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignItems(root_child0, YGAlignFlexEnd);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 72);
   YGNodeStyleSetHeight(root_child0_child0, 72);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -1949,18 +1872,15 @@ TEST(YogaTest, align_center_should_size_based_on_content) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0, 1);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child0, 20);
   YGNodeStyleSetHeight(root_child0_child0_child0, 20);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -2025,18 +1945,15 @@ TEST(YogaTest, align_stretch_should_size_based_on_parent) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifyCenter);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0, 1);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child0, 20);
   YGNodeStyleSetHeight(root_child0_child0_child0, 20);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -2100,17 +2017,14 @@ TEST(YogaTest, align_flex_start_with_shrinking_children) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignItems(root_child0, YGAlignFlexStart);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0, 1);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0_child0, 1);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -2173,17 +2087,14 @@ TEST(YogaTest, align_flex_start_with_stretching_children) {
   YGNodeStyleSetHeight(root, 500);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0, 1);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0_child0, 1);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -2247,17 +2158,14 @@ TEST(YogaTest, align_flex_start_with_shrinking_children_with_stretch) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignItems(root_child0, YGAlignFlexStart);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0, 1);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0_child0, 1);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);

--- a/tests/generated/YGAlignSelfTest.cpp
+++ b/tests/generated/YGAlignSelfTest.cpp
@@ -22,7 +22,6 @@ TEST(YogaTest, align_self_center) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignSelf(root_child0, YGAlignCenter);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -66,7 +65,6 @@ TEST(YogaTest, align_self_flex_end) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignSelf(root_child0, YGAlignFlexEnd);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -110,7 +108,6 @@ TEST(YogaTest, align_self_flex_start) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignSelf(root_child0, YGAlignFlexStart);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -155,7 +152,6 @@ TEST(YogaTest, align_self_flex_end_override_flex_start) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignSelf(root_child0, YGAlignFlexEnd);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -200,20 +196,17 @@ TEST(YogaTest, align_self_baseline) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignSelf(root_child0, YGAlignBaseline);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignSelf(root_child1, YGAlignBaseline);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1_child0, 50);
   YGNodeStyleSetHeight(root_child1_child0, 10);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);

--- a/tests/generated/YGAndroidNewsFeed.cpp
+++ b/tests/generated/YGAndroidNewsFeed.cpp
@@ -21,24 +21,20 @@ TEST(YogaTest, android_news_feed) {
   YGNodeStyleSetWidth(root, 1080);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignContent(root_child0_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignContent(root_child0_child0_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0_child0_child0_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root_child0_child0_child0_child0, YGAlignStretch);
   YGNodeStyleSetAlignItems(root_child0_child0_child0_child0, YGAlignFlexStart);
-  YGNodeStyleSetPositionType(root_child0_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0_child0_child0_child0, YGEdgeStart, 36);
   YGNodeStyleSetMargin(root_child0_child0_child0_child0, YGEdgeTop, 24);
   YGNodeInsertChild(root_child0_child0_child0, root_child0_child0_child0_child0, 0);
@@ -46,19 +42,16 @@ TEST(YogaTest, android_news_feed) {
   const YGNodeRef root_child0_child0_child0_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0_child0_child0_child0_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root_child0_child0_child0_child0_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child0_child0_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root_child0_child0_child0_child0, root_child0_child0_child0_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0_child0_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignContent(root_child0_child0_child0_child0_child0_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child0_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child0_child0_child0_child0, 120);
   YGNodeStyleSetHeight(root_child0_child0_child0_child0_child0_child0, 120);
   YGNodeInsertChild(root_child0_child0_child0_child0_child0, root_child0_child0_child0_child0_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0_child0_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignContent(root_child0_child0_child0_child0_child1, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child0_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0_child0_child0_child0_child1, 1);
   YGNodeStyleSetMargin(root_child0_child0_child0_child0_child1, YGEdgeRight, 36);
   YGNodeStyleSetPadding(root_child0_child0_child0_child0_child1, YGEdgeLeft, 36);
@@ -70,26 +63,22 @@ TEST(YogaTest, android_news_feed) {
   const YGNodeRef root_child0_child0_child0_child0_child1_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0_child0_child0_child0_child1_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root_child0_child0_child0_child0_child1_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child0_child0_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0_child0_child0_child0_child1_child0, 1);
   YGNodeInsertChild(root_child0_child0_child0_child0_child1, root_child0_child0_child0_child0_child1_child0, 0);
 
   const YGNodeRef root_child0_child0_child0_child0_child1_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignContent(root_child0_child0_child0_child0_child1_child1, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child0_child0_child1_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0_child0_child0_child0_child1_child1, 1);
   YGNodeInsertChild(root_child0_child0_child0_child0_child1, root_child0_child0_child0_child0_child1_child1, 1);
 
   const YGNodeRef root_child0_child0_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignContent(root_child0_child0_child1, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child1, YGPositionTypeRelative);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child1, 1);
 
   const YGNodeRef root_child0_child0_child1_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0_child0_child1_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root_child0_child0_child1_child0, YGAlignStretch);
   YGNodeStyleSetAlignItems(root_child0_child0_child1_child0, YGAlignFlexStart);
-  YGNodeStyleSetPositionType(root_child0_child0_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0_child0_child1_child0, YGEdgeStart, 174);
   YGNodeStyleSetMargin(root_child0_child0_child1_child0, YGEdgeTop, 24);
   YGNodeInsertChild(root_child0_child0_child1, root_child0_child0_child1_child0, 0);
@@ -97,19 +86,16 @@ TEST(YogaTest, android_news_feed) {
   const YGNodeRef root_child0_child0_child1_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0_child0_child1_child0_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root_child0_child0_child1_child0_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child1_child0_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root_child0_child0_child1_child0, root_child0_child0_child1_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child1_child0_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignContent(root_child0_child0_child1_child0_child0_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child1_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child1_child0_child0_child0, 72);
   YGNodeStyleSetHeight(root_child0_child0_child1_child0_child0_child0, 72);
   YGNodeInsertChild(root_child0_child0_child1_child0_child0, root_child0_child0_child1_child0_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child1_child0_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignContent(root_child0_child0_child1_child0_child1, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child1_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0_child0_child1_child0_child1, 1);
   YGNodeStyleSetMargin(root_child0_child0_child1_child0_child1, YGEdgeRight, 36);
   YGNodeStyleSetPadding(root_child0_child0_child1_child0_child1, YGEdgeLeft, 36);
@@ -121,13 +107,11 @@ TEST(YogaTest, android_news_feed) {
   const YGNodeRef root_child0_child0_child1_child0_child1_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0_child0_child1_child0_child1_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root_child0_child0_child1_child0_child1_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child1_child0_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0_child0_child1_child0_child1_child0, 1);
   YGNodeInsertChild(root_child0_child0_child1_child0_child1, root_child0_child0_child1_child0_child1_child0, 0);
 
   const YGNodeRef root_child0_child0_child1_child0_child1_child1 = YGNodeNewWithConfig(config);
   YGNodeStyleSetAlignContent(root_child0_child0_child1_child0_child1_child1, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child1_child0_child1_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0_child0_child1_child0_child1_child1, 1);
   YGNodeInsertChild(root_child0_child0_child1_child0_child1, root_child0_child0_child1_child0_child1_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);

--- a/tests/generated/YGAspectRatioTest.cpp
+++ b/tests/generated/YGAspectRatioTest.cpp
@@ -23,7 +23,6 @@ TEST(YogaTest, aspect_ratio_does_not_stretch_cross_axis_dim) {
   YGNodeStyleSetHeight(root, 300);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetOverflow(root_child0, YGOverflowScroll);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0, 1);
@@ -32,11 +31,9 @@ TEST(YogaTest, aspect_ratio_does_not_stretch_cross_axis_dim) {
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0_child0, YGFlexDirectionRow);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0_child0, 2);
   YGNodeStyleSetFlexShrink(root_child0_child0_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0_child0_child0, 0);
@@ -44,19 +41,16 @@ TEST(YogaTest, aspect_ratio_does_not_stretch_cross_axis_dim) {
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child1, 5);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child1, 1);
 
   const YGNodeRef root_child0_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0_child2, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0_child2, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0_child0_child2, 0);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child2, 2);
 
   const YGNodeRef root_child0_child0_child2_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child2_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0_child2_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0_child2_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0_child0_child2_child0, 0);
@@ -64,12 +58,10 @@ TEST(YogaTest, aspect_ratio_does_not_stretch_cross_axis_dim) {
   YGNodeInsertChild(root_child0_child0_child2, root_child0_child0_child2_child0, 0);
 
   const YGNodeRef root_child0_child0_child2_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child2_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child2_child0_child0, 5);
   YGNodeInsertChild(root_child0_child0_child2_child0, root_child0_child0_child2_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child2_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child2_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0_child2_child0_child1, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0_child2_child0_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0_child0_child2_child0_child1, 0);

--- a/tests/generated/YGBorderTest.cpp
+++ b/tests/generated/YGBorderTest.cpp
@@ -52,7 +52,6 @@ TEST(YogaTest, border_container_match_child) {
   YGNodeStyleSetBorder(root, YGEdgeBottom, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -99,7 +98,6 @@ TEST(YogaTest, border_flex_child) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -146,7 +144,6 @@ TEST(YogaTest, border_stretch_child) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -193,7 +190,6 @@ TEST(YogaTest, border_center_child) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);

--- a/tests/generated/YGDimensionTest.cpp
+++ b/tests/generated/YGDimensionTest.cpp
@@ -19,7 +19,6 @@ TEST(YogaTest, wrap_child) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -60,11 +59,9 @@ TEST(YogaTest, wrap_grandchild) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);

--- a/tests/generated/YGDisplayTest.cpp
+++ b/tests/generated/YGDisplayTest.cpp
@@ -22,12 +22,10 @@ TEST(YogaTest, display_none) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetDisplay(root_child1, YGDisplayNone);
   YGNodeInsertChild(root, root_child1, 1);
@@ -81,12 +79,10 @@ TEST(YogaTest, display_none_fixed_size) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeStyleSetDisplay(root_child1, YGDisplayNone);
@@ -141,7 +137,6 @@ TEST(YogaTest, display_none_with_margin) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0, YGEdgeLeft, 10);
   YGNodeStyleSetMargin(root_child0, YGEdgeTop, 10);
   YGNodeStyleSetMargin(root_child0, YGEdgeRight, 10);
@@ -152,7 +147,6 @@ TEST(YogaTest, display_none_with_margin) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -205,14 +199,12 @@ TEST(YogaTest, display_none_with_child) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 0);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexShrink(root_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1, 0);
@@ -220,7 +212,6 @@ TEST(YogaTest, display_none_with_child) {
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1_child0, 1);
   YGNodeStyleSetFlexShrink(root_child1_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1_child0, 0);
@@ -228,7 +219,6 @@ TEST(YogaTest, display_none_with_child) {
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetFlexShrink(root_child2, 1);
   YGNodeStyleSetFlexBasisPercent(root_child2, 0);
@@ -303,12 +293,10 @@ TEST(YogaTest, display_none_with_position) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetPosition(root_child1, YGEdgeTop, 10);
   YGNodeStyleSetDisplay(root_child1, YGDisplayNone);

--- a/tests/generated/YGFlexDirectionTest.cpp
+++ b/tests/generated/YGFlexDirectionTest.cpp
@@ -20,17 +20,14 @@ TEST(YogaTest, flex_direction_column_no_height) {
   YGNodeStyleSetWidth(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -92,17 +89,14 @@ TEST(YogaTest, flex_direction_row_no_width) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -164,17 +158,14 @@ TEST(YogaTest, flex_direction_column) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -237,17 +228,14 @@ TEST(YogaTest, flex_direction_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -310,17 +298,14 @@ TEST(YogaTest, flex_direction_column_reverse) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -383,17 +368,14 @@ TEST(YogaTest, flex_direction_row_reverse) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -457,17 +439,14 @@ TEST(YogaTest, flex_direction_row_reverse_margin_left) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -531,17 +510,14 @@ TEST(YogaTest, flex_direction_row_reverse_margin_start) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -605,17 +581,14 @@ TEST(YogaTest, flex_direction_row_reverse_margin_right) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -679,17 +652,14 @@ TEST(YogaTest, flex_direction_row_reverse_margin_end) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -753,17 +723,14 @@ TEST(YogaTest, flex_direction_column_reverse_margin_top) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -827,17 +794,14 @@ TEST(YogaTest, flex_direction_column_reverse_margin_bottom) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -901,17 +865,14 @@ TEST(YogaTest, flex_direction_row_reverse_padding_left) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -975,17 +936,14 @@ TEST(YogaTest, flex_direction_row_reverse_padding_start) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1049,17 +1007,14 @@ TEST(YogaTest, flex_direction_row_reverse_padding_right) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1123,17 +1078,14 @@ TEST(YogaTest, flex_direction_row_reverse_padding_end) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1197,17 +1149,14 @@ TEST(YogaTest, flex_direction_column_reverse_padding_top) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1271,17 +1220,14 @@ TEST(YogaTest, flex_direction_column_reverse_padding_bottom) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1345,17 +1291,14 @@ TEST(YogaTest, flex_direction_row_reverse_border_left) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1419,17 +1362,14 @@ TEST(YogaTest, flex_direction_row_reverse_border_start) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1493,17 +1433,14 @@ TEST(YogaTest, flex_direction_row_reverse_border_right) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1567,17 +1504,14 @@ TEST(YogaTest, flex_direction_row_reverse_border_end) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1641,17 +1575,14 @@ TEST(YogaTest, flex_direction_column_reverse_border_top) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1715,17 +1646,14 @@ TEST(YogaTest, flex_direction_column_reverse_border_bottom) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1788,24 +1716,20 @@ TEST(YogaTest, flex_direction_row_reverse_pos_left) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPosition(root_child0, YGEdgeLeft, 100);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 10);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1878,24 +1802,20 @@ TEST(YogaTest, flex_direction_row_reverse_pos_start) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPosition(root_child0, YGEdgeStart, 100);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 10);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1968,24 +1888,20 @@ TEST(YogaTest, flex_direction_row_reverse_pos_right) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPosition(root_child0, YGEdgeRight, 100);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 10);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2058,24 +1974,20 @@ TEST(YogaTest, flex_direction_row_reverse_pos_end) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPosition(root_child0, YGEdgeEnd, 100);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 10);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2148,24 +2060,20 @@ TEST(YogaTest, flex_direction_column_reverse_pos_top) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPosition(root_child0, YGEdgeTop, 100);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 10);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2238,24 +2146,20 @@ TEST(YogaTest, flex_direction_column_reverse_pos_bottom) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPosition(root_child0, YGEdgeBottom, 100);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 10);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2328,7 +2232,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_pos_left) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -2341,12 +2244,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_pos_left) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2419,7 +2320,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_pos_right) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -2432,12 +2332,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_pos_right) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2510,7 +2408,6 @@ TEST(YogaTest, flex_direction_col_reverse_inner_pos_top) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -2523,12 +2420,10 @@ TEST(YogaTest, flex_direction_col_reverse_inner_pos_top) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2601,7 +2496,6 @@ TEST(YogaTest, flex_direction_col_reverse_inner_pos_bottom) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -2614,12 +2508,10 @@ TEST(YogaTest, flex_direction_col_reverse_inner_pos_bottom) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2694,7 +2586,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_pos_start) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -2707,12 +2598,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_pos_start) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2787,7 +2676,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_pos_end) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -2800,12 +2688,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_pos_end) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2878,7 +2764,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_margin_left) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -2891,12 +2776,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_margin_left) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2969,7 +2852,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_margin_right) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -2982,12 +2864,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_margin_right) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3060,7 +2940,6 @@ TEST(YogaTest, flex_direction_col_reverse_inner_margin_top) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -3073,12 +2952,10 @@ TEST(YogaTest, flex_direction_col_reverse_inner_margin_top) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3151,7 +3028,6 @@ TEST(YogaTest, flex_direction_col_reverse_inner_margin_bottom) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -3164,12 +3040,10 @@ TEST(YogaTest, flex_direction_col_reverse_inner_margin_bottom) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3242,7 +3116,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_marign_start) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -3255,12 +3128,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_marign_start) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3333,7 +3204,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_margin_end) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -3346,12 +3216,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_margin_end) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3424,7 +3292,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_border_left) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -3437,12 +3304,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_border_left) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3515,7 +3380,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_border_right) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -3528,12 +3392,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_border_right) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3606,7 +3468,6 @@ TEST(YogaTest, flex_direction_col_reverse_inner_border_top) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -3619,12 +3480,10 @@ TEST(YogaTest, flex_direction_col_reverse_inner_border_top) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3697,7 +3556,6 @@ TEST(YogaTest, flex_direction_col_reverse_inner_border_bottom) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -3710,12 +3568,10 @@ TEST(YogaTest, flex_direction_col_reverse_inner_border_bottom) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3788,7 +3644,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_border_start) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -3801,12 +3656,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_border_start) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3879,7 +3732,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_border_end) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -3892,12 +3744,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_border_end) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -3970,7 +3820,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_padding_left) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -3983,12 +3832,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_padding_left) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -4061,7 +3908,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_padding_right) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -4074,12 +3920,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_padding_right) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -4152,7 +3996,6 @@ TEST(YogaTest, flex_direction_col_reverse_inner_padding_top) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -4165,12 +4008,10 @@ TEST(YogaTest, flex_direction_col_reverse_inner_padding_top) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -4243,7 +4084,6 @@ TEST(YogaTest, flex_direction_col_reverse_inner_padding_bottom) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionColumnReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -4256,12 +4096,10 @@ TEST(YogaTest, flex_direction_col_reverse_inner_padding_bottom) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -4334,7 +4172,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_padding_start) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -4347,12 +4184,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_padding_start) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -4425,7 +4260,6 @@ TEST(YogaTest, flex_direction_row_reverse_inner_padding_end) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRowReverse);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
@@ -4438,12 +4272,10 @@ TEST(YogaTest, flex_direction_row_reverse_inner_padding_end) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child2, 10);
   YGNodeInsertChild(root_child0, root_child0_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);

--- a/tests/generated/YGFlexTest.cpp
+++ b/tests/generated/YGFlexTest.cpp
@@ -21,13 +21,11 @@ TEST(YogaTest, flex_basis_flex_grow_column) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -80,14 +78,12 @@ TEST(YogaTest, flex_shrink_flex_grow_row) {
   YGNodeStyleSetHeight(root, 500);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeStyleSetWidth(root_child0, 500);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child1, 1);
   YGNodeStyleSetWidth(root_child1, 500);
   YGNodeStyleSetHeight(root_child1, 100);
@@ -142,14 +138,12 @@ TEST(YogaTest, flex_shrink_flex_grow_child_flex_shrink_other_child) {
   YGNodeStyleSetHeight(root, 500);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeStyleSetWidth(root_child0, 500);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexShrink(root_child1, 1);
   YGNodeStyleSetWidth(root_child1, 500);
@@ -205,13 +199,11 @@ TEST(YogaTest, flex_basis_flex_grow_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -263,13 +255,11 @@ TEST(YogaTest, flex_basis_flex_shrink_column) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexBasis(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -322,13 +312,11 @@ TEST(YogaTest, flex_basis_flex_shrink_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexBasis(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -379,20 +367,17 @@ TEST(YogaTest, flex_shrink_to_zero) {
   YGNodeStyleSetHeight(root, 75);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child1, 1);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeStyleSetHeight(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
@@ -455,20 +440,17 @@ TEST(YogaTest, flex_basis_overrides_main_size) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
@@ -531,11 +513,9 @@ TEST(YogaTest, flex_grow_shrink_at_most) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0_child0, 1);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -588,18 +568,15 @@ TEST(YogaTest, flex_grow_less_than_factor_one) {
   YGNodeStyleSetHeight(root, 500);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 0.2f);
   YGNodeStyleSetFlexBasis(root_child0, 40);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 0.2f);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 0.4f);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);

--- a/tests/generated/YGFlexWrapTest.cpp
+++ b/tests/generated/YGFlexWrapTest.cpp
@@ -21,25 +21,21 @@ TEST(YogaTest, wrap_column) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 30);
   YGNodeStyleSetHeight(root_child0, 30);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 30);
   YGNodeStyleSetHeight(root_child1, 30);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 30);
   YGNodeStyleSetHeight(root_child2, 30);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 30);
   YGNodeStyleSetHeight(root_child3, 30);
   YGNodeInsertChild(root, root_child3, 3);
@@ -113,25 +109,21 @@ TEST(YogaTest, wrap_row) {
   YGNodeStyleSetWidth(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 30);
   YGNodeStyleSetHeight(root_child0, 30);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 30);
   YGNodeStyleSetHeight(root_child1, 30);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 30);
   YGNodeStyleSetHeight(root_child2, 30);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 30);
   YGNodeStyleSetHeight(root_child3, 30);
   YGNodeInsertChild(root, root_child3, 3);
@@ -206,25 +198,21 @@ TEST(YogaTest, wrap_row_align_items_flex_end) {
   YGNodeStyleSetWidth(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 30);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 30);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 30);
   YGNodeStyleSetHeight(root_child2, 30);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 30);
   YGNodeStyleSetHeight(root_child3, 30);
   YGNodeInsertChild(root, root_child3, 3);
@@ -299,25 +287,21 @@ TEST(YogaTest, wrap_row_align_items_center) {
   YGNodeStyleSetWidth(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 30);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 30);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 30);
   YGNodeStyleSetHeight(root_child2, 30);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 30);
   YGNodeStyleSetHeight(root_child3, 30);
   YGNodeInsertChild(root, root_child3, 3);
@@ -391,14 +375,12 @@ TEST(YogaTest, flex_wrap_children_with_min_main_overriding_flex_basis) {
   YGNodeStyleSetWidth(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexBasis(root_child0, 50);
   YGNodeStyleSetMinWidth(root_child0, 55);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexBasis(root_child1, 50);
   YGNodeStyleSetMinWidth(root_child1, 55);
   YGNodeStyleSetHeight(root_child1, 50);
@@ -452,23 +434,19 @@ TEST(YogaTest, flex_wrap_wrap_to_child_height) {
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignItems(root_child0, YGAlignFlexStart);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0_child0, 100);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 100);
   YGNodeStyleSetHeight(root_child1, 100);
   YGNodeInsertChild(root, root_child1, 1);
@@ -543,12 +521,10 @@ TEST(YogaTest, flex_wrap_align_stretch_fits_one_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -601,31 +577,26 @@ TEST(YogaTest, wrap_reverse_row_align_content_flex_start) {
   YGNodeStyleSetWidth(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 30);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 30);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 30);
   YGNodeStyleSetHeight(root_child2, 30);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 30);
   YGNodeStyleSetHeight(root_child3, 40);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 30);
   YGNodeStyleSetHeight(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
@@ -710,31 +681,26 @@ TEST(YogaTest, wrap_reverse_row_align_content_center) {
   YGNodeStyleSetWidth(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 30);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 30);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 30);
   YGNodeStyleSetHeight(root_child2, 30);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 30);
   YGNodeStyleSetHeight(root_child3, 40);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 30);
   YGNodeStyleSetHeight(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
@@ -818,31 +784,26 @@ TEST(YogaTest, wrap_reverse_row_single_line_different_size) {
   YGNodeStyleSetWidth(root, 300);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 30);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 30);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 30);
   YGNodeStyleSetHeight(root_child2, 30);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 30);
   YGNodeStyleSetHeight(root_child3, 40);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 30);
   YGNodeStyleSetHeight(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
@@ -927,31 +888,26 @@ TEST(YogaTest, wrap_reverse_row_align_content_stretch) {
   YGNodeStyleSetWidth(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 30);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 30);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 30);
   YGNodeStyleSetHeight(root_child2, 30);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 30);
   YGNodeStyleSetHeight(root_child3, 40);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 30);
   YGNodeStyleSetHeight(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
@@ -1036,31 +992,26 @@ TEST(YogaTest, wrap_reverse_row_align_content_space_around) {
   YGNodeStyleSetWidth(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 30);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 30);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 30);
   YGNodeStyleSetHeight(root_child2, 30);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 30);
   YGNodeStyleSetHeight(root_child3, 40);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 30);
   YGNodeStyleSetHeight(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
@@ -1145,31 +1096,26 @@ TEST(YogaTest, wrap_reverse_column_fixed_size) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 30);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 30);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 30);
   YGNodeStyleSetHeight(root_child2, 30);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 30);
   YGNodeStyleSetHeight(root_child3, 40);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 30);
   YGNodeStyleSetHeight(root_child4, 50);
   YGNodeInsertChild(root, root_child4, 4);
@@ -1254,18 +1200,15 @@ TEST(YogaTest, wrapped_row_within_align_items_center) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 150);
   YGNodeStyleSetHeight(root_child0_child0, 80);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 80);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
@@ -1330,18 +1273,15 @@ TEST(YogaTest, wrapped_row_within_align_items_flex_start) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 150);
   YGNodeStyleSetHeight(root_child0_child0, 80);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 80);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
@@ -1406,18 +1346,15 @@ TEST(YogaTest, wrapped_row_within_align_items_flex_end) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 150);
   YGNodeStyleSetHeight(root_child0_child0, 80);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 80);
   YGNodeStyleSetHeight(root_child0_child1, 80);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
@@ -1484,14 +1421,12 @@ TEST(YogaTest, wrapped_column_max_height) {
   YGNodeStyleSetHeight(root, 500);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 500);
   YGNodeStyleSetMaxHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child1, YGEdgeLeft, 20);
   YGNodeStyleSetMargin(root_child1, YGEdgeTop, 20);
   YGNodeStyleSetMargin(root_child1, YGEdgeRight, 20);
@@ -1501,7 +1436,6 @@ TEST(YogaTest, wrapped_column_max_height) {
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 100);
   YGNodeStyleSetHeight(root_child2, 100);
   YGNodeInsertChild(root, root_child2, 2);
@@ -1568,7 +1502,6 @@ TEST(YogaTest, wrapped_column_max_height_flex) {
   YGNodeStyleSetHeight(root, 500);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 0);
@@ -1578,7 +1511,6 @@ TEST(YogaTest, wrapped_column_max_height_flex) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexShrink(root_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1, 0);
@@ -1591,7 +1523,6 @@ TEST(YogaTest, wrapped_column_max_height_flex) {
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 100);
   YGNodeStyleSetHeight(root_child2, 100);
   YGNodeInsertChild(root, root_child2, 2);
@@ -1655,28 +1586,23 @@ TEST(YogaTest, wrap_nodes_with_content_sizing_overflowing_margin) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetWidth(root_child0, 85);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child0, 40);
   YGNodeStyleSetHeight(root_child0_child0_child0, 40);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0_child1, YGEdgeRight, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1_child0, 40);
   YGNodeStyleSetHeight(root_child0_child1_child0, 40);
   YGNodeInsertChild(root_child0_child1, root_child0_child1_child0, 0);
@@ -1760,28 +1686,23 @@ TEST(YogaTest, wrap_nodes_with_content_sizing_margin_cross) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexWrap(root_child0, YGWrapWrap);
   YGNodeStyleSetWidth(root_child0, 70);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child0, 40);
   YGNodeStyleSetHeight(root_child0_child0_child0, 40);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0_child1, YGEdgeTop, 10);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child0_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1_child0, 40);
   YGNodeStyleSetHeight(root_child0_child1_child0, 40);
   YGNodeInsertChild(root_child0_child1, root_child0_child1_child0, 0);

--- a/tests/generated/YGGapTest.cpp
+++ b/tests/generated/YGGapTest.cpp
@@ -24,21 +24,18 @@ TEST(YogaTest, column_gap_flexible) {
   YGNodeStyleSetGap(root, YGGutterRow, 20);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 0);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexShrink(root_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1, 0);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetFlexShrink(root_child2, 1);
   YGNodeStyleSetFlexBasisPercent(root_child2, 0);
@@ -104,17 +101,14 @@ TEST(YogaTest, column_gap_inflexible) {
   YGNodeStyleSetGap(root, YGGutterColumn, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -178,19 +172,16 @@ TEST(YogaTest, column_gap_mixed_flexible) {
   YGNodeStyleSetGap(root, YGGutterColumn, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexShrink(root_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1, 0);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -254,7 +245,6 @@ TEST(YogaTest, column_gap_child_margins) {
   YGNodeStyleSetGap(root, YGGutterColumn, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 0);
@@ -263,7 +253,6 @@ TEST(YogaTest, column_gap_child_margins) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexShrink(root_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1, 0);
@@ -272,7 +261,6 @@ TEST(YogaTest, column_gap_child_margins) {
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetFlexShrink(root_child2, 1);
   YGNodeStyleSetFlexBasisPercent(root_child2, 0);
@@ -341,55 +329,46 @@ TEST(YogaTest, column_row_gap_wrapping) {
   YGNodeStyleSetGap(root, YGGutterRow, 20);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeStyleSetHeight(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 20);
   YGNodeStyleSetHeight(root_child3, 20);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 20);
   YGNodeStyleSetHeight(root_child4, 20);
   YGNodeInsertChild(root, root_child4, 4);
 
   const YGNodeRef root_child5 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child5, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child5, 20);
   YGNodeStyleSetHeight(root_child5, 20);
   YGNodeInsertChild(root, root_child5, 5);
 
   const YGNodeRef root_child6 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child6, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child6, 20);
   YGNodeStyleSetHeight(root_child6, 20);
   YGNodeInsertChild(root, root_child6, 6);
 
   const YGNodeRef root_child7 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child7, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child7, 20);
   YGNodeStyleSetHeight(root_child7, 20);
   YGNodeInsertChild(root, root_child7, 7);
 
   const YGNodeRef root_child8 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child8, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child8, 20);
   YGNodeStyleSetHeight(root_child8, 20);
   YGNodeInsertChild(root, root_child8, 8);
@@ -521,19 +500,16 @@ TEST(YogaTest, column_gap_start_index) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeStyleSetHeight(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 20);
   YGNodeStyleSetHeight(root_child3, 20);
   YGNodeInsertChild(root, root_child3, 3);
@@ -608,17 +584,14 @@ TEST(YogaTest, column_gap_justify_flex_start) {
   YGNodeStyleSetGap(root, YGGutterColumn, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -683,17 +656,14 @@ TEST(YogaTest, column_gap_justify_center) {
   YGNodeStyleSetGap(root, YGGutterColumn, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -758,17 +728,14 @@ TEST(YogaTest, column_gap_justify_flex_end) {
   YGNodeStyleSetGap(root, YGGutterColumn, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -833,17 +800,14 @@ TEST(YogaTest, column_gap_justify_space_between) {
   YGNodeStyleSetGap(root, YGGutterColumn, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -908,17 +872,14 @@ TEST(YogaTest, column_gap_justify_space_around) {
   YGNodeStyleSetGap(root, YGGutterColumn, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -983,17 +944,14 @@ TEST(YogaTest, column_gap_justify_space_evenly) {
   YGNodeStyleSetGap(root, YGGutterColumn, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1059,37 +1017,31 @@ TEST(YogaTest, column_gap_wrap_align_flex_start) {
   YGNodeStyleSetGap(root, YGGutterRow, 20);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeStyleSetHeight(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 20);
   YGNodeStyleSetHeight(root_child3, 20);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 20);
   YGNodeStyleSetHeight(root_child4, 20);
   YGNodeInsertChild(root, root_child4, 4);
 
   const YGNodeRef root_child5 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child5, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child5, 20);
   YGNodeStyleSetHeight(root_child5, 20);
   YGNodeInsertChild(root, root_child5, 5);
@@ -1187,37 +1139,31 @@ TEST(YogaTest, column_gap_wrap_align_center) {
   YGNodeStyleSetGap(root, YGGutterRow, 20);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeStyleSetHeight(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 20);
   YGNodeStyleSetHeight(root_child3, 20);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 20);
   YGNodeStyleSetHeight(root_child4, 20);
   YGNodeInsertChild(root, root_child4, 4);
 
   const YGNodeRef root_child5 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child5, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child5, 20);
   YGNodeStyleSetHeight(root_child5, 20);
   YGNodeInsertChild(root, root_child5, 5);
@@ -1315,37 +1261,31 @@ TEST(YogaTest, column_gap_wrap_align_flex_end) {
   YGNodeStyleSetGap(root, YGGutterRow, 20);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeStyleSetHeight(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 20);
   YGNodeStyleSetHeight(root_child3, 20);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 20);
   YGNodeStyleSetHeight(root_child4, 20);
   YGNodeInsertChild(root, root_child4, 4);
 
   const YGNodeRef root_child5 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child5, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child5, 20);
   YGNodeStyleSetHeight(root_child5, 20);
   YGNodeInsertChild(root, root_child5, 5);
@@ -1443,37 +1383,31 @@ TEST(YogaTest, column_gap_wrap_align_space_between) {
   YGNodeStyleSetGap(root, YGGutterRow, 20);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeStyleSetHeight(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 20);
   YGNodeStyleSetHeight(root_child3, 20);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 20);
   YGNodeStyleSetHeight(root_child4, 20);
   YGNodeInsertChild(root, root_child4, 4);
 
   const YGNodeRef root_child5 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child5, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child5, 20);
   YGNodeStyleSetHeight(root_child5, 20);
   YGNodeInsertChild(root, root_child5, 5);
@@ -1571,37 +1505,31 @@ TEST(YogaTest, column_gap_wrap_align_space_around) {
   YGNodeStyleSetGap(root, YGGutterRow, 20);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeStyleSetHeight(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 20);
   YGNodeStyleSetHeight(root_child3, 20);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 20);
   YGNodeStyleSetHeight(root_child4, 20);
   YGNodeInsertChild(root, root_child4, 4);
 
   const YGNodeRef root_child5 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child5, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child5, 20);
   YGNodeStyleSetHeight(root_child5, 20);
   YGNodeInsertChild(root, root_child5, 5);
@@ -1698,31 +1626,26 @@ TEST(YogaTest, column_gap_wrap_align_stretch) {
   YGNodeStyleSetGap(root, YGGutterColumn, 5);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetMinWidth(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetMinWidth(root_child1, 60);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetMinWidth(root_child2, 60);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child3, 1);
   YGNodeStyleSetMinWidth(root_child3, 60);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child4, 1);
   YGNodeStyleSetMinWidth(root_child4, 60);
   YGNodeInsertChild(root, root_child4, 4);
@@ -1806,17 +1729,14 @@ TEST(YogaTest, column_gap_determines_parent_width) {
   YGNodeStyleSetGap(root, YGGutterColumn, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 30);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1883,32 +1803,26 @@ TEST(YogaTest, row_gap_align_items_stretch) {
   YGNodeStyleSetGap(root, YGGutterRow, 20);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 20);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 20);
   YGNodeInsertChild(root, root_child4, 4);
 
   const YGNodeRef root_child5 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child5, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child5, 20);
   YGNodeInsertChild(root, root_child5, 5);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2005,32 +1919,26 @@ TEST(YogaTest, row_gap_align_items_end) {
   YGNodeStyleSetGap(root, YGGutterRow, 20);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 20);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child3, 20);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child4, 20);
   YGNodeInsertChild(root, root_child4, 4);
 
   const YGNodeRef root_child5 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child5, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child5, 20);
   YGNodeInsertChild(root, root_child5, 5);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -2123,7 +2031,6 @@ TEST(YogaTest, row_gap_column_child_margins) {
   YGNodeStyleSetGap(root, YGGutterRow, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 0);
@@ -2132,7 +2039,6 @@ TEST(YogaTest, row_gap_column_child_margins) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexShrink(root_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1, 0);
@@ -2141,7 +2047,6 @@ TEST(YogaTest, row_gap_column_child_margins) {
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetFlexShrink(root_child2, 1);
   YGNodeStyleSetFlexBasisPercent(root_child2, 0);
@@ -2210,21 +2115,18 @@ TEST(YogaTest, row_gap_row_wrap_child_margins) {
   YGNodeStyleSetGap(root, YGGutterRow, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0, YGEdgeTop, 2);
   YGNodeStyleSetMargin(root_child0, YGEdgeBottom, 2);
   YGNodeStyleSetWidth(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child1, YGEdgeTop, 10);
   YGNodeStyleSetMargin(root_child1, YGEdgeBottom, 10);
   YGNodeStyleSetWidth(root_child1, 60);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child2, YGEdgeTop, 15);
   YGNodeStyleSetMargin(root_child2, YGEdgeBottom, 15);
   YGNodeStyleSetWidth(root_child2, 60);
@@ -2288,17 +2190,14 @@ TEST(YogaTest, row_gap_determines_parent_height) {
   YGNodeStyleSetGap(root, YGGutterRow, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 20);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child2, 30);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);

--- a/tests/generated/YGJustifyContentTest.cpp
+++ b/tests/generated/YGJustifyContentTest.cpp
@@ -22,17 +22,14 @@ TEST(YogaTest, justify_content_row_flex_start) {
   YGNodeStyleSetHeight(root, 102);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -96,17 +93,14 @@ TEST(YogaTest, justify_content_row_flex_end) {
   YGNodeStyleSetHeight(root, 102);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -170,17 +164,14 @@ TEST(YogaTest, justify_content_row_center) {
   YGNodeStyleSetHeight(root, 102);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -244,17 +235,14 @@ TEST(YogaTest, justify_content_row_space_between) {
   YGNodeStyleSetHeight(root, 102);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -318,17 +306,14 @@ TEST(YogaTest, justify_content_row_space_around) {
   YGNodeStyleSetHeight(root, 102);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -390,17 +375,14 @@ TEST(YogaTest, justify_content_column_flex_start) {
   YGNodeStyleSetHeight(root, 102);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -463,17 +445,14 @@ TEST(YogaTest, justify_content_column_flex_end) {
   YGNodeStyleSetHeight(root, 102);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -536,17 +515,14 @@ TEST(YogaTest, justify_content_column_center) {
   YGNodeStyleSetHeight(root, 102);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -609,17 +585,14 @@ TEST(YogaTest, justify_content_column_space_between) {
   YGNodeStyleSetHeight(root, 102);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -682,17 +655,14 @@ TEST(YogaTest, justify_content_column_space_around) {
   YGNodeStyleSetHeight(root, 102);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -756,7 +726,6 @@ TEST(YogaTest, justify_content_row_min_width_and_margin) {
   YGNodeStyleSetMinWidth(root, 50);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
@@ -802,7 +771,6 @@ TEST(YogaTest, justify_content_row_max_width_and_margin) {
   YGNodeStyleSetMaxWidth(root, 80);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
@@ -846,7 +814,6 @@ TEST(YogaTest, justify_content_column_min_height_and_margin) {
   YGNodeStyleSetMinHeight(root, 50);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
@@ -891,7 +858,6 @@ TEST(YogaTest, justify_content_colunn_max_height_and_margin) {
   YGNodeStyleSetMaxHeight(root, 80);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 20);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
@@ -935,17 +901,14 @@ TEST(YogaTest, justify_content_column_space_evenly) {
   YGNodeStyleSetHeight(root, 102);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1009,17 +972,14 @@ TEST(YogaTest, justify_content_row_space_evenly) {
   YGNodeStyleSetHeight(root, 102);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1084,14 +1044,12 @@ TEST(YogaTest, justify_content_min_width_with_padding_child_width_greater_than_p
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0_child0, YGJustifyCenter);
   YGNodeStyleSetAlignContent(root_child0_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetPadding(root_child0_child0, YGEdgeLeft, 100);
   YGNodeStyleSetPadding(root_child0_child0, YGEdgeRight, 100);
   YGNodeStyleSetMinWidth(root_child0_child0, 400);
@@ -1100,7 +1058,6 @@ TEST(YogaTest, justify_content_min_width_with_padding_child_width_greater_than_p
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0_child0_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root_child0_child0_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child0, 300);
   YGNodeStyleSetHeight(root_child0_child0_child0, 100);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -1166,14 +1123,12 @@ TEST(YogaTest, justify_content_min_width_with_padding_child_width_lower_than_par
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0_child0, YGJustifyCenter);
   YGNodeStyleSetAlignContent(root_child0_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetPadding(root_child0_child0, YGEdgeLeft, 100);
   YGNodeStyleSetPadding(root_child0_child0, YGEdgeRight, 100);
   YGNodeStyleSetMinWidth(root_child0_child0, 400);
@@ -1182,7 +1137,6 @@ TEST(YogaTest, justify_content_min_width_with_padding_child_width_lower_than_par
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0_child0_child0, YGFlexDirectionRow);
   YGNodeStyleSetAlignContent(root_child0_child0_child0, YGAlignStretch);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child0, 199);
   YGNodeStyleSetHeight(root_child0_child0_child0, 100);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -1247,18 +1201,15 @@ TEST(YogaTest, justify_content_space_between_indefinite_container_dim_with_free_
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0, YGJustifySpaceBetween);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMinWidth(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0, 50);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 50);
   YGNodeStyleSetHeight(root_child0_child1, 50);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);

--- a/tests/generated/YGMarginTest.cpp
+++ b/tests/generated/YGMarginTest.cpp
@@ -22,7 +22,6 @@ TEST(YogaTest, margin_start) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0, YGEdgeStart, 10);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -65,7 +64,6 @@ TEST(YogaTest, margin_top) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0, YGEdgeTop, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -110,7 +108,6 @@ TEST(YogaTest, margin_end) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0, YGEdgeEnd, 10);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -154,7 +151,6 @@ TEST(YogaTest, margin_bottom) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0, YGEdgeBottom, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -198,7 +194,6 @@ TEST(YogaTest, margin_and_flex_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetMargin(root_child0, YGEdgeStart, 10);
   YGNodeStyleSetMargin(root_child0, YGEdgeEnd, 10);
@@ -242,7 +237,6 @@ TEST(YogaTest, margin_and_flex_column) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetMargin(root_child0, YGEdgeTop, 10);
   YGNodeStyleSetMargin(root_child0, YGEdgeBottom, 10);
@@ -287,7 +281,6 @@ TEST(YogaTest, margin_and_stretch_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetMargin(root_child0, YGEdgeTop, 10);
   YGNodeStyleSetMargin(root_child0, YGEdgeBottom, 10);
@@ -331,7 +324,6 @@ TEST(YogaTest, margin_and_stretch_column) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetMargin(root_child0, YGEdgeStart, 10);
   YGNodeStyleSetMargin(root_child0, YGEdgeEnd, 10);
@@ -376,13 +368,11 @@ TEST(YogaTest, margin_with_sibling_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetMargin(root_child0, YGEdgeEnd, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -434,13 +424,11 @@ TEST(YogaTest, margin_with_sibling_column) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetMargin(root_child0, YGEdgeBottom, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -493,14 +481,12 @@ TEST(YogaTest, margin_auto_bottom) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeBottom);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -554,14 +540,12 @@ TEST(YogaTest, margin_auto_top) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeTop);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -615,7 +599,6 @@ TEST(YogaTest, margin_auto_bottom_and_top) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeTop);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeBottom);
   YGNodeStyleSetWidth(root_child0, 50);
@@ -623,7 +606,6 @@ TEST(YogaTest, margin_auto_bottom_and_top) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -677,7 +659,6 @@ TEST(YogaTest, margin_auto_bottom_and_top_justify_center) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeTop);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeBottom);
   YGNodeStyleSetWidth(root_child0, 50);
@@ -685,7 +666,6 @@ TEST(YogaTest, margin_auto_bottom_and_top_justify_center) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -739,21 +719,18 @@ TEST(YogaTest, margin_auto_mutiple_children_column) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeTop);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child1, YGEdgeTop);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeStyleSetHeight(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
@@ -818,21 +795,18 @@ TEST(YogaTest, margin_auto_mutiple_children_row) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeRight);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child1, YGEdgeRight);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeStyleSetHeight(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
@@ -897,7 +871,6 @@ TEST(YogaTest, margin_auto_left_and_right_column) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeLeft);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeRight);
   YGNodeStyleSetWidth(root_child0, 50);
@@ -905,7 +878,6 @@ TEST(YogaTest, margin_auto_left_and_right_column) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -958,7 +930,6 @@ TEST(YogaTest, margin_auto_left_and_right) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeLeft);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeRight);
   YGNodeStyleSetWidth(root_child0, 50);
@@ -966,7 +937,6 @@ TEST(YogaTest, margin_auto_left_and_right) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1021,7 +991,6 @@ TEST(YogaTest, margin_auto_start_and_end_column) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeStart);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeEnd);
   YGNodeStyleSetWidth(root_child0, 50);
@@ -1029,7 +998,6 @@ TEST(YogaTest, margin_auto_start_and_end_column) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1082,7 +1050,6 @@ TEST(YogaTest, margin_auto_start_and_end) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeStart);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeEnd);
   YGNodeStyleSetWidth(root_child0, 50);
@@ -1090,7 +1057,6 @@ TEST(YogaTest, margin_auto_start_and_end) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1144,7 +1110,6 @@ TEST(YogaTest, margin_auto_left_and_right_column_and_center) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeLeft);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeRight);
   YGNodeStyleSetWidth(root_child0, 50);
@@ -1152,7 +1117,6 @@ TEST(YogaTest, margin_auto_left_and_right_column_and_center) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1206,14 +1170,12 @@ TEST(YogaTest, margin_auto_left) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeLeft);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1267,14 +1229,12 @@ TEST(YogaTest, margin_auto_right) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeRight);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1328,7 +1288,6 @@ TEST(YogaTest, margin_auto_left_and_right_stretch) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeLeft);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeRight);
   YGNodeStyleSetWidth(root_child0, 50);
@@ -1336,7 +1295,6 @@ TEST(YogaTest, margin_auto_left_and_right_stretch) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1389,7 +1347,6 @@ TEST(YogaTest, margin_auto_top_and_bottom_stretch) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeTop);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeBottom);
   YGNodeStyleSetWidth(root_child0, 50);
@@ -1397,7 +1354,6 @@ TEST(YogaTest, margin_auto_top_and_bottom_stretch) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1450,7 +1406,6 @@ TEST(YogaTest, margin_should_not_be_part_of_max_height) {
   YGNodeStyleSetHeight(root, 250);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0, YGEdgeTop, 20);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
@@ -1495,7 +1450,6 @@ TEST(YogaTest, margin_should_not_be_part_of_max_width) {
   YGNodeStyleSetHeight(root, 250);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0, YGEdgeLeft, 20);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetMaxWidth(root_child0, 100);
@@ -1541,7 +1495,6 @@ TEST(YogaTest, margin_auto_left_right_child_bigger_than_parent) {
   YGNodeStyleSetHeight(root, 52);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeLeft);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeRight);
   YGNodeStyleSetWidth(root_child0, 72);
@@ -1587,7 +1540,6 @@ TEST(YogaTest, margin_auto_left_child_bigger_than_parent) {
   YGNodeStyleSetHeight(root, 52);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeLeft);
   YGNodeStyleSetWidth(root_child0, 72);
   YGNodeStyleSetHeight(root_child0, 72);
@@ -1632,7 +1584,6 @@ TEST(YogaTest, margin_fix_left_auto_right_child_bigger_than_parent) {
   YGNodeStyleSetHeight(root, 52);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0, YGEdgeLeft, 10);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeRight);
   YGNodeStyleSetWidth(root_child0, 72);
@@ -1678,7 +1629,6 @@ TEST(YogaTest, margin_auto_left_fix_right_child_bigger_than_parent) {
   YGNodeStyleSetHeight(root, 52);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginAuto(root_child0, YGEdgeLeft);
   YGNodeStyleSetMargin(root_child0, YGEdgeRight, 10);
   YGNodeStyleSetWidth(root_child0, 72);
@@ -1724,7 +1674,6 @@ TEST(YogaTest, margin_auto_top_stretching_child) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 0);
@@ -1732,7 +1681,6 @@ TEST(YogaTest, margin_auto_top_stretching_child) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
@@ -1786,7 +1734,6 @@ TEST(YogaTest, margin_auto_left_stretching_child) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 0);
@@ -1794,7 +1741,6 @@ TEST(YogaTest, margin_auto_left_stretching_child) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);

--- a/tests/generated/YGMinMaxDimensionTest.cpp
+++ b/tests/generated/YGMinMaxDimensionTest.cpp
@@ -21,7 +21,6 @@ TEST(YogaTest, max_width) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMaxWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -65,7 +64,6 @@ TEST(YogaTest, max_height) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetMaxHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
@@ -110,13 +108,11 @@ TEST(YogaTest, min_height) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetMinHeight(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -171,13 +167,11 @@ TEST(YogaTest, min_width) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetMinWidth(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -231,7 +225,6 @@ TEST(YogaTest, justify_content_min_max) {
   YGNodeStyleSetMaxHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 60);
   YGNodeStyleSetHeight(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
@@ -276,7 +269,6 @@ TEST(YogaTest, align_items_min_max) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 60);
   YGNodeStyleSetHeight(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
@@ -320,19 +312,16 @@ TEST(YogaTest, justify_content_overflow_min_max) {
   YGNodeStyleSetMaxHeight(root, 110);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 50);
   YGNodeStyleSetHeight(root_child2, 50);
   YGNodeInsertChild(root, root_child2, 2);
@@ -396,13 +385,11 @@ TEST(YogaTest, flex_grow_to_min) {
   YGNodeStyleSetMaxHeight(root, 500);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -457,11 +444,9 @@ TEST(YogaTest, flex_grow_in_at_most_container) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0_child0, 0);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -513,7 +498,6 @@ TEST(YogaTest, flex_grow_child) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 0);
   YGNodeStyleSetHeight(root_child0, 100);
@@ -557,12 +541,10 @@ TEST(YogaTest, flex_grow_within_constrained_min_max_column) {
   YGNodeStyleSetMaxHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -615,12 +597,10 @@ TEST(YogaTest, flex_grow_within_max_width) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMaxWidth(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -674,12 +654,10 @@ TEST(YogaTest, flex_grow_within_constrained_max_width) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMaxWidth(root_child0, 300);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetHeight(root_child0_child0, 20);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -734,13 +712,11 @@ TEST(YogaTest, flex_root_ignored) {
   YGNodeStyleSetMaxHeight(root, 500);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 100);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -793,20 +769,17 @@ TEST(YogaTest, flex_grow_root_minimized) {
   YGNodeStyleSetMaxHeight(root, 500);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetMinHeight(root_child0, 100);
   YGNodeStyleSetMaxHeight(root_child0, 500);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0_child0, 200);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0_child1, 100);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -868,20 +841,17 @@ TEST(YogaTest, flex_grow_height_maximized) {
   YGNodeStyleSetHeight(root, 500);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetMinHeight(root_child0, 100);
   YGNodeStyleSetMaxHeight(root_child0, 500);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0_child0, 200);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0_child1, 100);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -944,12 +914,10 @@ TEST(YogaTest, flex_grow_within_constrained_min_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1000,12 +968,10 @@ TEST(YogaTest, flex_grow_within_constrained_min_column) {
   YGNodeStyleSetMinHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1057,19 +1023,16 @@ TEST(YogaTest, flex_grow_within_constrained_max_row) {
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0, YGFlexDirectionRow);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMaxWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child1, 50);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1131,13 +1094,11 @@ TEST(YogaTest, flex_grow_within_constrained_max_column) {
   YGNodeStyleSetMaxHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child1, 50);
   YGNodeInsertChild(root, root_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1190,14 +1151,12 @@ TEST(YogaTest, child_min_max_width_flexing) {
   YGNodeStyleSetHeight(root, 50);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 0);
   YGNodeStyleSetMinWidth(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1, 50);
   YGNodeStyleSetMaxWidth(root_child1, 20);
@@ -1360,7 +1319,6 @@ TEST(YogaTest, min_max_percent_no_width_height) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetMinWidthPercent(root_child0, 10);
   YGNodeStyleSetMaxWidthPercent(root_child0, 10);
   YGNodeStyleSetMinHeightPercent(root_child0, 10);

--- a/tests/generated/YGPaddingTest.cpp
+++ b/tests/generated/YGPaddingTest.cpp
@@ -52,7 +52,6 @@ TEST(YogaTest, padding_container_match_child) {
   YGNodeStyleSetPadding(root, YGEdgeBottom, 10);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -99,7 +98,6 @@ TEST(YogaTest, padding_flex_child) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -146,7 +144,6 @@ TEST(YogaTest, padding_stretch_child) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -193,7 +190,6 @@ TEST(YogaTest, padding_center_child) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
@@ -238,7 +234,6 @@ TEST(YogaTest, child_with_padding_align_end) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPadding(root_child0, YGEdgeLeft, 20);
   YGNodeStyleSetPadding(root_child0, YGEdgeTop, 20);
   YGNodeStyleSetPadding(root_child0, YGEdgeRight, 20);

--- a/tests/generated/YGPercentageTest.cpp
+++ b/tests/generated/YGPercentageTest.cpp
@@ -22,7 +22,6 @@ TEST(YogaTest, percentage_width_height) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0, 30);
   YGNodeStyleSetHeightPercent(root_child0, 30);
   YGNodeInsertChild(root, root_child0, 0);
@@ -66,7 +65,6 @@ TEST(YogaTest, percentage_position_left_top) {
   YGNodeStyleSetHeight(root, 400);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPositionPercent(root_child0, YGEdgeLeft, 10);
   YGNodeStyleSetPositionPercent(root_child0, YGEdgeTop, 20);
   YGNodeStyleSetWidthPercent(root_child0, 45);
@@ -112,7 +110,6 @@ TEST(YogaTest, percentage_position_bottom_right) {
   YGNodeStyleSetHeight(root, 500);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPositionPercent(root_child0, YGEdgeRight, 20);
   YGNodeStyleSetPositionPercent(root_child0, YGEdgeBottom, 10);
   YGNodeStyleSetWidthPercent(root_child0, 55);
@@ -158,13 +155,11 @@ TEST(YogaTest, percentage_flex_basis) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1, 25);
   YGNodeInsertChild(root, root_child1, 1);
@@ -217,13 +212,11 @@ TEST(YogaTest, percentage_flex_basis_cross) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetFlexBasisPercent(root_child1, 25);
   YGNodeInsertChild(root, root_child1, 1);
@@ -278,13 +271,11 @@ TEST(YogaTest, percentage_flex_basis_cross_min_height) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetMinHeightPercent(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 2);
   YGNodeStyleSetMinHeightPercent(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
@@ -338,14 +329,12 @@ TEST(YogaTest, percentage_flex_basis_main_max_height) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 10);
   YGNodeStyleSetMaxHeightPercent(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 4);
   YGNodeStyleSetFlexBasisPercent(root_child1, 10);
   YGNodeStyleSetMaxHeightPercent(root_child1, 20);
@@ -399,14 +388,12 @@ TEST(YogaTest, percentage_flex_basis_cross_max_height) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 10);
   YGNodeStyleSetMaxHeightPercent(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 4);
   YGNodeStyleSetFlexBasisPercent(root_child1, 10);
   YGNodeStyleSetMaxHeightPercent(root_child1, 20);
@@ -461,14 +448,12 @@ TEST(YogaTest, percentage_flex_basis_main_max_width) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 15);
   YGNodeStyleSetMaxWidthPercent(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 4);
   YGNodeStyleSetFlexBasisPercent(root_child1, 10);
   YGNodeStyleSetMaxWidthPercent(root_child1, 20);
@@ -522,14 +507,12 @@ TEST(YogaTest, percentage_flex_basis_cross_max_width) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 10);
   YGNodeStyleSetMaxWidthPercent(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 4);
   YGNodeStyleSetFlexBasisPercent(root_child1, 15);
   YGNodeStyleSetMaxWidthPercent(root_child1, 20);
@@ -584,14 +567,12 @@ TEST(YogaTest, percentage_flex_basis_main_min_width) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 15);
   YGNodeStyleSetMinWidthPercent(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 4);
   YGNodeStyleSetFlexBasisPercent(root_child1, 10);
   YGNodeStyleSetMinWidthPercent(root_child1, 20);
@@ -645,14 +626,12 @@ TEST(YogaTest, percentage_flex_basis_cross_min_width) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 10);
   YGNodeStyleSetMinWidthPercent(root_child0, 60);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 4);
   YGNodeStyleSetFlexBasisPercent(root_child1, 15);
   YGNodeStyleSetMinWidthPercent(root_child1, 20);
@@ -706,7 +685,6 @@ TEST(YogaTest, percentage_multiple_nested_with_padding_margin_and_percentage_val
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasisPercent(root_child0, 10);
   YGNodeStyleSetMargin(root_child0, YGEdgeLeft, 5);
@@ -721,7 +699,6 @@ TEST(YogaTest, percentage_multiple_nested_with_padding_margin_and_percentage_val
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetMargin(root_child0_child0, YGEdgeLeft, 5);
   YGNodeStyleSetMargin(root_child0_child0, YGEdgeTop, 5);
   YGNodeStyleSetMargin(root_child0_child0, YGEdgeRight, 5);
@@ -734,7 +711,6 @@ TEST(YogaTest, percentage_multiple_nested_with_padding_margin_and_percentage_val
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginPercent(root_child0_child0_child0, YGEdgeLeft, 5);
   YGNodeStyleSetMarginPercent(root_child0_child0_child0, YGEdgeTop, 5);
   YGNodeStyleSetMarginPercent(root_child0_child0_child0, YGEdgeRight, 5);
@@ -747,7 +723,6 @@ TEST(YogaTest, percentage_multiple_nested_with_padding_margin_and_percentage_val
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 4);
   YGNodeStyleSetFlexBasisPercent(root_child1, 15);
   YGNodeStyleSetMinWidthPercent(root_child1, 20);
@@ -821,7 +796,6 @@ TEST(YogaTest, percentage_margin_should_calculate_based_only_on_width) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetMarginPercent(root_child0, YGEdgeLeft, 10);
   YGNodeStyleSetMarginPercent(root_child0, YGEdgeTop, 10);
@@ -830,7 +804,6 @@ TEST(YogaTest, percentage_margin_should_calculate_based_only_on_width) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 10);
   YGNodeStyleSetHeight(root_child0_child0, 10);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -883,7 +856,6 @@ TEST(YogaTest, percentage_padding_should_calculate_based_only_on_width) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetPaddingPercent(root_child0, YGEdgeLeft, 10);
   YGNodeStyleSetPaddingPercent(root_child0, YGEdgeTop, 10);
@@ -892,7 +864,6 @@ TEST(YogaTest, percentage_padding_should_calculate_based_only_on_width) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 10);
   YGNodeStyleSetHeight(root_child0_child0, 10);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -988,7 +959,6 @@ TEST(YogaTest, percentage_width_height_undefined_parent_size) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0, 50);
   YGNodeStyleSetHeightPercent(root_child0, 50);
   YGNodeInsertChild(root, root_child0, 0);
@@ -1032,22 +1002,18 @@ TEST(YogaTest, percent_within_flex_grow) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child1_child0, 100);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child2, 100);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -1121,24 +1087,20 @@ TEST(YogaTest, percentage_container_in_wrapping_container) {
   YGNodeStyleSetHeight(root, 200);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
   YGNodeStyleSetFlexDirection(root_child0_child0, YGFlexDirectionRow);
   YGNodeStyleSetJustifyContent(root_child0_child0, YGJustifyCenter);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child1, 50);
   YGNodeStyleSetHeight(root_child0_child0_child1, 50);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child1, 1);
@@ -1219,12 +1181,10 @@ TEST(YogaTest, percent_absolute_position) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child1, 100);
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);

--- a/tests/generated/YGRoundingTest.cpp
+++ b/tests/generated/YGRoundingTest.cpp
@@ -22,17 +22,14 @@ TEST(YogaTest, rounding_flex_basis_flex_grow_row_width_of_100) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -95,27 +92,22 @@ TEST(YogaTest, rounding_flex_basis_flex_grow_row_prime_number_width) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeInsertChild(root, root_child2, 2);
 
   const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child3, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child3, 1);
   YGNodeInsertChild(root, root_child3, 3);
 
   const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child4, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child4, 1);
   YGNodeInsertChild(root, root_child4, 4);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -198,18 +190,15 @@ TEST(YogaTest, rounding_flex_basis_flex_shrink_row) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexShrink(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexBasis(root_child1, 25);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexBasis(root_child2, 25);
   YGNodeInsertChild(root, root_child2, 2);
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
@@ -271,20 +260,17 @@ TEST(YogaTest, rounding_flex_basis_overrides_main_size) {
   YGNodeStyleSetHeight(root, 113);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
@@ -347,20 +333,17 @@ TEST(YogaTest, rounding_total_fractial) {
   YGNodeStyleSetHeight(root, 113.4f);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 0.7f);
   YGNodeStyleSetFlexBasis(root_child0, 50.3f);
   YGNodeStyleSetHeight(root_child0, 20.3f);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1.6f);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1.1f);
   YGNodeStyleSetHeight(root_child2, 10.7f);
   YGNodeInsertChild(root, root_child2, 2);
@@ -423,14 +406,12 @@ TEST(YogaTest, rounding_total_fractial_nested) {
   YGNodeStyleSetHeight(root, 113.4f);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 0.7f);
   YGNodeStyleSetFlexBasis(root_child0, 50.3f);
   YGNodeStyleSetHeight(root_child0, 20.3f);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0_child0, 0.3f);
   YGNodeStyleSetPosition(root_child0_child0, YGEdgeBottom, 13.3f);
@@ -438,7 +419,6 @@ TEST(YogaTest, rounding_total_fractial_nested) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0_child1, 4);
   YGNodeStyleSetFlexBasis(root_child0_child1, 0.3f);
   YGNodeStyleSetPosition(root_child0_child1, YGEdgeTop, 13.3f);
@@ -446,13 +426,11 @@ TEST(YogaTest, rounding_total_fractial_nested) {
   YGNodeInsertChild(root_child0, root_child0_child1, 1);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1.6f);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1.1f);
   YGNodeStyleSetHeight(root_child2, 10.7f);
   YGNodeInsertChild(root, root_child2, 2);
@@ -535,20 +513,17 @@ TEST(YogaTest, rounding_fractial_input_1) {
   YGNodeStyleSetHeight(root, 113.4f);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
@@ -611,20 +586,17 @@ TEST(YogaTest, rounding_fractial_input_2) {
   YGNodeStyleSetHeight(root, 113.6f);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
@@ -688,20 +660,17 @@ TEST(YogaTest, rounding_fractial_input_3) {
   YGNodeStyleSetHeight(root, 113.4f);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
@@ -765,20 +734,17 @@ TEST(YogaTest, rounding_fractial_input_4) {
   YGNodeStyleSetHeight(root, 113.4f);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetFlexBasis(root_child0, 50);
   YGNodeStyleSetHeight(root_child0, 20);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
@@ -841,25 +807,21 @@ TEST(YogaTest, rounding_inner_node_controversy_horizontal) {
   YGNodeStyleSetWidth(root, 320);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetHeight(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetHeight(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1_child0, 1);
   YGNodeStyleSetHeight(root_child1_child0, 10);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetHeight(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
@@ -931,25 +893,21 @@ TEST(YogaTest, rounding_inner_node_controversy_vertical) {
   YGNodeStyleSetHeight(root, 320);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetWidth(root_child0, 10);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetWidth(root_child1, 10);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1_child0, 1);
   YGNodeStyleSetWidth(root_child1_child0, 10);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetWidth(root_child2, 10);
   YGNodeInsertChild(root, root_child2, 2);
@@ -1023,43 +981,36 @@ TEST(YogaTest, rounding_inner_node_controversy_combined) {
   YGNodeStyleSetHeight(root, 320);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child0, 1);
   YGNodeStyleSetHeightPercent(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1, 1);
   YGNodeStyleSetHeightPercent(root_child1, 100);
   YGNodeInsertChild(root, root_child1, 1);
 
   const YGNodeRef root_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1_child0, 1);
   YGNodeStyleSetWidthPercent(root_child1_child0, 100);
   YGNodeInsertChild(root_child1, root_child1_child0, 0);
 
   const YGNodeRef root_child1_child1 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child1, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1_child1, 1);
   YGNodeStyleSetWidthPercent(root_child1_child1, 100);
   YGNodeInsertChild(root_child1, root_child1_child1, 1);
 
   const YGNodeRef root_child1_child1_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child1_child0, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1_child1_child0, 1);
   YGNodeStyleSetWidthPercent(root_child1_child1_child0, 100);
   YGNodeInsertChild(root_child1_child1, root_child1_child1_child0, 0);
 
   const YGNodeRef root_child1_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child1_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child1_child2, 1);
   YGNodeStyleSetWidthPercent(root_child1_child2, 100);
   YGNodeInsertChild(root_child1, root_child1_child2, 2);
 
   const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child2, YGPositionTypeRelative);
   YGNodeStyleSetFlexGrow(root_child2, 1);
   YGNodeStyleSetHeightPercent(root_child2, 100);
   YGNodeInsertChild(root, root_child2, 2);

--- a/tests/generated/YGSizeOverflowTest.cpp
+++ b/tests/generated/YGSizeOverflowTest.cpp
@@ -21,11 +21,9 @@ TEST(YogaTest, nested_overflowing_child) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 200);
   YGNodeStyleSetHeight(root_child0_child0, 200);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -78,13 +76,11 @@ TEST(YogaTest, nested_overflowing_child_in_constraint_parent) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeStyleSetHeight(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 200);
   YGNodeStyleSetHeight(root_child0_child0, 200);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -137,12 +133,10 @@ TEST(YogaTest, parent_wrap_child_size_overflowing_parent) {
   YGNodeStyleSetHeight(root, 100);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 100);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 200);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);

--- a/tests/generated/YGStaticPositionTest.cpp
+++ b/tests/generated/YGStaticPositionTest.cpp
@@ -21,6 +21,7 @@ TEST(YogaTest, static_position_insets_have_no_effect_left_top) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeStatic);
   YGNodeStyleSetPosition(root_child0, YGEdgeLeft, 50);
   YGNodeStyleSetPosition(root_child0, YGEdgeTop, 50);
   YGNodeStyleSetWidth(root_child0, 100);
@@ -65,6 +66,7 @@ TEST(YogaTest, static_position_insets_have_no_effect_right_bottom) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0, YGPositionTypeStatic);
   YGNodeStyleSetPosition(root_child0, YGEdgeRight, 50);
   YGNodeStyleSetPosition(root_child0, YGEdgeBottom, 50);
   YGNodeStyleSetWidth(root_child0, 100);
@@ -109,12 +111,12 @@ TEST(YogaTest, static_position_absolute_child_insets_relative_to_positioned_ance
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetMargin(root_child0_child0, YGEdgeLeft, 100);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
@@ -186,30 +188,33 @@ TEST(YogaTest, static_position_absolute_child_insets_relative_to_positioned_ance
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetMargin(root_child0_child0, YGEdgeLeft, 100);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetMargin(root_child0_child0_child0, YGEdgeLeft, 100);
   YGNodeStyleSetWidth(root_child0_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0_child0, 100);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetMargin(root_child0_child0_child0_child0, YGEdgeLeft, 100);
   YGNodeStyleSetWidth(root_child0_child0_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0_child0_child0, 100);
   YGNodeInsertChild(root_child0_child0_child0, root_child0_child0_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0_child0_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetMargin(root_child0_child0_child0_child0_child0, YGEdgeLeft, 100);
   YGNodeStyleSetWidth(root_child0_child0_child0_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0_child0_child0_child0, 100);
@@ -311,12 +316,12 @@ TEST(YogaTest, static_position_absolute_child_width_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -385,18 +390,17 @@ TEST(YogaTest, static_position_relative_child_width_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -459,17 +463,18 @@ TEST(YogaTest, static_position_static_child_width_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidthPercent(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -532,12 +537,12 @@ TEST(YogaTest, static_position_absolute_child_height_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -606,18 +611,17 @@ TEST(YogaTest, static_position_relative_child_height_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child0, 50);
   YGNodeStyleSetHeightPercent(root_child0_child0_child0, 50);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -680,17 +684,18 @@ TEST(YogaTest, static_position_static_child_height_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0_child0, 50);
   YGNodeStyleSetHeightPercent(root_child0_child0_child0, 50);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -753,12 +758,12 @@ TEST(YogaTest, static_position_absolute_child_left_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -828,18 +833,17 @@ TEST(YogaTest, static_position_relative_child_left_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetPositionPercent(root_child0_child0_child0, YGEdgeLeft, 50);
   YGNodeStyleSetWidth(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
@@ -903,17 +907,18 @@ TEST(YogaTest, static_position_static_child_left_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetPositionPercent(root_child0_child0_child0, YGEdgeLeft, 50);
   YGNodeStyleSetWidth(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
@@ -977,12 +982,12 @@ TEST(YogaTest, static_position_absolute_child_right_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -1052,18 +1057,17 @@ TEST(YogaTest, static_position_relative_child_right_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetPositionPercent(root_child0_child0_child0, YGEdgeRight, 50);
   YGNodeStyleSetWidth(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
@@ -1127,17 +1131,18 @@ TEST(YogaTest, static_position_static_child_right_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetPositionPercent(root_child0_child0_child0, YGEdgeRight, 50);
   YGNodeStyleSetWidth(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
@@ -1201,12 +1206,12 @@ TEST(YogaTest, static_position_absolute_child_top_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -1276,18 +1281,17 @@ TEST(YogaTest, static_position_relative_child_top_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetPositionPercent(root_child0_child0_child0, YGEdgeTop, 50);
   YGNodeStyleSetWidth(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
@@ -1351,17 +1355,18 @@ TEST(YogaTest, static_position_static_child_top_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetPositionPercent(root_child0_child0_child0, YGEdgeTop, 50);
   YGNodeStyleSetWidth(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
@@ -1425,12 +1430,12 @@ TEST(YogaTest, static_position_absolute_child_bottom_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -1500,18 +1505,17 @@ TEST(YogaTest, static_position_relative_child_bottom_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetPositionPercent(root_child0_child0_child0, YGEdgeBottom, 50);
   YGNodeStyleSetWidth(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
@@ -1575,17 +1579,18 @@ TEST(YogaTest, static_position_static_child_bottom_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetPositionPercent(root_child0_child0_child0, YGEdgeBottom, 50);
   YGNodeStyleSetWidth(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
@@ -1649,12 +1654,12 @@ TEST(YogaTest, static_position_absolute_child_margin_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -1727,18 +1732,17 @@ TEST(YogaTest, static_position_relative_child_margin_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetMarginPercent(root_child0_child0_child0, YGEdgeLeft, 50);
   YGNodeStyleSetMarginPercent(root_child0_child0_child0, YGEdgeTop, 50);
   YGNodeStyleSetMarginPercent(root_child0_child0_child0, YGEdgeRight, 50);
@@ -1805,17 +1809,18 @@ TEST(YogaTest, static_position_static_child_margin_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetMarginPercent(root_child0_child0_child0, YGEdgeLeft, 50);
   YGNodeStyleSetMarginPercent(root_child0_child0_child0, YGEdgeTop, 50);
   YGNodeStyleSetMarginPercent(root_child0_child0_child0, YGEdgeRight, 50);
@@ -1882,12 +1887,12 @@ TEST(YogaTest, static_position_absolute_child_padding_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -1960,18 +1965,17 @@ TEST(YogaTest, static_position_relative_child_padding_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetPaddingPercent(root_child0_child0_child0, YGEdgeLeft, 50);
   YGNodeStyleSetPaddingPercent(root_child0_child0_child0, YGEdgeTop, 50);
   YGNodeStyleSetPaddingPercent(root_child0_child0_child0, YGEdgeRight, 50);
@@ -2038,17 +2042,18 @@ TEST(YogaTest, static_position_static_child_padding_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetPaddingPercent(root_child0_child0_child0, YGEdgeLeft, 50);
   YGNodeStyleSetPaddingPercent(root_child0_child0_child0, YGEdgeTop, 50);
   YGNodeStyleSetPaddingPercent(root_child0_child0_child0, YGEdgeRight, 50);
@@ -2115,12 +2120,12 @@ TEST(YogaTest, static_position_absolute_child_border_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -2189,18 +2194,17 @@ TEST(YogaTest, static_position_relative_child_border_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -2263,17 +2267,18 @@ TEST(YogaTest, static_position_static_child_border_percentage) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidth(root_child0, 200);
   YGNodeStyleSetHeight(root_child0, 200);
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -2336,7 +2341,6 @@ TEST(YogaTest, static_position_absolute_child_containing_block_padding_box) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPadding(root_child0, YGEdgeLeft, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeTop, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeRight, 100);
@@ -2346,6 +2350,7 @@ TEST(YogaTest, static_position_absolute_child_containing_block_padding_box) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -2414,7 +2419,6 @@ TEST(YogaTest, static_position_relative_child_containing_block_padding_box) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPadding(root_child0, YGEdgeLeft, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeTop, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeRight, 100);
@@ -2424,12 +2428,12 @@ TEST(YogaTest, static_position_relative_child_containing_block_padding_box) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -2492,7 +2496,6 @@ TEST(YogaTest, static_position_static_child_containing_block_padding_box) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPadding(root_child0, YGEdgeLeft, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeTop, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeRight, 100);
@@ -2502,11 +2505,13 @@ TEST(YogaTest, static_position_static_child_containing_block_padding_box) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidth(root_child0_child0, 100);
   YGNodeStyleSetHeight(root_child0_child0, 100);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   const YGNodeRef root_child0_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidthPercent(root_child0_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0_child0, 50);
   YGNodeInsertChild(root_child0_child0, root_child0_child0_child0, 0);
@@ -2569,7 +2574,6 @@ TEST(YogaTest, static_position_absolute_child_containing_block_content_box) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPadding(root_child0, YGEdgeLeft, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeTop, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeRight, 100);
@@ -2632,7 +2636,6 @@ TEST(YogaTest, static_position_relative_child_containing_block_content_box) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPadding(root_child0, YGEdgeLeft, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeTop, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeRight, 100);
@@ -2642,7 +2645,6 @@ TEST(YogaTest, static_position_relative_child_containing_block_content_box) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeRelative);
   YGNodeStyleSetWidthPercent(root_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0, 50);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
@@ -2695,7 +2697,6 @@ TEST(YogaTest, static_position_static_child_containing_block_content_box) {
   YGNodeStyleSetPositionType(root, YGPositionTypeAbsolute);
 
   const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
-  YGNodeStyleSetPositionType(root_child0, YGPositionTypeRelative);
   YGNodeStyleSetPadding(root_child0, YGEdgeLeft, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeTop, 100);
   YGNodeStyleSetPadding(root_child0, YGEdgeRight, 100);
@@ -2705,6 +2706,7 @@ TEST(YogaTest, static_position_static_child_containing_block_content_box) {
   YGNodeInsertChild(root, root_child0, 0);
 
   const YGNodeRef root_child0_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(root_child0_child0, YGPositionTypeStatic);
   YGNodeStyleSetWidthPercent(root_child0_child0, 50);
   YGNodeStyleSetHeight(root_child0_child0, 50);
   YGNodeInsertChild(root_child0, root_child0_child0, 0);

--- a/yoga/style/Style.h
+++ b/yoga/style/Style.h
@@ -270,7 +270,8 @@ class YG_EXPORT Style {
   Align alignContent_ : bitCount<Align>() = Align::FlexStart;
   Align alignItems_ : bitCount<Align>() = Align::Stretch;
   Align alignSelf_ : bitCount<Align>() = Align::Auto;
-  PositionType positionType_ : bitCount<PositionType>() = PositionType::Static;
+  PositionType positionType_
+      : bitCount<PositionType>() = PositionType::Relative;
   Wrap flexWrap_ : bitCount<Wrap>() = Wrap::NoWrap;
   Overflow overflow_ : bitCount<Overflow>() = Overflow::Visible;
   Display display_ : bitCount<Display>() = Display::Flex;


### PR DESCRIPTION
Summary: The previous version of static didn't do anything inside of Yoga. Now that we're making it do something, this changes the default back to relative so that users with no errata set don't see their deafult styles changing.

Differential Revision: D51182955

