### PR TITLE
Change Style::resolveColumnGap() return from Length to Style::Length

### DIFF
--- a/yoga/style/Style.h
+++ b/yoga/style/Style.h
@@ -215,7 +215,7 @@ class YG_EXPORT Style {
     aspectRatio_ = value;
   }
 
-  Length resolveColumnGap() const {
+  Style::Length resolveColumnGap() const {
     if (gap_[yoga::to_underlying(Gutter::Column)].isDefined()) {
       return gap_[yoga::to_underlying(Gutter::Column)];
     } else {


### PR DESCRIPTION
Summary:
Accidentally left this inconsistent with some of the refactoring. Rename the lone usage of `Length` within Style class to `Style::Length` to match the rest of the code.

This is functionally identical as before.

Changelog: [Internal]

Reviewed By: yungsters

Differential Revision: D52096820


