### PR TITLE
Add default test for box sizing

### DIFF
--- a/enums.py
+++ b/enums.py
@@ -33,7 +33,7 @@ ENUMS = {
     "PositionType": ["Static", "Relative", "Absolute"],
     "Display": ["Flex", "None"],
     "Wrap": ["NoWrap", "Wrap", "WrapReverse"],
-    "BoxSizing": ["ContentBox", "BorderBox"],
+    "BoxSizing": ["BorderBox", "ContentBox"],
     "MeasureMode": ["Undefined", "Exactly", "AtMost"],
     "Dimension": ["Width", "Height"],
     "Edge": [

--- a/java/com/facebook/yoga/YogaBoxSizing.java
+++ b/java/com/facebook/yoga/YogaBoxSizing.java
@@ -10,8 +10,8 @@
 package com.facebook.yoga;
 
 public enum YogaBoxSizing {
-  CONTENT_BOX(0),
-  BORDER_BOX(1);
+  BORDER_BOX(0),
+  CONTENT_BOX(1);
 
   private final int mIntValue;
 
@@ -25,8 +25,8 @@ public enum YogaBoxSizing {
 
   public static YogaBoxSizing fromInt(int value) {
     switch (value) {
-      case 0: return CONTENT_BOX;
-      case 1: return BORDER_BOX;
+      case 0: return BORDER_BOX;
+      case 1: return CONTENT_BOX;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);
     }
   }

--- a/javascript/src/generated/YGEnums.ts
+++ b/javascript/src/generated/YGEnums.ts
@@ -20,8 +20,8 @@ export enum Align {
 }
 
 export enum BoxSizing {
-  ContentBox = 0,
-  BorderBox = 1,
+  BorderBox = 0,
+  ContentBox = 1,
 }
 
 export enum Dimension {
@@ -142,8 +142,8 @@ const constants = {
   ALIGN_SPACE_BETWEEN: Align.SpaceBetween,
   ALIGN_SPACE_AROUND: Align.SpaceAround,
   ALIGN_SPACE_EVENLY: Align.SpaceEvenly,
-  BOX_SIZING_CONTENT_BOX: BoxSizing.ContentBox,
   BOX_SIZING_BORDER_BOX: BoxSizing.BorderBox,
+  BOX_SIZING_CONTENT_BOX: BoxSizing.ContentBox,
   DIMENSION_WIDTH: Dimension.Width,
   DIMENSION_HEIGHT: Dimension.Height,
   DIRECTION_INHERIT: Direction.Inherit,

--- a/tests/YGDefaultValuesTest.cpp
+++ b/tests/YGDefaultValuesTest.cpp
@@ -162,3 +162,14 @@ TEST(YogaTest, assert_legacy_stretch_behaviour) {
 
   YGConfigFree(config);
 }
+
+TEST(YogaTest, assert_box_sizing_border_box) {
+  YGConfig* config = YGConfigNew();
+  YGNodeRef root = YGNodeNewWithConfig(config);
+
+  ASSERT_EQ(YGBoxSizingBorderBox, YGNodeStyleGetBoxSizing(root));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}

--- a/yoga/YGEnums.cpp
+++ b/yoga/YGEnums.cpp
@@ -35,10 +35,10 @@ const char* YGAlignToString(const YGAlign value) {
 
 const char* YGBoxSizingToString(const YGBoxSizing value) {
   switch (value) {
-    case YGBoxSizingContentBox:
-      return "content-box";
     case YGBoxSizingBorderBox:
       return "border-box";
+    case YGBoxSizingContentBox:
+      return "content-box";
   }
   return "unknown";
 }

--- a/yoga/YGEnums.h
+++ b/yoga/YGEnums.h
@@ -26,8 +26,8 @@ YG_ENUM_DECL(
 
 YG_ENUM_DECL(
     YGBoxSizing,
-    YGBoxSizingContentBox,
-    YGBoxSizingBorderBox)
+    YGBoxSizingBorderBox,
+    YGBoxSizingContentBox)
 
 YG_ENUM_DECL(
     YGDimension,

--- a/yoga/enums/BoxSizing.h
+++ b/yoga/enums/BoxSizing.h
@@ -16,8 +16,8 @@
 namespace facebook::yoga {
 
 enum class BoxSizing : uint8_t {
-  ContentBox = YGBoxSizingContentBox,
   BorderBox = YGBoxSizingBorderBox,
+  ContentBox = YGBoxSizingContentBox,
 };
 
 template <>


### PR DESCRIPTION
Summary:
Had a mini heart attack thinking I set the default to content box. Wrote this to double check and it passed. Might as well check it in

Technically the default to BoxSizing.h is ContentBox, but in the style we override that. Regardless I switched that around so border box was the default.

Changelog: [Internal]

Differential Revision: D63802722


