### PR TITLE
Android Gradle Plugin 8.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@
  */
 
 plugins {
-    id("com.android.library") version "8.2.0-beta06" apply false
-    id("com.android.application") version "8.2.0-beta06" apply false
+    id("com.android.library") version "8.2.1" apply false
+    id("com.android.application") version "8.2.1" apply false
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 }
 


### PR DESCRIPTION
We technically didn't need to be on the Beta before for NDK 26, but this bumps to the latest, non-prerelease version.