### PR TITLE
Make it so that we can console.log in browser to debug gentest

### DIFF
--- a/gentest/gentest-driver.ts
+++ b/gentest/gentest-driver.ts
@@ -100,15 +100,21 @@ for (const fileName of fixtures) {
   await driver.get('file://' + process.cwd() + '/test.html');
   const logs = await driver.manage().logs().get(logging.Type.BROWSER);
 
+  const testLogs = logs.filter(
+    log => !log.message.replace(/^[^"]*/, '').startsWith('"gentest-log:'),
+  );
+
   await fs.writeFile(
     `${yogaDir}/tests/generated/${fileNameNoExtension}.cpp`,
-    addSignatureToSourceCode(JSON.parse(logs[0].message.replace(/^[^"]*/, ''))),
+    addSignatureToSourceCode(
+      JSON.parse(testLogs[0].message.replace(/^[^"]*/, '')),
+    ),
   );
 
   await fs.writeFile(
     `${yogaDir}/java/tests/generated/com/facebook/yoga/${fileNameNoExtension}.java`,
     addSignatureToSourceCode(
-      JSON.parse(logs[1].message.replace(/^[^"]*/, '')).replace(
+      JSON.parse(testLogs[1].message.replace(/^[^"]*/, '')).replace(
         'YogaTest',
         fileNameNoExtension,
       ),
@@ -118,7 +124,7 @@ for (const fileName of fixtures) {
   await fs.writeFile(
     `${yogaDir}/javascript/tests/generated/${fileNameNoExtension}.test.ts`,
     addSignatureToSourceCode(
-      JSON.parse(logs[2].message.replace(/^[^"]*/, '')).replace(
+      JSON.parse(testLogs[2].message.replace(/^[^"]*/, '')).replace(
         'YogaTest',
         fileNameNoExtension,
       ),

--- a/gentest/gentest-log.js
+++ b/gentest/gentest-log.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// eslint-disable-next-line no-unused-vars
+function gentestLog(message) {
+  console.log('gentest-log: ', message);
+}

--- a/gentest/test-template.html
+++ b/gentest/test-template.html
@@ -8,6 +8,7 @@
   <script src="gentest-cpp.js"></script>
   <script src="gentest-java.js"></script>
   <script src="gentest-javascript.js"></script>
+  <script src="gentest-log.js"></script>
 
   <style>
     @font-face {


### PR DESCRIPTION
Summary: Our gentest works by console.logging the contents of the test it is generating to the browser powered by the driver. The driver then reads the logs and writes it to a file. An unfortunate side effect here is that we cannot console.log to debug how the gentest logic actually works since the driver is expecting formatted code. To get around this I had the driver filter out logs with a certain prefix and add that a helper that logs a message with this prefix to the scripts.

Differential Revision: D64011035


