### PR TITLE
Add support for using Yoga from swift on non Darwin platforms. 

### DIFF
--- a/yoga/YGMacros.h
+++ b/yoga/YGMacros.h
@@ -49,7 +49,7 @@
 #define YG_ENUM_END(name)
 #else
 #define YG_ENUM_BEGIN(name) enum name
-#define YG_ENUM_END(name) name
+#define YG_ENUM_END(name) __attribute__((enum_extensibility(closed))) name
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Specify that enums are closed for correct swift export on non darwin platforms.

---

Swift exports plain c enums as constants. On Darwin the yoga macros hit the NS_ENUM case which generates a swift enum, however on linux NS_ENUM is not defined.

See [This post] for a some more background. https://belkadan.com/blog/2021/10/Swift-Regret-Unannotated-C-Enums/

Tested on a couple of CI builds:
- [Failing build](https://github.com/iainsmith/YogaSwift/actions/runs/10478362350/job/29021559312)
- [Passing build](https://github.com/iainsmith/YogaSwift/actions/runs/10493885336/job/29068883339) swift build passes on this, but swift test is failing still for unrelated reasons.

Which results in a compiler error for the missing switch cases.
```swift
[303/309] Compiling YogaSwift YGNodeView.swift
/home/runner/work/YogaSwift/YogaSwift/Sources/YogaSwift/YGNode.swift:50:56: error: type 'YGDirection' has no member 'LTR'
48 |     width: Float = YGValueUndefined.value, height: Float = YGValueUndefined.value
49 |   ) {
50 |     YGNodeCalculateLayout(self.__node, width, height, .LTR)
   |                                                        `- error: type 'YGDirection' has no member 'LTR'
51 |   }
52 | }
```