### PR TITLE
Fix flooring of border

### DIFF
--- a/tests/StyleTest.cpp
+++ b/tests/StyleTest.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <yoga/style/Style.h>
+
+namespace facebook::yoga {
+
+TEST(Style, computed_padding_is_floored) {
+  yoga::Style style;
+  style.setPadding(Edge::All, value::points(-1.0f));
+  auto paddingStart = style.computeInlineStartPadding(
+      FlexDirection::Row, Direction::LTR, 0.0f /*widthSize*/);
+  ASSERT_EQ(paddingStart, 0.0f);
+}
+
+TEST(Style, computed_border_is_floored) {
+  yoga::Style style;
+  style.setBorder(Edge::All, value::points(-1.0f));
+  auto borderStart =
+      style.computeInlineStartBorder(FlexDirection::Row, Direction::LTR);
+  ASSERT_EQ(borderStart, 0.0f);
+}
+
+TEST(Style, computed_gap_is_floored) {
+  yoga::Style style;
+  style.setGap(Gutter::Column, value::points(-1.0f));
+  auto gapBetweenColumns = style.computeGapForAxis(FlexDirection::Row);
+  ASSERT_EQ(gapBetweenColumns, 0.0f);
+}
+
+TEST(Style, computed_margin_is_not_floored) {
+  yoga::Style style;
+  style.setMargin(Edge::All, value::points(-1.0f));
+  auto marginStart = style.computeInlineStartMargin(
+      FlexDirection::Row, Direction::LTR, 0.0f /*widthSize*/);
+  ASSERT_EQ(marginStart, -1.0f);
+}
+
+} // namespace facebook::yoga

--- a/yoga/style/Style.h
+++ b/yoga/style/Style.h
@@ -312,28 +312,32 @@ class YG_EXPORT Style {
   }
 
   float computeFlexStartBorder(FlexDirection axis, Direction direction) const {
-    return computeBorder(flexStartEdge(axis), direction)
-        .resolve(0.0f)
-        .unwrapOrDefault(0.0f);
+    return maxOrDefined(
+        computeBorder(flexStartEdge(axis), direction).resolve(0.0f).unwrap(),
+        0.0f);
   }
 
   float computeInlineStartBorder(FlexDirection axis, Direction direction)
       const {
-    return computeBorder(inlineStartEdge(axis, direction), direction)
-        .resolve(0.0f)
-        .unwrapOrDefault(0.0f);
+    return maxOrDefined(
+        computeBorder(inlineStartEdge(axis, direction), direction)
+            .resolve(0.0f)
+            .unwrap(),
+        0.0f);
   }
 
   float computeFlexEndBorder(FlexDirection axis, Direction direction) const {
-    return computeBorder(flexEndEdge(axis), direction)
-        .resolve(0.0f)
-        .unwrapOrDefault(0.0f);
+    return maxOrDefined(
+        computeBorder(flexEndEdge(axis), direction).resolve(0.0f).unwrap(),
+        0.0f);
   }
 
   float computeInlineEndBorder(FlexDirection axis, Direction direction) const {
-    return computeBorder(inlineEndEdge(axis, direction), direction)
-        .resolve(0.0f)
-        .unwrapOrDefault(0.0f);
+    return maxOrDefined(
+        computeBorder(inlineEndEdge(axis, direction), direction)
+            .resolve(0.0f)
+            .unwrap(),
+        0.0f);
   }
 
   float computeFlexStartPadding(


### PR DESCRIPTION
Summary: I added a small regression D52605596, where negative border would not be correctly floored. This fixes that, and starts adding tests specifically targeting the computed style API, now decoupled from the yoga node.

Differential Revision: D52930827


