### PR TITLE
Update yoga aar targets

### DIFF
--- a/java/AndroidManifest.xml
+++ b/java/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+
+  This source code is licensed under the MIT license found in the
+  LICENSE file in the root directory of this source tree.
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
@@ -9,11 +12,6 @@
           android:versionCode="1"
           android:versionName="1.0"
     >
-
-    <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="31"
-        />
 
     <application/>
 


### PR DESCRIPTION
Summary:
Follow up on comments from D68152410

- Removes minsdk version from manifest
- Update to MIT licence
- Rename targets that don't export existing libs

I've looked into using yoga_java_library and adding a param to pass what libs to exclude, but ultimately provided_deps does what we need and it simpler to maintain; we still need to add the different targets because the aar needs to depend on :jni-server and not :jni.

Reviewed By: NickGerleman

Differential Revision: D69455682


