### PR TITLE
Remove YGNodeSetPrintFunc and related

### DIFF
--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -324,10 +324,6 @@ YGNodeType YGNodeGetNodeType(YGNodeConstRef node) {
   return unscopedEnum(resolveRef(node)->getNodeType());
 }
 
-void YGNodeSetPrintFunc(YGNodeRef node, YGPrintFunc printFunc) {
-  resolveRef(node)->setPrintFunc(printFunc);
-}
-
 void YGNodeSetAlwaysFormsContainingBlock(
     YGNodeRef node,
     bool alwaysFormsContainingBlock) {

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -262,14 +262,6 @@ YG_EXPORT void YGNodeSetNodeType(YGNodeRef node, YGNodeType nodeType);
  */
 YG_EXPORT YGNodeType YGNodeGetNodeType(YGNodeConstRef node);
 
-typedef void (*YGPrintFunc)(YGNodeConstRef node);
-
-/**
- * Set a function to be called when configured to print nodes during layout for
- * debugging.
- */
-YG_EXPORT void YGNodeSetPrintFunc(YGNodeRef node, YGPrintFunc printFunc);
-
 /**
  * Make it so that this node will always form a containing block for any
  * descendant nodes. This is useful for when a node has a property outside of

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -2097,35 +2097,6 @@ static void calculateLayoutImpl(
   }
 }
 
-bool gPrintChanges = false;
-bool gPrintSkips = false;
-
-static const char* spacer =
-    "                                                            ";
-
-static const char* spacerWithLength(const unsigned long level) {
-  const size_t spacerLen = strlen(spacer);
-  if (level > spacerLen) {
-    return &spacer[0];
-  } else {
-    return &spacer[spacerLen - level];
-  }
-}
-
-static const char* sizingModeName(
-    const SizingMode mode,
-    const bool performLayout) {
-  switch (mode) {
-    case SizingMode::MaxContent:
-      return performLayout ? "LAY_UNDEFINED" : "UNDEFINED";
-    case SizingMode::StretchFit:
-      return performLayout ? "LAY_EXACTLY" : "EXACTLY";
-    case SizingMode::FitContent:
-      return performLayout ? "LAY_AT_MOST" : "AT_MOST";
-  }
-  return "";
-}
-
 //
 // This is a wrapper around the calculateLayoutImpl function. It determines
 // whether the layout request is redundant and can be skipped.
@@ -2252,48 +2223,7 @@ bool calculateLayoutInternal(
 
     (performLayout ? layoutMarkerData.cachedLayouts
                    : layoutMarkerData.cachedMeasures) += 1;
-
-    if (gPrintChanges && gPrintSkips) {
-      yoga::log(
-          node,
-          LogLevel::Verbose,
-          "%s%d.{[skipped] ",
-          spacerWithLength(depth),
-          depth);
-      node->print();
-      yoga::log(
-          node,
-          LogLevel::Verbose,
-          "wm: %s, hm: %s, aw: %f ah: %f => d: (%f, %f) %s\n",
-          sizingModeName(widthSizingMode, performLayout),
-          sizingModeName(heightSizingMode, performLayout),
-          availableWidth,
-          availableHeight,
-          cachedResults->computedWidth,
-          cachedResults->computedHeight,
-          LayoutPassReasonToString(reason));
-    }
   } else {
-    if (gPrintChanges) {
-      yoga::log(
-          node,
-          LogLevel::Verbose,
-          "%s%d.{%s",
-          spacerWithLength(depth),
-          depth,
-          needToVisitNode ? "*" : "");
-      node->print();
-      yoga::log(
-          node,
-          LogLevel::Verbose,
-          "wm: %s, hm: %s, aw: %f ah: %f %s\n",
-          sizingModeName(widthSizingMode, performLayout),
-          sizingModeName(heightSizingMode, performLayout),
-          availableWidth,
-          availableHeight,
-          LayoutPassReasonToString(reason));
-    }
-
     calculateLayoutImpl(
         node,
         availableWidth,
@@ -2309,26 +2239,6 @@ bool calculateLayoutInternal(
         generationCount,
         reason);
 
-    if (gPrintChanges) {
-      yoga::log(
-          node,
-          LogLevel::Verbose,
-          "%s%d.}%s",
-          spacerWithLength(depth),
-          depth,
-          needToVisitNode ? "*" : "");
-      node->print();
-      yoga::log(
-          node,
-          LogLevel::Verbose,
-          "wm: %s, hm: %s, d: (%f, %f) %s\n",
-          sizingModeName(widthSizingMode, performLayout),
-          sizingModeName(heightSizingMode, performLayout),
-          layout->measuredDimension(Dimension::Width),
-          layout->measuredDimension(Dimension::Height),
-          LayoutPassReasonToString(reason));
-    }
-
     layout->lastOwnerDirection = ownerDirection;
 
     if (cachedResults == nullptr) {
@@ -2338,9 +2248,6 @@ bool calculateLayoutInternal(
 
       if (layout->nextCachedMeasurementsIndex ==
           LayoutResults::MaxCachedMeasurements) {
-        if (gPrintChanges) {
-          yoga::log(node, LogLevel::Verbose, "Out of cache entries!\n");
-        }
         layout->nextCachedMeasurementsIndex = 0;
       }
 

--- a/yoga/node/Node.cpp
+++ b/yoga/node/Node.cpp
@@ -35,7 +35,6 @@ Node::Node(Node&& node) {
   context_ = node.context_;
   measureFunc_ = node.measureFunc_;
   baselineFunc_ = node.baselineFunc_;
-  printFunc_ = node.printFunc_;
   dirtiedFunc_ = node.dirtiedFunc_;
   style_ = node.style_;
   layout_ = node.layout_;
@@ -46,12 +45,6 @@ Node::Node(Node&& node) {
   resolvedDimensions_ = node.resolvedDimensions_;
   for (auto c : children_) {
     c->setOwner(this);
-  }
-}
-
-void Node::print() {
-  if (printFunc_ != nullptr) {
-    printFunc_(this);
   }
 }
 

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -52,8 +52,6 @@ class YG_EXPORT Node : public ::YGNode {
     return alwaysFormsContainingBlock_;
   }
 
-  void print();
-
   bool getHasNewLayout() const {
     return hasNewLayout_;
   }
@@ -250,10 +248,6 @@ class YG_EXPORT Node : public ::YGNode {
     alwaysFormsContainingBlock_ = alwaysFormsContainingBlock;
   }
 
-  void setPrintFunc(YGPrintFunc printFunc) {
-    printFunc_ = printFunc;
-  }
-
   void setHasNewLayout(bool hasNewLayout) {
     hasNewLayout_ = hasNewLayout;
   }
@@ -376,9 +370,8 @@ class YG_EXPORT Node : public ::YGNode {
   bool alwaysFormsContainingBlock_ : 1 = false;
   NodeType nodeType_ : bitCount<NodeType>() = NodeType::Default;
   void* context_ = nullptr;
-  YGMeasureFunc measureFunc_ = {nullptr};
-  YGBaselineFunc baselineFunc_ = {nullptr};
-  YGPrintFunc printFunc_ = {nullptr};
+  YGMeasureFunc measureFunc_ = nullptr;
+  YGBaselineFunc baselineFunc_ = nullptr;
   YGDirtiedFunc dirtiedFunc_ = nullptr;
   Style style_ = {};
   LayoutResults layout_ = {};


### PR DESCRIPTION
Summary:
Separate from `YGConfigSetPrintTreeFlag` we have a public API `YGNodeSetPrintFunc` which sets a function called, if you manually change a constant in source code during debugging.

This is not debug-only, is exposed as part of the public API (without a way to turn it on from the public API), and takes up a pointer per node doing nothing.

I'm not aware of anyone recently using the capability, and the tracing/event related work done since then would be more powerful for this anyway.

Remove the API.

Differential Revision: D52767445


