### PR TITLE
Make new nodes dirty by default

### DIFF
--- a/tests/YGStyleTest.cpp
+++ b/tests/YGStyleTest.cpp
@@ -11,10 +11,8 @@
 TEST(YogaTest, copy_style_same) {
   const YGNodeRef node0 = YGNodeNew();
   const YGNodeRef node1 = YGNodeNew();
-  ASSERT_FALSE(YGNodeIsDirty(node0));
 
   YGNodeCopyStyle(node0, node1);
-  ASSERT_FALSE(YGNodeIsDirty(node0));
 
   YGNodeFree(node0);
   YGNodeFree(node1);
@@ -22,7 +20,6 @@ TEST(YogaTest, copy_style_same) {
 
 TEST(YogaTest, copy_style_modified) {
   const YGNodeRef node0 = YGNodeNew();
-  ASSERT_FALSE(YGNodeIsDirty(node0));
   ASSERT_EQ(YGFlexDirectionColumn, YGNodeStyleGetFlexDirection(node0));
   ASSERT_FALSE(YGNodeStyleGetMaxHeight(node0).unit != YGUnitUndefined);
 
@@ -31,7 +28,6 @@ TEST(YogaTest, copy_style_modified) {
   YGNodeStyleSetMaxHeight(node1, 10);
 
   YGNodeCopyStyle(node0, node1);
-  ASSERT_TRUE(YGNodeIsDirty(node0));
   ASSERT_EQ(YGFlexDirectionRow, YGNodeStyleGetFlexDirection(node0));
   ASSERT_FLOAT_EQ(10, YGNodeStyleGetMaxHeight(node0).value);
 
@@ -44,14 +40,12 @@ TEST(YogaTest, copy_style_modified_same) {
   YGNodeStyleSetFlexDirection(node0, YGFlexDirectionRow);
   YGNodeStyleSetMaxHeight(node0, 10);
   YGNodeCalculateLayout(node0, YGUndefined, YGUndefined, YGDirectionLTR);
-  ASSERT_FALSE(YGNodeIsDirty(node0));
 
   const YGNodeRef node1 = YGNodeNew();
   YGNodeStyleSetFlexDirection(node1, YGFlexDirectionRow);
   YGNodeStyleSetMaxHeight(node1, 10);
 
   YGNodeCopyStyle(node0, node1);
-  ASSERT_FALSE(YGNodeIsDirty(node0));
 
   YGNodeFree(node0);
   YGNodeFree(node1);

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -271,7 +271,7 @@ class YG_EXPORT Node : public ::YGNode {
 
   bool hasNewLayout_ : 1 = true;
   bool isReferenceBaseline_ : 1 = false;
-  bool isDirty_ : 1 = false;
+  bool isDirty_ : 1 = true;
   bool alwaysFormsContainingBlock_ : 1 = false;
   NodeType nodeType_ : bitCount<NodeType>() = NodeType::Default;
   void* context_ = nullptr;


### PR DESCRIPTION
Summary:
Yoga has quirk where newly constructed nodes are clean, which isn't really correct. Normally never shows in in real code because setting a style or children  will dirty. Fabric doesn't use the public APIs that do this dirtying, so it ends up getting creative instead.

We should fix so that newly constructed nodes are dirty. Copy-constructed Nodes (also only a Fabric thing, will retain original dirty flag.

Changelog: [Internal]

Differential Revision: D55855328


