### PR TITLE
Re-enabled disabled tests ReactPropForShadowNodeSpecTest and ReactPropForShadowNodeSetterTest

### DIFF
--- a/java/com/facebook/yoga/YogaConfig.java
+++ b/java/com/facebook/yoga/YogaConfig.java
@@ -27,5 +27,5 @@ public abstract class YogaConfig {
 
   public abstract YogaLogger getLogger();
 
-  abstract long getNativePointer();
+  protected abstract long getNativePointer();
 }

--- a/java/com/facebook/yoga/YogaConfigJNIBase.java
+++ b/java/com/facebook/yoga/YogaConfigJNIBase.java
@@ -60,7 +60,7 @@ public abstract class YogaConfigJNIBase extends YogaConfig {
     return mLogger;
   }
 
-  long getNativePointer() {
+  protected long getNativePointer() {
     return mNativePointer;
   }
 }


### PR DESCRIPTION
Summary:
Those tests are currently disabled due to Yoga attempting to do JNI calls.
I've added infra to bypass .so loading during tests, and we should be good to re-enable those tests by now.

Changelog:
[Internal] [Changed] - Re-enabled disabled tests ReactPropForShadowNodeSpecTest and ReactPropForShadowNodeSetterTest

Differential Revision: D51814491


