### PR TITLE
Add concurrency group for website publish

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   publish:
     name: Publish to GitHub Pages


### PR DESCRIPTION
Summary: Make each workflow acquire a shared mutex so that if two commits happen close to each other, the publish order must correspond to commit order.

Differential Revision: D52031970


