### PR TITLE
Don't enable `ordinalCount()` or `bitCount()` for bitflag enums

### DIFF
--- a/enums.py
+++ b/enums.py
@@ -169,19 +169,19 @@ for name, values in sorted(ENUMS.items()):
             ordinal = value[0] if isinstance(value, tuple) else value
             f.write(f"  {ordinal} = YG{name}{ordinal},\n")
         f.write("};\n\n")
-        f.write(
-            f"YG_DEFINE_ENUM_FLAG_OPERATORS({name})\n\n" if name in BITSET_ENUMS else ""
-        )
 
-        f.write("template <>\n")
-        f.write(f"constexpr inline int32_t ordinalCount<{name}>() {{\n")
-        f.write(f"  return {len(values)};\n")
-        f.write("} \n\n")
+        if name in BITSET_ENUMS:
+            f.write(f"YG_DEFINE_ENUM_FLAG_OPERATORS({name})\n\n")
+        else:
+            f.write("template <>\n")
+            f.write(f"constexpr inline int32_t ordinalCount<{name}>() {{\n")
+            f.write(f"  return {len(values)};\n")
+            f.write("} \n\n")
 
-        f.write("template <>\n")
-        f.write(f"constexpr inline int32_t bitCount<{name}>() {{\n")
-        f.write(f"  return {math.ceil(math.log(len(values), 2))};\n")
-        f.write("} \n\n")
+            f.write("template <>\n")
+            f.write(f"constexpr inline int32_t bitCount<{name}>() {{\n")
+            f.write(f"  return {math.ceil(math.log(len(values), 2))};\n")
+            f.write("} \n\n")
 
         f.write(f"constexpr inline {name} scopedEnum(YG{name} unscoped) {{\n")
         f.write(f"  return static_cast<{name}>(unscoped);\n")

--- a/yoga/enums/Errata.h
+++ b/yoga/enums/Errata.h
@@ -26,16 +26,6 @@ enum class Errata : uint32_t {
 
 YG_DEFINE_ENUM_FLAG_OPERATORS(Errata)
 
-template <>
-constexpr inline int32_t ordinalCount<Errata>() {
-  return 6;
-} 
-
-template <>
-constexpr inline int32_t bitCount<Errata>() {
-  return 3;
-} 
-
 constexpr inline Errata scopedEnum(YGErrata unscoped) {
   return static_cast<Errata>(unscoped);
 }

--- a/yoga/enums/PrintOptions.h
+++ b/yoga/enums/PrintOptions.h
@@ -23,16 +23,6 @@ enum class PrintOptions : uint32_t {
 
 YG_DEFINE_ENUM_FLAG_OPERATORS(PrintOptions)
 
-template <>
-constexpr inline int32_t ordinalCount<PrintOptions>() {
-  return 3;
-} 
-
-template <>
-constexpr inline int32_t bitCount<PrintOptions>() {
-  return 2;
-} 
-
 constexpr inline PrintOptions scopedEnum(YGPrintOptions unscoped) {
   return static_cast<PrintOptions>(unscoped);
 }


### PR DESCRIPTION
Summary:
Bitfield enums are not sequential, so use of these functions on these enums would be invalid.

I looked at whether we could trivially move `bitCount` to template based on `ordinalCount`. `bitCount` must be constexpr, since we use it directly as a bit-field size constant. `log2` and `ceil` to be constexpr, which isn't in stock C++ until C++ 26 🥲.

Differential Revision: D51518899


