### PR TITLE
Fix documentation of 'alignContent' property configured with spaces

### DIFF
--- a/website/docs/styling/align-content.mdx
+++ b/website/docs/styling/align-content.mdx
@@ -17,15 +17,15 @@ has effect when items are wrapped to multiple lines using [flex wrap](/docs/styl
 
 **Center**: Align wrapped lines in the center of the container's cross axis.
 
-**Space between**: Evenly space wrapped lines across the container's main axis, distributing
+**Space between**: Evenly space wrapped lines across the container's cross axis, distributing
 remaining space between the lines.
 
-**Space around**: Evenly space wrapped lines across the container's main axis, distributing
+**Space around**: Evenly space wrapped lines across the container's cross axis, distributing
 remaining space around the lines. Compared to space between using
 space around will result in space being distributed to the beginning of
 the first lines and end of the last line.
 
-**Space evenly**: Evenly space wrapped lines across the container's main axis, distributing
+**Space evenly**: Evenly space wrapped lines across the container's cross axis, distributing
 remaining space around the lines. Compared to space around, space evenly will not
 double the gaps between children. The size of gaps between children and between
 the parent's edges and the first/last child will all be equal.


### PR DESCRIPTION
The documentation shall be corrected to specify in which axis the spaces are distributed when flex container is configured 'alignContent' property.