### PR TITLE
Move trailing position functions

### DIFF
--- a/yoga/algorithm/AbsoluteLayout.cpp
+++ b/yoga/algorithm/AbsoluteLayout.cpp
@@ -9,6 +9,7 @@
 #include <yoga/algorithm/Align.h>
 #include <yoga/algorithm/BoundAxis.h>
 #include <yoga/algorithm/CalculateLayout.h>
+#include <yoga/algorithm/TrailingPosition.h>
 
 namespace facebook::yoga {
 

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -23,6 +23,7 @@
 #include <yoga/algorithm/FlexLine.h>
 #include <yoga/algorithm/PixelGrid.h>
 #include <yoga/algorithm/SizingMode.h>
+#include <yoga/algorithm/TrailingPosition.h>
 #include <yoga/debug/AssertFatal.h>
 #include <yoga/debug/Log.h>
 #include <yoga/debug/NodeToString.h>

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -35,21 +35,6 @@ namespace facebook::yoga {
 
 std::atomic<uint32_t> gCurrentGenerationCount(0);
 
-bool calculateLayoutInternal(
-    yoga::Node* const node,
-    const float availableWidth,
-    const float availableHeight,
-    const Direction ownerDirection,
-    const SizingMode widthSizingMode,
-    const SizingMode heightSizingMode,
-    const float ownerWidth,
-    const float ownerHeight,
-    const bool performLayout,
-    const LayoutPassReason reason,
-    LayoutData& layoutMarkerData,
-    const uint32_t depth,
-    const uint32_t generationCount);
-
 static void constrainMaxSizeForMode(
     const yoga::Node* node,
     FlexDirection axis,

--- a/yoga/algorithm/CalculateLayout.h
+++ b/yoga/algorithm/CalculateLayout.h
@@ -35,31 +35,4 @@ bool calculateLayoutInternal(
     const uint32_t depth,
     const uint32_t generationCount);
 
-// Given an offset to an edge, returns the offset to the opposite edge on the
-// same axis. This assumes that the width/height of both nodes is determined at
-// this point.
-inline float getPositionOfOppositeEdge(
-    float position,
-    FlexDirection axis,
-    const yoga::Node* const containingNode,
-    const yoga::Node* const node) {
-  return containingNode->getLayout().measuredDimension(dimension(axis)) -
-      node->getLayout().measuredDimension(dimension(axis)) - position;
-}
-
-inline void setChildTrailingPosition(
-    const yoga::Node* const node,
-    yoga::Node* const child,
-    const FlexDirection axis) {
-  child->setLayoutPosition(
-      getPositionOfOppositeEdge(
-          child->getLayout().position(flexStartEdge(axis)), axis, node, child),
-      flexEndEdge(axis));
-}
-
-inline bool needsTrailingPosition(const FlexDirection axis) {
-  return axis == FlexDirection::RowReverse ||
-      axis == FlexDirection::ColumnReverse;
-}
-
 } // namespace facebook::yoga

--- a/yoga/algorithm/TrailingPosition.h
+++ b/yoga/algorithm/TrailingPosition.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <yoga/Yoga.h>
+#include <yoga/algorithm/FlexDirection.h>
+#include <yoga/event/event.h>
+#include <yoga/node/Node.h>
+
+namespace facebook::yoga {
+
+// Given an offset to an edge, returns the offset to the opposite edge on the
+// same axis. This assumes that the width/height of both nodes is determined at
+// this point.
+inline float getPositionOfOppositeEdge(
+    float position,
+    FlexDirection axis,
+    const yoga::Node* const containingNode,
+    const yoga::Node* const node) {
+  return containingNode->getLayout().measuredDimension(dimension(axis)) -
+      node->getLayout().measuredDimension(dimension(axis)) - position;
+}
+
+inline void setChildTrailingPosition(
+    const yoga::Node* const node,
+    yoga::Node* const child,
+    const FlexDirection axis) {
+  child->setLayoutPosition(
+      getPositionOfOppositeEdge(
+          child->getLayout().position(flexStartEdge(axis)), axis, node, child),
+      flexEndEdge(axis));
+}
+
+inline bool needsTrailingPosition(const FlexDirection axis) {
+  return axis == FlexDirection::RowReverse ||
+      axis == FlexDirection::ColumnReverse;
+}
+
+} // namespace facebook::yoga


### PR DESCRIPTION
Summary: I have some reservations about  some of the conditional setting of trailing position in general, and some of the repeated transformations that neccesitates this, but these functions don't belong in `CalculateLayout.h`. For now, just move these to their own header.

Reviewed By: joevilches

Differential Revision: D52292121


