### PR TITLE
Update YGNodeStyleGetGap to return YGValue

### DIFF
--- a/capture/NodeToString.cpp
+++ b/capture/NodeToString.cpp
@@ -225,17 +225,17 @@ static void serializeTreeImpl(
     appendEdges<&YGNodeStyleGetPosition>(
         j, "position", node, defaultNode.get());
 
-    appendFloatIfNotDefault(
+    appendYGValueIfNotDefault(
         j["style"],
         "gap",
         YGNodeStyleGetGap(node, YGGutterAll),
         YGNodeStyleGetGap(defaultNode.get(), YGGutterAll));
-    appendFloatIfNotDefault(
+    appendYGValueIfNotDefault(
         j["style"],
         "column-gap",
         YGNodeStyleGetGap(node, YGGutterColumn),
         YGNodeStyleGetGap(defaultNode.get(), YGGutterColumn));
-    appendFloatIfNotDefault(
+    appendYGValueIfNotDefault(
         j["style"],
         "row-gap",
         YGNodeStyleGetGap(node, YGGutterRow),

--- a/java/com/facebook/yoga/YogaNative.java
+++ b/java/com/facebook/yoga/YogaNative.java
@@ -130,7 +130,7 @@ public class YogaNative {
   static native void jni_YGNodeStyleSetMaxHeightStretchJNI(long nativePointer);
   static native float jni_YGNodeStyleGetAspectRatioJNI(long nativePointer);
   static native void jni_YGNodeStyleSetAspectRatioJNI(long nativePointer, float aspectRatio);
-  static native float jni_YGNodeStyleGetGapJNI(long nativePointer, int gutter);
+  static native long jni_YGNodeStyleGetGapJNI(long nativePointer, int gutter);
   static native void jni_YGNodeStyleSetGapJNI(long nativePointer, int gutter, float gapLength);
   static native void jni_YGNodeStyleSetGapPercentJNI(long nativePointer, int gutter, float gapLength);
   static native void jni_YGNodeSetHasMeasureFuncJNI(long nativePointer, boolean hasMeasureFunc);

--- a/java/com/facebook/yoga/YogaNode.java
+++ b/java/com/facebook/yoga/YogaNode.java
@@ -236,7 +236,7 @@ public abstract class YogaNode implements YogaProps {
 
   public abstract void setAspectRatio(float aspectRatio);
 
-  public abstract float getGap(YogaGutter gutter);
+  public abstract YogaValue getGap(YogaGutter gutter);
 
   public abstract void setGap(YogaGutter gutter, float gapLength);
 

--- a/java/com/facebook/yoga/YogaNodeJNIBase.java
+++ b/java/com/facebook/yoga/YogaNodeJNIBase.java
@@ -811,8 +811,8 @@ public abstract class YogaNodeJNIBase extends YogaNode implements Cloneable {
   }
 
   @Override
-  public float getGap(YogaGutter gutter) {
-    return YogaNative.jni_YGNodeStyleGetGapJNI(mNativePointer, gutter.intValue());
+  public YogaValue getGap(YogaGutter gutter) {
+    return valueFromLong(YogaNative.jni_YGNodeStyleGetGapJNI(mNativePointer, gutter.intValue()));
   }
 
   @Override

--- a/java/jni/YGJNIVanilla.cpp
+++ b/java/jni/YGJNIVanilla.cpp
@@ -725,13 +725,13 @@ jni_YGNodeCloneJNI(JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {
   return reinterpret_cast<jlong>(clonedYogaNode);
 }
 
-static jfloat jni_YGNodeStyleGetGapJNI(
+static jlong jni_YGNodeStyleGetGapJNI(
     JNIEnv* /*env*/,
     jobject /*obj*/,
     jlong nativePointer,
     jint gutter) {
-  return (jfloat)YGNodeStyleGetGap(
-      _jlong2YGNodeRef(nativePointer), static_cast<YGGutter>(gutter));
+  return YogaValue::asJavaLong(YGNodeStyleGetGap(
+      _jlong2YGNodeRef(nativePointer), static_cast<YGGutter>(gutter)));
 }
 
 static void jni_YGNodeStyleSetGapJNI(

--- a/java/jni/YGJNIVanilla.cpp
+++ b/java/jni/YGJNIVanilla.cpp
@@ -1057,7 +1057,7 @@ static JNINativeMethod methods[] = {
     {"jni_YGNodeSetHasMeasureFuncJNI",
      "(JZ)V",
      (void*)jni_YGNodeSetHasMeasureFuncJNI},
-    {"jni_YGNodeStyleGetGapJNI", "(JI)F", (void*)jni_YGNodeStyleGetGapJNI},
+    {"jni_YGNodeStyleGetGapJNI", "(JI)J", (void*)jni_YGNodeStyleGetGapJNI},
     {"jni_YGNodeStyleSetGapJNI", "(JIF)V", (void*)jni_YGNodeStyleSetGapJNI},
     {"jni_YGNodeStyleSetGapPercentJNI",
      "(JIF)V",

--- a/javascript/src/Node.cpp
+++ b/javascript/src/Node.cpp
@@ -439,8 +439,9 @@ Value Node::getPadding(int edge) const {
       YGNodeStyleGetPadding(m_node, static_cast<YGEdge>(edge)));
 }
 
-float Node::getGap(int gutter) {
-  return YGNodeStyleGetGap(m_node, static_cast<YGGutter>(gutter));
+Value Node::getGap(int gutter) const {
+  return Value::fromYGValue(
+      YGNodeStyleGetGap(m_node, static_cast<YGGutter>(gutter)));
 }
 
 bool Node::isReferenceBaseline() {

--- a/javascript/src/Node.h
+++ b/javascript/src/Node.h
@@ -186,7 +186,7 @@ class Node {
 
   Value getPadding(int edge) const;
 
-  float getGap(int gutter);
+  Value getGap(int gutter) const;
 
   int getBoxSizing(void) const;
 

--- a/yoga/YGNodeStyle.cpp
+++ b/yoga/YGNodeStyle.cpp
@@ -293,13 +293,8 @@ void YGNodeStyleSetGapPercent(YGNodeRef node, YGGutter gutter, float percent) {
       node, scopedEnum(gutter), StyleLength::percent(percent));
 }
 
-float YGNodeStyleGetGap(const YGNodeConstRef node, const YGGutter gutter) {
-  auto gapLength = resolveRef(node)->style().gap(scopedEnum(gutter));
-  if (gapLength.isUndefined() || gapLength.isAuto()) {
-    return YGUndefined;
-  }
-
-  return static_cast<YGValue>(gapLength).value;
+YGValue YGNodeStyleGetGap(const YGNodeConstRef node, const YGGutter gutter) {
+  return (YGValue)resolveRef(node)->style().gap(scopedEnum(gutter));
 }
 
 void YGNodeStyleSetAspectRatio(const YGNodeRef node, const float aspectRatio) {

--- a/yoga/YGNodeStyle.h
+++ b/yoga/YGNodeStyle.h
@@ -96,7 +96,7 @@ YG_EXPORT void
 YGNodeStyleSetGap(YGNodeRef node, YGGutter gutter, float gapLength);
 YG_EXPORT void
 YGNodeStyleSetGapPercent(YGNodeRef node, YGGutter gutter, float gapLength);
-YG_EXPORT float YGNodeStyleGetGap(YGNodeConstRef node, YGGutter gutter);
+YG_EXPORT YGValue YGNodeStyleGetGap(YGNodeConstRef node, YGGutter gutter);
 
 YG_EXPORT void YGNodeStyleSetBoxSizing(YGNodeRef node, YGBoxSizing boxSizing);
 YG_EXPORT YGBoxSizing YGNodeStyleGetBoxSizing(YGNodeConstRef node);


### PR DESCRIPTION
Gap can be styled using both `points` and `percentages`, but YGNodeStyleGetGap currently returns a float value.

To maintain alignment with the `padding` and `margin` functionalities and allow it to be handled in bridging code, this function has been updated to return YGValue.