### PR TITLE
Update GHA actions/upload-artifact to v4, unbreak CI

### DIFF
--- a/.github/workflows/publish-android-release.yml
+++ b/.github/workflows/publish-android-release.yml
@@ -24,7 +24,7 @@ jobs:
           ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'snapshot-artifacts'
           path: '~/.m2/repository/'

--- a/.github/workflows/publish-android-snashot.yml
+++ b/.github/workflows/publish-android-snashot.yml
@@ -23,7 +23,7 @@ jobs:
           ORG_GRADLE_PROJECT_USE_SNAPSHOT: true
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'snapshot-artifacts'
           path: '~/.m2/repository/'

--- a/.github/workflows/validate-js.yml
+++ b/.github/workflows/validate-js.yml
@@ -110,7 +110,7 @@ jobs:
         run: yarn pack --filename yoga-layout.tar.gz
         working-directory: javascript
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: npm-package
           path: javascript/yoga-layout.tar.gz


### PR DESCRIPTION
Summary:
`actions/upload-artifact@v3` is deprecated and will no longer execute, causing CI to fail - eg:

https://github.com/facebook/yoga/actions/runs/13789185831/job/38564343959

See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ for context

Differential Revision: D70986391
