### PR TITLE
Remove explicitly specified exceptions flag

### DIFF
--- a/cmake/project-defaults.cmake
+++ b/cmake/project-defaults.cmake
@@ -29,8 +29,6 @@ else()
 add_compile_options(
     # Don't omit frame pointers (e.g. for crash dumps)
     -fno-omit-frame-pointer
-    # Enable exception handling
-    -fexceptions
     # Enable warnings and warnings as errors
     -Wall
     -Werror


### PR DESCRIPTION
Using the build system configuration
instead of explicitly specified.