### PR TITLE
fix: remove non-ASCII comment to resolve C4819 encoding warning in VS2022 (zh-CN)

### DIFF
--- a/yoga/algorithm/SizingMode.h
+++ b/yoga/algorithm/SizingMode.h
@@ -27,7 +27,7 @@ enum class SizingMode {
   StretchFit,
 
   /**
-   * A box’s “ideal” size in a given axis when given infinite available space.
+   * A box's "ideal" size in a given axis when given infinite available space.
    * Usually this is the smallest size the box could take in that axis while
    * still fitting around its contents, i.e. minimizing unfilled space while
    * avoiding overflow.


### PR DESCRIPTION
warning C4819: The file contains a character that cannot be represented in the current code page (936). Save the file in Unicode format to prevent data loss.