### PR TITLE
Add more unit tests for rounding values to pixel grid

### DIFF
--- a/tests/YGRoundingFunctionTest.cpp
+++ b/tests/YGRoundingFunctionTest.cpp
@@ -8,6 +8,8 @@
 #include <gtest/gtest.h>
 #include <yoga/Yoga.h>
 
+#include <cmath>
+
 TEST(YogaTest, rounding_value) {
   // Test that whole numbers are rounded to whole despite ceil/floor flags
   ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(6.000001, 2.0, false, false));
@@ -39,6 +41,44 @@ TEST(YogaTest, rounding_value) {
   ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-5.99, 2.0, false, false));
   ASSERT_FLOAT_EQ(-5.5, YGRoundValueToPixelGrid(-5.99, 2.0, true, false));
   ASSERT_FLOAT_EQ(-6.0, YGRoundValueToPixelGrid(-5.99, 2.0, false, true));
+
+  // Rounding up/down halfway values is as expected for both positive and
+  // negative numbers
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3.5, 1.0, false, false));
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3.4, 1.0, false, false));
+  ASSERT_FLOAT_EQ(-4, YGRoundValueToPixelGrid(-3.6, 1.0, false, false));
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3.499999, 1.0, false, false));
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3.500001, 1.0, false, false));
+  ASSERT_FLOAT_EQ(-4, YGRoundValueToPixelGrid(-3.5001, 1.0, false, false));
+
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3.5, 1.0, true, false));
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3.4, 1.0, true, false));
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3.6, 1.0, true, false));
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3.499999, 1.0, true, false));
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3.500001, 1.0, true, false));
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3.5001, 1.0, true, false));
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3.00001, 1.0, true, false));
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3, 1.0, true, false));
+
+  ASSERT_FLOAT_EQ(-4, YGRoundValueToPixelGrid(-3.5, 1.0, false, true));
+  ASSERT_FLOAT_EQ(-4, YGRoundValueToPixelGrid(-3.4, 1.0, false, true));
+  ASSERT_FLOAT_EQ(-4, YGRoundValueToPixelGrid(-3.6, 1.0, false, true));
+  ASSERT_FLOAT_EQ(-4, YGRoundValueToPixelGrid(-3.499999, 1.0, false, true));
+  ASSERT_FLOAT_EQ(-4, YGRoundValueToPixelGrid(-3.500001, 1.0, false, true));
+  ASSERT_FLOAT_EQ(-4, YGRoundValueToPixelGrid(-3.5001, 1.0, false, true));
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3.00001, 1.0, false, true));
+  ASSERT_FLOAT_EQ(-3, YGRoundValueToPixelGrid(-3, 1.0, false, true));
+
+  // NAN is treated as expected:
+  ASSERT_TRUE(std::isnan(YGRoundValueToPixelGrid(
+      std::numeric_limits<double>::quiet_NaN(), 1.5, false, false)));
+  ASSERT_TRUE(std::isnan(YGRoundValueToPixelGrid(
+      1.5, std::numeric_limits<double>::quiet_NaN(), false, false)));
+  ASSERT_TRUE(std::isnan(YGRoundValueToPixelGrid(
+      std::numeric_limits<double>::quiet_NaN(),
+      std::numeric_limits<double>::quiet_NaN(),
+      false,
+      false)));
 }
 
 static YGSize measureText(

--- a/yoga/algorithm/PixelGrid.cpp
+++ b/yoga/algorithm/PixelGrid.cpp
@@ -66,7 +66,8 @@ void roundLayoutResultsToPixelGrid(
     yoga::Node* const node,
     const double absoluteLeft,
     const double absoluteTop) {
-  const auto pointScaleFactor = node->getConfig()->getPointScaleFactor();
+  const auto pointScaleFactor =
+      static_cast<double>(node->getConfig()->getPointScaleFactor());
 
   const double nodeLeft = node->getLayout().position(PhysicalEdge::Left);
   const double nodeTop = node->getLayout().position(PhysicalEdge::Top);
@@ -80,7 +81,7 @@ void roundLayoutResultsToPixelGrid(
   const double absoluteNodeRight = absoluteNodeLeft + nodeWidth;
   const double absoluteNodeBottom = absoluteNodeTop + nodeHeight;
 
-  if (pointScaleFactor != 0.0f) {
+  if (pointScaleFactor != 0.0) {
     // If a node has a custom measure function we never want to round down its
     // size as this could lead to unwanted text truncation.
     const bool textRounding = node->getNodeType() == NodeType::Text;
@@ -96,12 +97,14 @@ void roundLayoutResultsToPixelGrid(
     // We multiply dimension by scale factor and if the result is close to the
     // whole number, we don't have any fraction To verify if the result is close
     // to whole number we want to check both floor and ceil numbers
+
+    const double scaledNodeWith = nodeWidth * pointScaleFactor;
     const bool hasFractionalWidth =
-        !yoga::inexactEquals(fmod(nodeWidth * pointScaleFactor, 1.0), 0) &&
-        !yoga::inexactEquals(fmod(nodeWidth * pointScaleFactor, 1.0), 1.0);
+        !yoga::inexactEquals(round(scaledNodeWith), scaledNodeWith);
+
+    const double scaledNodeHeight = nodeHeight * pointScaleFactor;
     const bool hasFractionalHeight =
-        !yoga::inexactEquals(fmod(nodeHeight * pointScaleFactor, 1.0), 0) &&
-        !yoga::inexactEquals(fmod(nodeHeight * pointScaleFactor, 1.0), 1.0);
+        !yoga::inexactEquals(round(scaledNodeHeight), scaledNodeHeight);
 
     node->setLayoutDimension(
         roundValueToPixelGrid(


### PR DESCRIPTION
Summary:
# Changelog:
[Internal] - 

I was looking into some profiling results and noticed that Yoga has some quirky custom logic when it comes to rounding to the pixel grid, especially for the values that are halfway through.

There are already unit tests in place, but those cases weren't covered, so I am adding these extra corner cases here, to make sure they are covered in case that the actual rounding function may get modified (which it might make sense to, as it's currently can be more expensive than it could have been in some scenarios).

Differential Revision: D67712673


