### PR TITLE
Enable RTTI to fix exception pointer issue on React Native

### DIFF
--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -19,8 +19,8 @@ add_compile_options(
     # Enable warnings and warnings as errors
     /W4
     /WX
-    # Disable RTTI
-    $<$<COMPILE_LANGUAGE:CXX>:/GR->
+    # Enable RTTI
+    $<$<COMPILE_LANGUAGE:CXX>:/GR>
     # Use /O2 (Maximize Speed)
     $<$<CONFIG:RELEASE>:/O2>)
 
@@ -34,8 +34,8 @@ add_compile_options(
     # Enable warnings and warnings as errors
     -Wall
     -Werror
-    # Disable RTTI
-    $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+    # Enable RTTI
+    $<$<COMPILE_LANGUAGE:CXX>:-frtti>
     # Use -O2 (prioritize speed)
     $<$<CONFIG:RELEASE>:-O2>
     # Enable separate sections per function/data item


### PR DESCRIPTION
Summary:
Disabling RTTI for Yoga is causing std::exception to don't work properly in OSS.
Fixes: https://github.com/facebook/react-native/issues/48027

Not sure why we originally disabled RTTI for Yoga, but we have it enable for the whole
React Native build so it probably makes sense to have it enabled for Yoga as well.

Changelog:
[Internal] [Changed] - Enable RTTI to fix exception pointer issue on React Native

Differential Revision: D70386744


