### PR TITLE
Fix/typescript 4 node module resolution

### DIFF
--- a/javascript/.gitignore
+++ b/javascript/.gitignore
@@ -2,3 +2,6 @@
 /binaries
 /build
 /dist
+load.js
+load.js.map
+load.d.ts

--- a/javascript/jest.config.js
+++ b/javascript/jest.config.js
@@ -11,4 +11,7 @@ export default {
   setupFiles: ['./jest.setup.js'],
   testRegex: '/tests/.*\\.test\\.ts$',
   extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.\\.?\\/.+)\\.js$': '$1',
+  },
 };

--- a/javascript/just.config.cjs
+++ b/javascript/just.config.cjs
@@ -84,7 +84,7 @@ task(
       declarationDir: 'dist',
     }),
     babelTransformTask({src: 'src', dst: 'dist/src'}),
-    transformLoadTask(),
+    transformLoadEntryPointTask(),
     'prepack-package-json',
   ),
 );
@@ -98,29 +98,16 @@ function recursiveReplace(obj, pattern, replacement) {
     }
   }
 }
-
-function transformLoadTask() {
+function transformLoadEntryPointTask() {
   return async () => {
-    const js = {
-      content:
-        'export * from "./dist/src/load.js";\n//# sourceMappingURL=load.js.map\n',
-    };
-    await writeFile('load.js', js.content);
+    await tscTask({
+      project: 'tsconfig.load.json',
+    })();
 
-    const sourceMap = {
-      version: 3,
-      file: 'load.js',
-      names: [],
-      sources: ['./src/load.ts'],
-      sourcesContent: [js.content],
-      mappings: 'AAAA,cAAc,YAAY',
-    };
-    await writeFile('load.js.map', JSON.stringify(sourceMap));
-
-    const dts = {
-      content: 'export * from "./dist/src/load.js";\n',
-    };
-    await writeFile('load.d.ts', dts.content);
+    await babelTransformTask({
+      src: 'load.ts',
+      dst: '.',
+    })();
   };
 }
 

--- a/javascript/just.config.cjs
+++ b/javascript/just.config.cjs
@@ -113,7 +113,7 @@ function transformLoadTask() {
       names: [],
       sources: ['./src/load.ts'],
       sourcesContent: [js.content],
-      mappings: 'AAAA,cAAc,eAAe',
+      mappings: 'AAAA,cAAc,YAAY',
     };
     await writeFile('load.js.map', JSON.stringify(sourceMap));
 

--- a/javascript/just.config.cjs
+++ b/javascript/just.config.cjs
@@ -84,6 +84,7 @@ task(
       declarationDir: 'dist',
     }),
     babelTransformTask({src: 'src', dst: 'dist/src'}),
+    transformLoadTask(),
     'prepack-package-json',
   ),
 );
@@ -96,6 +97,31 @@ function recursiveReplace(obj, pattern, replacement) {
       recursiveReplace(value, pattern, replacement);
     }
   }
+}
+
+function transformLoadTask() {
+  return async () => {
+    const js = {
+      content:
+        'export * from "./dist/src/load.js";\n//# sourceMappingURL=load.js.map\n',
+    };
+    await writeFile('load.js', js.content);
+
+    const sourceMap = {
+      version: 3,
+      file: 'load.js',
+      names: [],
+      sources: ['./src/load.ts'],
+      sourcesContent: [js.content],
+      mappings: 'AAAA,cAAc,eAAe',
+    };
+    await writeFile('load.js.map', JSON.stringify(sourceMap));
+
+    const dts = {
+      content: 'export * from "./dist/src/load.js";\n',
+    };
+    await writeFile('load.d.ts', dts.content);
+  };
 }
 
 function babelTransformTask(opts) {

--- a/javascript/just.config.cjs
+++ b/javascript/just.config.cjs
@@ -98,16 +98,29 @@ function recursiveReplace(obj, pattern, replacement) {
     }
   }
 }
+
 function transformLoadEntryPointTask() {
   return async () => {
+    const loadPath = path.join(__dirname, 'load.ts');
+    const loadContent = await readFile(loadPath, 'utf-8');
+    const transformedContent = loadContent.replace(
+      /\.\/src\/(.*)\.js/,
+      './dist/src/$1.js',
+    );
+    await writeFile(loadPath, transformedContent);
+
     await tscTask({
       project: 'tsconfig.load.json',
+      rootDir: '.',
+      outDir: '.',
     })();
 
     await babelTransformTask({
       src: 'load.ts',
       dst: '.',
     })();
+
+    await writeFile(loadPath, loadContent);
   };
 }
 

--- a/javascript/load.ts
+++ b/javascript/load.ts
@@ -1,1 +1,1 @@
-export * from './dist/src/load.js';
+export * from './src/load.js';

--- a/javascript/load.ts
+++ b/javascript/load.ts
@@ -1,0 +1,1 @@
+export * from './dist/src/load.js';

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -21,7 +21,8 @@
     "dist/src/**",
     "src/**",
     "load.js",
-    "load.js.map"
+    "load.js.map",
+    "load.d.ts"
   ],
   "scripts": {
     "benchmark": "just benchmark --config just.config.cjs",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -19,7 +19,9 @@
   "files": [
     "dist/binaries/**",
     "dist/src/**",
-    "src/**"
+    "src/**",
+    "load.js",
+    "load.js.map"
   ],
   "scripts": {
     "benchmark": "just benchmark --config just.config.cjs",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -20,9 +20,7 @@
     "dist/binaries/**",
     "dist/src/**",
     "src/**",
-    "load.js",
-    "load.js.map",
-    "load.d.ts"
+    "load.*"
   ],
   "scripts": {
     "benchmark": "just benchmark --config just.config.cjs",

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -9,15 +9,15 @@
 
 // @ts-ignore untyped from Emscripten
 import loadYoga from '../binaries/yoga-wasm-base64-esm.js';
-import wrapAssembly from './wrapAssembly.ts';
+import wrapAssembly from './wrapAssembly.js';
 
 export type {
   Config,
   DirtiedFunction,
   MeasureFunction,
   Node,
-} from './wrapAssembly.ts';
+} from './wrapAssembly.js';
 
 const Yoga = wrapAssembly(await loadYoga());
 export default Yoga;
-export * from './generated/YGEnums.ts';
+export * from './generated/YGEnums.js';

--- a/javascript/src/load.ts
+++ b/javascript/src/load.ts
@@ -9,7 +9,7 @@
 
 // @ts-ignore untyped from Emscripten
 import loadYogaImpl from '../binaries/yoga-wasm-base64-esm.js';
-import wrapAssembly from './wrapAssembly.ts';
+import wrapAssembly from './wrapAssembly.js';
 
 export type {
   Config,
@@ -17,9 +17,9 @@ export type {
   MeasureFunction,
   Node,
   Yoga,
-} from './wrapAssembly.ts';
+} from './wrapAssembly.js';
 
 export async function loadYoga() {
   return wrapAssembly(await loadYogaImpl());
 }
-export * from './generated/YGEnums.ts';
+export * from './generated/YGEnums.js';

--- a/javascript/src/wrapAssembly.ts
+++ b/javascript/src/wrapAssembly.ts
@@ -9,8 +9,8 @@
 
 // @ts-nocheck
 
-import {Unit, Direction} from './generated/YGEnums.ts';
-import YGEnums from './generated/YGEnums.ts';
+import {Unit, Direction} from './generated/YGEnums.js';
+import YGEnums from './generated/YGEnums.js';
 
 import type {
   Align,
@@ -26,7 +26,7 @@ import type {
   Overflow,
   PositionType,
   Wrap,
-} from './generated/YGEnums.ts';
+} from './generated/YGEnums.js';
 
 type Layout = {
   left: number;

--- a/javascript/tsconfig.load.json
+++ b/javascript/tsconfig.load.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": ".",
+    "emitDeclarationOnly": true
+  },
+  "files": ["load.ts"]
+}

--- a/javascript/tsconfig.load.json
+++ b/javascript/tsconfig.load.json
@@ -4,5 +4,6 @@
     "outDir": ".",
     "emitDeclarationOnly": true
   },
-  "files": ["load.ts"]
+  "files": ["load.ts"],
+  "exclude": ["tests/**/*", "src/**/*"]
 }

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -110,4 +110,5 @@ export default {
         },
       ],
     }),
+  plugins: [require.resolve('./plugins/webpack-config.js')],
 };

--- a/website/plugins/webpack-config.js
+++ b/website/plugins/webpack-config.js
@@ -3,13 +3,16 @@
 export default function webpackPlugin(context, options) {
   return {
     name: 'webpack-config-plugin',
-    // eslint-disable-next-line no-unused-vars
     configureWebpack(config) {
+      const resolve = config?.resolve ?? {};
+      const extensionAlias = resolve?.extensionAlias ?? {};
+
       return {
         resolve: {
+          ...resolve,
           extensionAlias: {
+            ...extensionAlias,
             '.js': ['.ts', '.js'],
-            '.mjs': ['.mts', '.mjs'],
           },
         },
       };

--- a/website/plugins/webpack-config.js
+++ b/website/plugins/webpack-config.js
@@ -1,0 +1,18 @@
+/** @type {import('@docusaurus/types').PluginModule} */
+// eslint-disable-next-line no-unused-vars
+export default function webpackPlugin(context, options) {
+  return {
+    name: 'webpack-config-plugin',
+    // eslint-disable-next-line no-unused-vars
+    configureWebpack(config) {
+      return {
+        resolve: {
+          extensionAlias: {
+            '.js': ['.ts', '.js'],
+            '.mjs': ['.mts', '.mjs'],
+          },
+        },
+      };
+    },
+  };
+}


### PR DESCRIPTION
Closes https://github.com/facebook/yoga/issues/1760

This PR adds support for TypeScript 4.x and `"node"` module resolution by fixing import extension handling. Previously, the package only worked with TypeScript 5.x due to `.ts` extensions in declaration files causing `TS2691` errors in earlier versions.

## Changes
- Changed imports from `.ts` to `.js`, configured in:
  - `Jest` - `moduleNameMapper`
  - `Docusaurus/Webpack` - `extensionAlias`
- Added `tsconfig.load.json` for the `/load` entry point
- Updated `just` build process:
  - Temporarily rewrites `load.ts` imports to point to `dist/src` 
  - Generates artifacts and restores source references
- Updated `package.json` to include `load.*` files