### PR TITLE
Fix failing MVSC benchmark builds

### DIFF
--- a/benchmark/Benchmark.cpp
+++ b/benchmark/Benchmark.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <filesystem>
 #include <fstream>
 
 #include <benchmark/Benchmark.h>
@@ -138,7 +139,7 @@ YGUnit unitFromJson(json& j) {
   std::string unit = j["unit"];
   if (unit == "px") {
     return YGUnitPoint;
-  } else if (unit == "\%") {
+  } else if (unit == "pct") {
     return YGUnitPercent;
   } else {
     throw std::invalid_argument(invalidArgumentMessage(unit, "YGUnit"));
@@ -382,7 +383,7 @@ void benchmark(std::filesystem::path& capturesDir) {
       totalDurations[i] = result.treeCreationDuration + result.layoutDuration;
     }
 
-    std::string captureName = capture.path().stem();
+    std::string captureName = capture.path().stem().string();
     printBenchmarkResult(captureName + " tree creation", treeCreationDurations);
     printBenchmarkResult(captureName + " layout", layoutDurations);
     printBenchmarkResult(captureName + " total", totalDurations);

--- a/capture/NodeToString.cpp
+++ b/capture/NodeToString.cpp
@@ -33,7 +33,7 @@ static void appendYGValueIfNotDefault(
     } else if (value.unit == YGUnitUndefined) {
       j["style"][key] = "undefined";
     } else {
-      std::string unit = value.unit == YGUnitPoint ? "px" : "%%";
+      std::string unit = value.unit == YGUnitPoint ? "px" : "pct";
       j["style"][key]["value"] = value.value;
       j["style"][key]["unit"] = unit;
     }


### PR DESCRIPTION
Summary: Noticed a recent stack of commits cause the MVSC builds of benchmark to fail. This was due to forgetting an `#include` for `filesystem` and trying to escape a character that cannot be escaped.

Differential Revision: D53461723


