### PR TITLE
Add CMake option to not build tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,12 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/project-defaults.cmake)
 
+option(BUILD_TESTS "Build tests" ON)
+
 add_subdirectory(yoga)
-add_subdirectory(tests)
+if (BUILD_TESTS)
+    add_subdirectory(tests)
+endif()
 
 option(BUILD_FUZZ_TESTS "Build fuzz tests" OFF)
 


### PR DESCRIPTION
To enable builds without tests, I added an option. This is useful for packaged versions of yoga, see https://github.com/conan-io/conan-center-index/pull/23019#discussion_r1523276818