### PR TITLE
Add JavaScript bindings for YGHasNewLayout

### DIFF
--- a/javascript/src/Node.cpp
+++ b/javascript/src/Node.cpp
@@ -421,6 +421,14 @@ bool Node::isDirty(void) const {
   return YGNodeIsDirty(m_node);
 }
 
+void Node::markLayoutSeen() {
+  YGNodeSetHasNewLayout(m_node, false);
+}
+
+bool Node::hasNewLayout(void) const {
+  return YGNodeGetHasNewLayout(m_node);
+}
+
 void Node::calculateLayout(double width, double height, int direction) {
   YGNodeCalculateLayout(
       m_node, width, height, static_cast<YGDirection>(direction));

--- a/javascript/src/Node.h
+++ b/javascript/src/Node.h
@@ -197,6 +197,8 @@ class Node {
  public: // Dirtiness accessors
   void markDirty(void);
   bool isDirty(void) const;
+  void markLayoutSeen();
+  bool hasNewLayout(void) const;
 
  public: // Layout mutators
   void calculateLayout(double width, double height, int direction);

--- a/javascript/src/embind.cpp
+++ b/javascript/src/embind.cpp
@@ -177,6 +177,9 @@ EMSCRIPTEN_BINDINGS(YOGA_LAYOUT) {
       .function("markDirty", &Node::markDirty)
       .function("isDirty", &Node::isDirty)
 
+      .function("markLayoutSeen", &Node::markLayoutSeen)
+      .function("hasNewLayout", &Node::hasNewLayout)
+
       .function("calculateLayout", &Node::calculateLayout)
 
       .function("getComputedLeft", &Node::getComputedLeft)

--- a/javascript/src/wrapAssembly.ts
+++ b/javascript/src/wrapAssembly.ts
@@ -120,6 +120,8 @@ export type Node = {
   isDirty(): boolean;
   isReferenceBaseline(): boolean;
   markDirty(): void;
+  hasNewLayout(): boolean;
+  markLayoutSeen(): void;
   removeChild(child: Node): void;
   reset(): void;
   setAlignContent(alignContent: Align): void;

--- a/javascript/tests/YGHasNewLayout.test.ts
+++ b/javascript/tests/YGHasNewLayout.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Yoga from 'yoga-layout';
+
+test('new_layout_can_be_marked_seen', () => {
+  const root = Yoga.Node.create();
+  root.markLayoutSeen();
+  expect(root.hasNewLayout()).toBe(false);
+});
+
+test('new_layout_calculating_layout_marks_layout_as_unseen', () => {
+  const root = Yoga.Node.create();
+  root.markLayoutSeen();
+  root.calculateLayout(undefined, undefined);
+  expect(root.hasNewLayout()).toBe(true);
+});
+
+test('new_layout_calculated_layout_can_be_marked_seen', () => {
+  const root = Yoga.Node.create();
+  root.calculateLayout(undefined, undefined);
+  root.markLayoutSeen();
+  expect(root.hasNewLayout()).toBe(false);
+});
+
+test('new_layout_recalculating_layout_does_mark_as_unseen', () => {
+  const root = Yoga.Node.create();
+  root.calculateLayout(undefined, undefined);
+  root.markLayoutSeen();
+  root.calculateLayout(undefined, undefined);
+  expect(root.hasNewLayout()).toBe(true);
+});
+
+test('new_layout_reset_also_resets_layout_seen', () => {
+  const root = Yoga.Node.create();
+  root.markLayoutSeen();
+  root.reset();
+  expect(root.hasNewLayout()).toBe(true);
+});
+
+test('new_layout_children_sets_new_layout', () => {
+  const root = Yoga.Node.create();
+  root.setAlignItems(Yoga.ALIGN_FLEX_START);
+  root.setWidth(100);
+  root.setHeight(100);
+
+  const root_child0 = Yoga.Node.create();
+  root_child0.setAlignItems(Yoga.ALIGN_FLEX_START);
+  root_child0.setWidth(50);
+  root_child0.setHeight(20);
+  root.insertChild(root_child0, 0);
+
+  const root_child1 = Yoga.Node.create();
+  root_child1.setAlignItems(Yoga.ALIGN_FLEX_START);
+  root_child1.setWidth(50);
+  root_child1.setHeight(20);
+  root.insertChild(root_child1, 0);
+
+  expect(root.hasNewLayout()).toEqual(true);
+  expect(root_child0.hasNewLayout()).toEqual(true);
+  expect(root_child1.hasNewLayout()).toEqual(true);
+
+  root.markLayoutSeen();
+  root_child0.markLayoutSeen();
+  root_child1.markLayoutSeen();
+
+  expect(root.hasNewLayout()).toEqual(false);
+  expect(root_child0.hasNewLayout()).toEqual(false);
+  expect(root_child1.hasNewLayout()).toEqual(false);
+
+  root_child1.setHeight(30);
+  root.calculateLayout(undefined, undefined);
+
+  expect(root.hasNewLayout()).toEqual(true);
+  expect(root_child0.hasNewLayout()).toEqual(true);
+  expect(root_child1.hasNewLayout()).toEqual(true);
+});

--- a/website/docs/advanced/incremental-layout.mdx
+++ b/website/docs/advanced/incremental-layout.mdx
@@ -59,11 +59,23 @@ void applyLayout(YogaNode node) {
 
 <TabItem value="js" label="JavaScript">
 
-:::danger
+```javascript
+void applyLayout(node) {
+  if (!node.hasNewLayout()) {
+    return;
+  }
 
-Yoga's JavaScript bindings are missing support for accessing the `HasNewLayout` flag. https://github.com/facebook/yoga/issues/681
+  // Reset the flag
+  node.markLayoutSeen();
 
-:::
+  // Do the real work
+  ...
+
+  for (let i = 0; i < node.getChildCount(); i++) {
+    applyLayout(node.getChildAt(i));
+  }
+}
+```
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Summary: Adds JavaScript bindings for YGHasNewLayout which introduces
two new node methods: `hasNewLayout()` and `markLayoutSeen()`.

Closes #681