### PR TITLE
Fix playground handling of visible scrollbars

### DIFF
--- a/website-next/src/components/EditorToolbar.module.css
+++ b/website-next/src/components/EditorToolbar.module.css
@@ -8,9 +8,6 @@
 .toolbar {
   display: flex;
   column-gap: 8px;
-  position: absolute;
-  top: 10px;
-  right: 10px;
 }
 
 .toolbar button {

--- a/website-next/src/components/EditorToolbar.tsx
+++ b/website-next/src/components/EditorToolbar.tsx
@@ -18,9 +18,15 @@ import styles from './EditorToolbar.module.css';
 
 export type Props = Readonly<{
   getCode: () => string;
+  className?: string;
+  style?: React.CSSProperties;
 }>;
 
-export default function EditorToolbar({getCode}: Props): JSX.Element {
+export default function EditorToolbar({
+  getCode,
+  className,
+  style,
+}: Props): JSX.Element {
   const handleCopy = useCallback(
     () => navigator.clipboard.writeText(getCode()),
     [],
@@ -36,7 +42,7 @@ export default function EditorToolbar({getCode}: Props): JSX.Element {
   );
 
   return (
-    <div className={clsx(styles.toolbar)}>
+    <div className={clsx(styles.toolbar, className)} style={style}>
       <ToolbarButton Icon={CopyIcon} label="Copy" onClick={handleCopy} />
       <ToolbarButton Icon={LinkIcon} label="Share" onClick={handleShare} />
     </div>

--- a/website-next/src/components/Playground.module.css
+++ b/website-next/src/components/Playground.module.css
@@ -26,16 +26,29 @@ html[data-theme='dark'] {
   background-color: var(--yg-color-playground-background);
 }
 
-.editorColumn {
-  position: relative;
-  flex: 8;
-  min-width: 0;
-}
-
 .playgroundRow {
   display: flex;
   flex-direction: row;
   column-gap: 16px;
+}
+
+.editorColumn {
+  flex: 8;
+  min-width: 0;
+  overflow-y: auto;
+  border: 1px solid var(--yg-color-editor-border);
+  border-radius: var(--ifm-pre-border-radius);
+  position: relative;
+}
+
+.editorScroll {
+ overflow-y: auto;
+}
+
+.editorToolbar {
+  position: absolute;
+  top: 10px;
+  right: 10px;
 }
 
 .playgroundEditor {
@@ -43,13 +56,12 @@ html[data-theme='dark'] {
     var(--ifm-font-family-monospace) !important;
   direction: ltr;
   height: calc(var(--yg-playground-height, 400px) - 32px);
-  overflow: scroll;
 }
 
 .playgroundEditor :global(.prism-code) {
-  height: 100%;
   box-shadow: var(--ifm-global-shadow-lw);
-  border: 1px solid var(--yg-color-editor-border);
+  min-height: 100%;
+  border-radius: 0;
 }
 
 .previewColumn {
@@ -86,8 +98,7 @@ html[data-theme='dark'] {
   }
 
   .playgroundEditor {
-    height: max-content;
-    overflow: visible;
+    height: unset;
   }
 
   .playgroundRow {
@@ -97,12 +108,13 @@ html[data-theme='dark'] {
 
   .editorColumn {
     padding: 0;
-    flex: 0 !important;
     margin-bottom: 10px;
+    flex: unset;
   }
 
   .previewColumn {
     padding: 10px;
     width: 100%;
+    flex: unset;
   }
 }

--- a/website-next/src/pages/index.module.css
+++ b/website-next/src/pages/index.module.css
@@ -22,11 +22,11 @@
 @media (max-width: 996px) {
   .heroLogo {
     display: none;
-   }
+  }
 
-   .playgroundSection :global(.prism-code) {
+  .playgroundSection :global(.playground-editor) {
     display: none;
-   }
+  }
 }
 
 .bg {


### PR DESCRIPTION
Summary:
On machines with scrollbars, we shouldn't show them unconditionally, and the toolbar should be in the area within them.

This also fixes a bug where the playground re-rendering (e.g. on theme change) makes the preview snap back to the initial code passes.

Differential Revision: D52145666


