### PR TITLE
Cache rounded layout values to ensure values are still rounded on consecutive layouts.

### DIFF
--- a/tests/YGMeasureTest.cpp
+++ b/tests/YGMeasureTest.cpp
@@ -22,6 +22,20 @@ static YGSize _measure(
   return YGSize{10, 10};
 }
 
+static YGSize _measureFraction(
+    YGNodeConstRef node,
+    float /*width*/,
+    YGMeasureMode /*widthMode*/,
+    float /*height*/,
+    YGMeasureMode /*heightMode*/) {
+  int* measureCount = (int*)YGNodeGetContext(node);
+  if (measureCount) {
+    (*measureCount)++;
+  }
+
+  return YGSize{10, 10.75};
+}
+
 static YGSize _simulate_wrapping_text(
     YGNodeConstRef /*node*/,
     float width,
@@ -83,6 +97,22 @@ TEST(YogaTest, measure_absolute_child_with_no_constraints) {
   YGNodeInsertChild(root_child0, root_child0_child0, 0);
 
   YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_EQ(1, measureCount);
+
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, measure_fractional) {
+  const YGNodeRef root = YGNodeNew();
+
+  int measureCount = 0;
+  YGNodeSetContext(root, &measureCount);
+  YGNodeSetMeasureFunc(root, _measureFraction);
+  YGNodeCalculateLayout(root, 100, YGUndefined, YGDirectionInherit);
+  ASSERT_EQ(11.f, YGNodeLayoutGetHeight(root));
+  YGNodeCalculateLayout(root, 100, YGUndefined, YGDirectionInherit);
+  ASSERT_EQ(11.f, YGNodeLayoutGetHeight(root));
 
   ASSERT_EQ(1, measureCount);
 

--- a/yoga/algorithm/PixelGrid.cpp
+++ b/yoga/algorithm/PixelGrid.cpp
@@ -103,25 +103,31 @@ void roundLayoutResultsToPixelGrid(
         !yoga::inexactEquals(fmod(nodeHeight * pointScaleFactor, 1.0), 0) &&
         !yoga::inexactEquals(fmod(nodeHeight * pointScaleFactor, 1.0), 1.0);
 
-    node->setLayoutDimension(
-        roundValueToPixelGrid(
+    float width = roundValueToPixelGrid(
             absoluteNodeRight,
             pointScaleFactor,
             (textRounding && hasFractionalWidth),
             (textRounding && !hasFractionalWidth)) -
             roundValueToPixelGrid(
-                absoluteNodeLeft, pointScaleFactor, false, textRounding),
-        Dimension::Width);
+                absoluteNodeLeft, pointScaleFactor, false, textRounding);
 
-    node->setLayoutDimension(
-        roundValueToPixelGrid(
+    float height = roundValueToPixelGrid(
             absoluteNodeBottom,
             pointScaleFactor,
             (textRounding && hasFractionalHeight),
             (textRounding && !hasFractionalHeight)) -
             roundValueToPixelGrid(
-                absoluteNodeTop, pointScaleFactor, false, textRounding),
-        Dimension::Height);
+                absoluteNodeTop, pointScaleFactor, false, textRounding);
+
+    node->setLayoutDimension(width, Dimension::Width);
+    node->setLayoutDimension(height, Dimension::Height);
+    
+    // Update the cached layout to match the rounded values so that they are used
+    // for subsequent layouts. The comparison for whether to use a cached values
+    // takes this rounding into consideration.
+    yoga::CachedMeasurement &cachedLayout = node->getLayout().cachedLayout;
+    cachedLayout.computedWidth = width;
+    cachedLayout.computedHeight = height;
   }
 
   for (yoga::Node* child : node->getChildren()) {


### PR DESCRIPTION
This PR updates `roundLayoutResultsToPixelGrid` to also update the cached layout values in addition to the measured values in the node. This is needed for consecutive layouts to avoid needing to re-round the node values if the cached value can be used and fixes https://github.com/facebook/yoga/issues/877. Re-rounding is costly due to the use of `fmod` and not a proper fix, instead updating the cache is much more performant. The check for whether a cached measurement can be used already takes rounding into consideration, and a test was added to both ensure that and that the rounded value is returned on a subsequent layout.