### PR TITLE
Bump to Gradle 8.7, AGP 8.7.1 and NDK 27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@
  */
 
 plugins {
-    id("com.android.library") version "8.2.1" apply false
-    id("com.android.application") version "8.2.1" apply false
+    id("com.android.library") version "8.7.1" apply false
+    id("com.android.application") version "8.7.1" apply false
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -23,7 +23,7 @@ android {
   namespace = "com.facebook.yoga"
   compileSdk = 35
   buildToolsVersion = "35.0.0"
-  ndkVersion = "26.0.10792818"
+  ndkVersion = "27.1.12297006"
 
   defaultConfig {
     minSdk = 21


### PR DESCRIPTION
Summary:
Bumping Gradle to 8.7, AGP to 8.7.1 and NDK to 27.1.12297006 in prep to build native libraries with 16KB page size support

See:
- Changelog r27: https://github.com/android/ndk/wiki/Changelog-r27
- 16KB page sizes: https://developer.android.com/guide/practices/page-sizes

Differential Revision: D64381441


