### PR TITLE
Add aar BUCK targets  to export Litho libraries as aars

### DIFF
--- a/java/AndroidManifest.xml
+++ b/java/AndroidManifest.xml
@@ -1,4 +1,19 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+-->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.facebook.yoga"
+          android:versionCode="1"
+          android:versionName="1.0"
+    >
+
+    <uses-sdk
+        android:minSdkVersion="16"
+        android:targetSdkVersion="31"
+        />
 
     <application/>
 


### PR DESCRIPTION
Summary:
This adds fb_native.android_aar targets for resources that are needed by Litho at runtime and cannot be exported as jars. 
- resource modules referenced by Litho
- Yoga library. Some dependencies required by Yoga neded to be added as "provided_deps" so they don't get exported with the aar

Reviewed By: astreet

Differential Revision: D68152410


