### PR TITLE
Do not manipulate strings in the args of an assert

### DIFF
--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -696,9 +696,7 @@ static float distributeFreeSpaceSecondPass(
     yoga::assertFatalWithNode(
         currentLineChild,
         yoga::isDefined(updatedMainSize),
-        ("updatedMainSize is undefined. mainAxisOwnerSize: " +
-         std::to_string(mainAxisOwnerSize))
-            .c_str());
+        "updatedMainSize is undefined.");
 
     deltaFreeSpace += updatedMainSize - childFlexBasis;
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/react-native/pull/47580

We should not be doing any work to handle an assertion. While we could, in theory, create a templatized assertion capability, in practice, it's unlikely that this stringified mainAxisOwnerSize is going to tell us much.

## Changelog

[Internal]

Reviewed By: jorge-cab

Differential Revision: D65862761


