### PR TITLE
Revert "Extra log for case where availableHeight is undefined and sizing mode != max content (#1687)"

### DIFF
--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -10,7 +10,6 @@
 #include <cfloat>
 #include <cmath>
 #include <cstring>
-#include <string>
 
 #include <yoga/Yoga.h>
 
@@ -693,13 +692,6 @@ static float distributeFreeSpaceSecondPass(
       }
     }
 
-    yoga::assertFatalWithNode(
-        currentLineChild,
-        yoga::isDefined(updatedMainSize),
-        ("updatedMainSize is undefined. mainAxisOwnerSize: " +
-         std::to_string(mainAxisOwnerSize))
-            .c_str());
-
     deltaFreeSpace += updatedMainSize - childFlexBasis;
 
     const float marginMain = currentLineChild->style().computeMarginForAxis(
@@ -793,20 +785,6 @@ static float distributeFreeSpaceSecondPass(
     const bool isLayoutPass = performLayout && !requiresStretchLayout;
     // Recursively call the layout algorithm for this child with the updated
     // main size.
-
-    yoga::assertFatalWithNode(
-        currentLineChild,
-        yoga::isUndefined(childMainSize)
-            ? childMainSizingMode == SizingMode::MaxContent
-            : true,
-        "childMainSize is undefined so childMainSizingMode must be MaxContent");
-    yoga::assertFatalWithNode(
-        currentLineChild,
-        yoga::isUndefined(childCrossSize)
-            ? childCrossSizingMode == SizingMode::MaxContent
-            : true,
-        "childCrossSize is undefined so childCrossSizingMode must be MaxContent");
-
     calculateLayoutInternal(
         currentLineChild,
         childWidth,


### PR DESCRIPTION
Summary:
Reverting https://github.com/facebook/yoga/pull/1687 as it appears to regress Yoga performance anywhere from 10-33%.

## Changelog

[Internal]

Differential Revision: D65863569


