### PR TITLE
Isolate distributed JavaScript

### DIFF
--- a/javascript/just.config.cjs
+++ b/javascript/just.config.cjs
@@ -13,11 +13,11 @@ const {
   logger,
   jestTask,
   option,
-  parallel,
   series,
   spawn,
   task,
   tscTask,
+  copyTask,
 } = require('just-scripts');
 
 const {existsSync} = require('fs');
@@ -58,16 +58,32 @@ task('prepack-package-json', async () => {
   const packageJsonContents = await readFile(packageJsonPath);
   const packageJson = JSON.parse(packageJsonContents.toString('utf-8'));
 
-  recursiveReplace(packageJson, /(.\/src\/.*)\.ts/, '$1.js');
-  packageJson.typings = packageJson.main.replace(/(.\/src\/.*)\.js/, '$1.d.ts');
+  packageJson.main = packageJson.main.replace(
+    /^.\/src\/(.*)\.ts/,
+    './dist/src/$1.js',
+  );
+  packageJson.types = packageJson.main.replace(/(.*)\.js/, '$1.d.ts');
+
+  recursiveReplace(
+    packageJson.exports,
+    /^.\/src\/(.*)\.ts/,
+    './dist/src/$1.js',
+  );
+
   await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 });
 
 task(
   'prepack',
   series(
-    parallel('build', tscTask({emitDeclarationOnly: true})),
-    babelTransformTask({dir: 'src'}),
+    'build',
+    copyTask({paths: ['binaries'], dest: 'dist/binaries'}),
+    tscTask({
+      emitDeclarationOnly: true,
+      rootDir: '.',
+      declarationDir: 'dist',
+    }),
+    babelTransformTask({src: 'src', dst: 'dist/src'}),
     'prepack-package-json',
   ),
 );
@@ -85,14 +101,14 @@ function recursiveReplace(obj, pattern, replacement) {
 function babelTransformTask(opts) {
   return () => {
     const args = [
-      opts.dir,
+      opts.src,
       '--source-maps',
       '--out-dir',
-      opts.dir,
+      opts.dst,
       '--extensions',
       '.js,.cjs,.mjs,.ts,.cts,.mts',
     ];
-    logger.info(`Transforming "${path.resolve(opts.dir)}"`);
+    logger.info(`Transforming "${path.resolve(opts.src)}"`);
 
     return spawn(node, [require.resolve('@babel/cli/bin/babel'), ...args], {
       cwd: __dirname,

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -11,12 +11,14 @@
   },
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
     "./load": "./src/load.ts"
   },
   "files": [
-    "binaries/**",
+    "dist/binaries/**",
+    "dist/src/**",
     "src/**"
   ],
   "scripts": {


### PR DESCRIPTION
Summary:
Right now we publish Yoga by transforming in-place, and rewriting the entrypoint to point to the generated vanilla JavaScript.

It is nice to include the original source, e.g. so that users can use sourcemaps when debugging, but putting these files on top of each other has been causing problems, like https://github.com/facebook/yoga/issues/1637#issuecomment-2049099690

This changes the packaging step to instead put all the outputs into a "dist" folder, and point the package entrypoints there. We still include original source for sourcemap usage.

Test Plan:

Ran `yarn prepack` and evaluated output.

Differential Revision: D56093470


