### PR TITLE
Try fixing CI after GHA Ubuntu 24.04 Update

### DIFF
--- a/.github/actions/clang-format/action.yml
+++ b/.github/actions/clang-format/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: LLVM version to use # Should be kept roughly in sync with arcanist
     required: false
-    default: 12
+    default: 18
 
 runs:
   using: "composite"

--- a/.github/actions/setup-cpp/action.yml
+++ b/.github/actions/setup-cpp/action.yml
@@ -16,6 +16,7 @@ runs:
       if: ${{ inputs.toolchain == 'Clang' }}
       shell: bash
       run: |
+        sudo apt-get install -y libc++-dev libc++abi-dev
         echo "CC=/usr/bin/clang" >> $GITHUB_ENV
         echo "CXX=/usr/bin/clang++" >> $GITHUB_ENV
         echo "CXXFLAGS=-stdlib=libc++" >> $GITHUB_ENV

--- a/.github/workflows/validate-cpp.yml
+++ b/.github/workflows/validate-cpp.yml
@@ -107,3 +107,5 @@ jobs:
 
       - name: clang-format
         uses: ./.github/actions/clang-format
+        with:
+          directory: yoga


### PR DESCRIPTION
New GHA images seem to have dropped the preinstalled libc++ package. Let's manually install it during setup.