### PR TITLE
Use crossAxisOwnerSize instead of ownerHeight in cross axis bound call

### DIFF
--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -1780,7 +1780,7 @@ static void calculateLayoutImpl(
                                     crossAxis,
                                     direction,
                                     unclampedCrossDim,
-                                    ownerHeight,
+                                    crossAxisOwnerSize,
                                     ownerWidth) -
         paddingAndBorderAxisCross;
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/react-native/pull/48080

Small bug that I noticed while doing intrinsic sizing. We have the ownerHeight as the axis size despite bounding the length of the cross axis. This should therefore be the crossAxisOwnerSize, which might be the width in some cases

Changelog: [Internal]

Differential Revision: D66736539


