### PR TITLE
Fix error from misspelled function name

### DIFF
--- a/javascript/src/Node.cpp
+++ b/javascript/src/Node.cpp
@@ -470,5 +470,6 @@ double Node::getComputedPadding(int edge) const {
 }
 
 void Node::setAlwaysFormsContainingBlock(bool alwaysFormsContainingBlock) {
-  return YGNodeSetAlwaysFormContainingBlock(m_node, alwaysFormsContainingBlock);
+  return YGNodeSetAlwaysFormsContainingBlock(
+      m_node, alwaysFormsContainingBlock);
 }


### PR DESCRIPTION
Summary:
`YGNodeSetAlwaysFormContainingBlock` -> `YGNodeSetAlwaysFormsContainingBlock`

Started getting tasks telling me github CI was broken. Turns out I was just mispelling this.

Its not a big deal but we really should ensure that stuff will not land if it break github CI...not in our wheelhouse but it seems quite silly that this happens.

Also, a lot of the random files do not have auto complete or code checking which is why I didn't notice this to begin with.

Differential Revision: D52632257


