### PR TITLE
Fixup npm package README

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -2,6 +2,8 @@
 
 This package provides prebuilt WebAssembly bindings for the Yoga layout engine.
 
+See more at https://yogalayout.dev
+
 ## Usage
 
 ```ts
@@ -24,37 +26,6 @@ node.freeRecursive();
 node.free();
 ```
 
-## Using TypeScript
+## Requirements
 
-This package provides out-of-the-box TypeScript typings so long as `tsc` is configured to support ESM resolution. It is recommended to set `moduleResolution: 'bundler'` or `moduleResolution: node16` in your `tsconfig.json` according to your environment.
-
-## ES Modules
-
-`yoga-layout` is only provided as an ES Module, relying on top-level await. This allows providing a synchronous API, while still allowing async WebAssembly compilation in browsers, and will allow eventual usage of ESM/WASM interop.
-
-## Contributing
-
-### Requirements
-
-1. Emscripten SDK
-1. CMake >= 3.13
-1. (Optional) ninja, for faster builds
-
-### Building
-
-```bash
-git clone https://github.com/facebook/yoga.git
-cd yoga/javascript
-yarn install
-yarn build
-```
-
-### Testing
-
-```bash
-# Build and test all entrypoints
-yarn test
-
-# Build and test a specific entrypoint
-yarn test:asmjs-sync
-```
+`yoga-layout` requires a toolchain that supports ES Modules and top-level await.

--- a/javascript/just.config.cjs
+++ b/javascript/just.config.cjs
@@ -59,6 +59,7 @@ task('prepack-package-json', async () => {
   const packageJson = JSON.parse(packageJsonContents.toString('utf-8'));
 
   recursiveReplace(packageJson, /(.\/src\/.*)\.ts/, '$1.js');
+  packageJson.typings = packageJson.main.replace(/(.\/src\/.*)\.js/, '$1.d.ts');
   await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 });
 


### PR DESCRIPTION
Summary: Remove some outdated information and make sure that npmjs shows the builtin TypeScript typings (now that we no longer have clever resolution schemes).

Reviewed By: javache

Differential Revision: D54788636


