### PR TITLE
Run CocoaPods Trunk Publish Job on macOS

### DIFF
--- a/.github/workflows/publish-cocoapods-release.yml
+++ b/.github/workflows/publish-cocoapods-release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish:
     name: Publish to CocoaPods trunk
-    runs-on: ubuntu-latest
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Summary: This was previously running on Ubuntu, but just happened to work until the setup job assumed macOS. Run the job on macOS.

Differential Revision: D54563775


