### PR TITLE
Fix MacCatalyst archiving for stand-alone pod

### DIFF
--- a/Yoga.podspec
+++ b/Yoga.podspec
@@ -24,10 +24,9 @@ Pod::Spec.new do |spec|
   spec.module_name = 'yoga'
   spec.requires_arc = false
   spec.pod_target_xcconfig = {
-    'DEFINES_MODULE' => 'YES'
-  }.merge!(ENV['USE_FRAMEWORKS'] != nil ? {
-    'HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)"'
-} : {})
+    'DEFINES_MODULE' => 'YES',
+    'HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)"',
+  }
 
   spec.compiler_flags = [
       '-fno-omit-frame-pointer',


### PR DESCRIPTION
Summary:
When used alone, yoga has no visibility over the USE_FRAMEWORKS variable set by React Native.

In this case, there is no other way to know whether the current target that will install the spec is using use_framewors or not. As a failsafe, condition, let's always add the `"$(PODS_TARGET_SRCROOT)"` to the search paths to make sure that archiving won't fail.

Whe used in other context, that should not be a problem: search paths are just directory Xcode uses to find headers that are needed.

Differential Revision: D54417386


