### PR TITLE
std::terminate belongs to <exception> header

### DIFF
--- a/yoga/debug/AssertFatal.cpp
+++ b/yoga/debug/AssertFatal.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <exception>
 #include <stdexcept>
 
 #include <yoga/config/Config.h>


### PR DESCRIPTION
See also https://en.cppreference.com/w/cpp/error/terminate.