### PR TITLE
Use static values for undefined and auto lengths

### DIFF
--- a/yoga/style/StyleValuePool.h
+++ b/yoga/style/StyleValuePool.h
@@ -49,9 +49,11 @@ class StyleValuePool {
 
   StyleLength getLength(StyleValueHandle handle) const {
     if (handle.isUndefined()) {
-      return StyleLength::undefined();
+      static const StyleLength undefined = StyleLength::undefined();
+      return undefined;
     } else if (handle.isAuto()) {
-      return StyleLength::ofAuto();
+      static const StyleLength ofAuto = StyleLength::ofAuto();
+      return ofAuto;
     } else {
       assert(
           handle.type() == StyleValueHandle::Type::Point ||


### PR DESCRIPTION
Summary:
Profiling in a test app with many undefined lengths shows this saves roughly 33% of time spent in Yoga.

## Changelog

[General][Fixed] Reduce amount of time spent in Yoga by reusing statically defined values in StyleLength::getLength()

Reviewed By: yungsters

Differential Revision: D65207753


