### PR TITLE
Rename Node.h's getResolvedDimension to getDimensionLength

### DIFF
--- a/yoga/algorithm/AbsoluteLayout.cpp
+++ b/yoga/algorithm/AbsoluteLayout.cpp
@@ -324,7 +324,7 @@ void layoutAbsoluteChild(
       FlexDirection::Column, containingBlockWidth);
 
   if (child->hasDefiniteLength(Dimension::Width, containingBlockWidth)) {
-    childWidth = child->getResolvedDimension(Dimension::Width)
+    childWidth = child->getProcessedDimension(Dimension::Width)
                      .resolve(containingBlockWidth)
                      .unwrap() +
         marginRow;
@@ -359,7 +359,7 @@ void layoutAbsoluteChild(
   }
 
   if (child->hasDefiniteLength(Dimension::Height, containingBlockHeight)) {
-    childHeight = child->getResolvedDimension(Dimension::Height)
+    childHeight = child->getProcessedDimension(Dimension::Height)
                       .resolve(containingBlockHeight)
                       .unwrap() +
         marginColumn;

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -110,7 +110,7 @@ static void computeFlexBasisForChild(
             child, FlexDirection::Row, direction, ownerWidth));
 
     child->setLayoutComputedFlexBasis(yoga::maxOrDefined(
-        child->getResolvedDimension(Dimension::Width).resolve(ownerWidth),
+        child->getProcessedDimension(Dimension::Width).resolve(ownerWidth),
         paddingAndBorder));
   } else if (!isMainAxisRow && isColumnStyleDimDefined) {
     // The height is definite, so use that as the flex basis.
@@ -118,7 +118,7 @@ static void computeFlexBasisForChild(
         FloatOptional(paddingAndBorderForAxis(
             child, FlexDirection::Column, direction, ownerWidth));
     child->setLayoutComputedFlexBasis(yoga::maxOrDefined(
-        child->getResolvedDimension(Dimension::Height).resolve(ownerHeight),
+        child->getProcessedDimension(Dimension::Height).resolve(ownerHeight),
         paddingAndBorder));
   } else {
     // Compute the flex basis and hypothetical main size (i.e. the clamped flex
@@ -132,14 +132,14 @@ static void computeFlexBasisForChild(
         child->style().computeMarginForAxis(FlexDirection::Column, ownerWidth);
 
     if (isRowStyleDimDefined) {
-      childWidth = child->getResolvedDimension(Dimension::Width)
+      childWidth = child->getProcessedDimension(Dimension::Width)
                        .resolve(ownerWidth)
                        .unwrap() +
           marginRow;
       childWidthSizingMode = SizingMode::StretchFit;
     }
     if (isColumnStyleDimDefined) {
-      childHeight = child->getResolvedDimension(Dimension::Height)
+      childHeight = child->getProcessedDimension(Dimension::Height)
                         .resolve(ownerHeight)
                         .unwrap() +
           marginColumn;
@@ -536,7 +536,7 @@ static float computeFlexBasisForChildren(
   }
 
   for (auto child : children) {
-    child->resolveDimension();
+    child->processDimensions();
     if (child->style().display() == Display::None) {
       zeroOutLayoutRecursively(child);
       child->setHasNewLayout(true);
@@ -709,13 +709,13 @@ static float distributeFreeSpaceSecondPass(
           : SizingMode::FitContent;
     } else {
       childCrossSize =
-          currentLineChild->getResolvedDimension(dimension(crossAxis))
+          currentLineChild->getProcessedDimension(dimension(crossAxis))
               .resolve(availableInnerCrossDim)
               .unwrap() +
           marginCross;
       const bool isLoosePercentageMeasurement =
-          currentLineChild->getResolvedDimension(dimension(crossAxis)).unit() ==
-              Unit::Percent &&
+          currentLineChild->getProcessedDimension(dimension(crossAxis))
+                  .unit() == Unit::Percent &&
           sizingModeCrossDim != SizingMode::StretchFit;
       childCrossSizingMode =
           yoga::isUndefined(childCrossSize) || isLoosePercentageMeasurement
@@ -1781,7 +1781,7 @@ static void calculateLayoutImpl(
     const float unclampedCrossDim = sizingModeCrossDim == SizingMode::StretchFit
         ? availableInnerCrossDim + paddingAndBorderAxisCross
         : node->hasDefiniteLength(dimension(crossAxis), crossAxisownerSize)
-        ? node->getResolvedDimension(dimension(crossAxis))
+        ? node->getProcessedDimension(dimension(crossAxis))
               .resolve(crossAxisownerSize)
               .unwrap()
         : totalLineCrossDim + paddingAndBorderAxisCross;
@@ -2354,13 +2354,13 @@ void calculateLayout(
   // visit all dirty nodes at least once. Subsequent visits will be skipped if
   // the input parameters don't change.
   gCurrentGenerationCount.fetch_add(1, std::memory_order_relaxed);
-  node->resolveDimension();
+  node->processDimensions();
   float width = YGUndefined;
   SizingMode widthSizingMode = SizingMode::MaxContent;
   const auto& style = node->style();
   if (node->hasDefiniteLength(Dimension::Width, ownerWidth)) {
     width =
-        (node->getResolvedDimension(dimension(FlexDirection::Row))
+        (node->getProcessedDimension(dimension(FlexDirection::Row))
              .resolve(ownerWidth)
              .unwrap() +
          node->style().computeMarginForAxis(FlexDirection::Row, ownerWidth));
@@ -2380,7 +2380,7 @@ void calculateLayout(
   SizingMode heightSizingMode = SizingMode::MaxContent;
   if (node->hasDefiniteLength(Dimension::Height, ownerHeight)) {
     height =
-        (node->getResolvedDimension(dimension(FlexDirection::Column))
+        (node->getProcessedDimension(dimension(FlexDirection::Column))
              .resolve(ownerHeight)
              .unwrap() +
          node->style().computeMarginForAxis(FlexDirection::Column, ownerWidth));

--- a/yoga/node/Node.cpp
+++ b/yoga/node/Node.cpp
@@ -43,7 +43,7 @@ Node::Node(Node&& node) noexcept
       owner_(node.owner_),
       children_(std::move(node.children_)),
       config_(node.config_),
-      resolvedDimensions_(node.resolvedDimensions_) {
+      processedDimensions_(node.processedDimensions_) {
   for (auto c : children_) {
     c->setOwner(this);
   }
@@ -292,14 +292,14 @@ Style::Length Node::resolveFlexBasisPtr() const {
   return value::ofAuto();
 }
 
-void Node::resolveDimension() {
+void Node::processDimensions() {
   for (auto dim : {Dimension::Width, Dimension::Height}) {
     if (style_.maxDimension(dim).isDefined() &&
         yoga::inexactEquals(
             style_.maxDimension(dim), style_.minDimension(dim))) {
-      resolvedDimensions_[yoga::to_underlying(dim)] = style_.maxDimension(dim);
+      processedDimensions_[yoga::to_underlying(dim)] = style_.maxDimension(dim);
     } else {
-      resolvedDimensions_[yoga::to_underlying(dim)] = style_.dimension(dim);
+      processedDimensions_[yoga::to_underlying(dim)] = style_.dimension(dim);
     }
   }
 }

--- a/yoga/node/Node.h
+++ b/yoga/node/Node.h
@@ -86,7 +86,7 @@ class YG_EXPORT Node : public ::YGNode {
    * https://www.w3.org/TR/css-sizing-3/#definite
    */
   inline bool hasDefiniteLength(Dimension dimension, float ownerSize) {
-    auto usedValue = getResolvedDimension(dimension).resolve(ownerSize);
+    auto usedValue = getProcessedDimension(dimension).resolve(ownerSize);
     return usedValue.isDefined() && usedValue.unwrap() >= 0.0f;
   }
 
@@ -152,12 +152,8 @@ class YG_EXPORT Node : public ::YGNode {
     return isDirty_;
   }
 
-  std::array<Style::Length, 2> getResolvedDimensions() const {
-    return resolvedDimensions_;
-  }
-
-  Style::Length getResolvedDimension(Dimension dimension) const {
-    return resolvedDimensions_[static_cast<size_t>(dimension)];
+  Style::Length getProcessedDimension(Dimension dimension) const {
+    return processedDimensions_[static_cast<size_t>(dimension)];
   }
 
   // Setters
@@ -233,7 +229,7 @@ class YG_EXPORT Node : public ::YGNode {
 
   // Other methods
   Style::Length resolveFlexBasisPtr() const;
-  void resolveDimension();
+  void processDimensions();
   Direction resolveDirection(Direction ownerDirection);
   void clearChildren();
   /// Replaces the occurrences of oldChild with newChild
@@ -280,7 +276,7 @@ class YG_EXPORT Node : public ::YGNode {
   Node* owner_ = nullptr;
   std::vector<Node*> children_;
   const Config* config_;
-  std::array<Style::Length, 2> resolvedDimensions_{
+  std::array<Style::Length, 2> processedDimensions_{
       {value::undefined(), value::undefined()}};
 };
 


### PR DESCRIPTION
Summary:
To get the height and width we call a function currently named `getResolvedDimension`. This returns a `Style::Length`, which in most cases we "resolve" immediately by calling `resolve`. This is a bit confusing that you need to `resolve` something that is already `resolved`.

I plan on adding a new function soon for `contextBox` which would resolve the length for you, so I think this should be renamed.

Also deleted unused `getResolvedDimensions`

Changelog: [Internal]

Differential Revision: D63407730
