### PR TITLE
Add 16K support for standalone Yoga

### DIFF
--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -30,6 +30,7 @@ android {
     consumerProguardFiles("proguard-rules.pro")
 
     ndk { abiFilters.addAll(setOf("x86", "x86_64", "armeabi-v7a", "arm64-v8a")) }
+    externalNativeBuild { cmake { arguments("-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON") } }
   }
 
   externalNativeBuild { cmake { path("CMakeLists.txt") } }


### PR DESCRIPTION
Summary:
While we added support for 16K pages for yoga through React Native,
the standalone version we upload to Maven Central wasn't handled.
This fixes it.

Reviewed By: NickGerleman

Differential Revision: D66975933


