### PR TITLE
Remove composite border comparisons

### DIFF
--- a/tests/OrdinalsTest.cpp
+++ b/tests/OrdinalsTest.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <deque>
+
+#include <gtest/gtest.h>
+#include <yoga/enums/Edge.h>
+
+namespace facebook::yoga {
+
+TEST(Ordinals, iteration) {
+  std::deque expectedEdges{
+      Edge::Left,
+      Edge::Top,
+      Edge::Right,
+      Edge::Bottom,
+      Edge::Start,
+      Edge::End,
+      Edge::Horizontal,
+      Edge::Vertical,
+      Edge::All};
+
+  for (auto edge : yoga::ordinals<Edge>()) {
+    ASSERT_EQ(edge, expectedEdges.front());
+    expectedEdges.pop_front();
+  }
+
+  ASSERT_TRUE(expectedEdges.empty());
+}
+
+} // namespace facebook::yoga

--- a/yoga/enums/YogaEnums.h
+++ b/yoga/enums/YogaEnums.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <iterator>
 #include <type_traits>
 
 namespace facebook::yoga {
@@ -14,13 +15,52 @@ namespace facebook::yoga {
 template <typename EnumT>
 constexpr inline int32_t ordinalCount();
 
+/**
+ * Count of bits needed to represent every ordinal
+ */
 template <typename EnumT>
 constexpr inline int32_t bitCount();
 
-// Polyfill of C++ 23 to_underlying()
-// https://en.cppreference.com/w/cpp/utility/to_underlying
+/**
+ * Polyfill of C++ 23 to_underlying()
+ * https://en.cppreference.com/w/cpp/utility/to_underlying
+ */
 constexpr auto to_underlying(auto e) noexcept {
   return static_cast<std::underlying_type_t<decltype(e)>>(e);
+}
+
+/**
+ * Convenience function to iterate through every value in a Yoga enum as part of
+ * a range-based for loop.
+ */
+template <typename EnumT>
+auto ordinals() {
+  struct Iterator {
+    EnumT e{};
+
+    EnumT operator*() const {
+      return e;
+    }
+
+    Iterator& operator++() {
+      e = static_cast<EnumT>(to_underlying(e) + 1);
+      return *this;
+    }
+
+    bool operator==(const Iterator& other) const = default;
+    bool operator!=(const Iterator& other) const = default;
+  };
+
+  struct Range {
+    Iterator begin() const {
+      return Iterator{};
+    }
+    Iterator end() const {
+      return Iterator{static_cast<EnumT>(ordinalCount<EnumT>())};
+    }
+  };
+
+  return Range{};
 }
 
 } // namespace facebook::yoga

--- a/yoga/style/Style.h
+++ b/yoga/style/Style.h
@@ -19,6 +19,7 @@
 #include <yoga/enums/Dimension.h>
 #include <yoga/enums/Direction.h>
 #include <yoga/enums/Display.h>
+#include <yoga/enums/Edge.h>
 #include <yoga/enums/FlexDirection.h>
 #include <yoga/enums/Gutter.h>
 #include <yoga/enums/Justify.h>


### PR DESCRIPTION
Summary:
Removes cases where we rely on comparing composite of Yoga edges, since we are removing that internal API (public API is already one at a time). Extracted from D50998164, with more sound facility for looping through edges.

Changelog: [Internal]

Differential Revision: D51478403


