### PR TITLE
Fix exhaustive switches

### DIFF
--- a/yoga/YGValue.h
+++ b/yoga/YGValue.h
@@ -72,9 +72,9 @@ inline bool operator==(const YGValue& lhs, const YGValue& rhs) {
     case YGUnitPoint:
     case YGUnitPercent:
       return lhs.value == rhs.value;
+    default:
+      return false;
   }
-
-  return false;
 }
 
 inline bool operator!=(const YGValue& lhs, const YGValue& rhs) {


### PR DESCRIPTION
Summary: Changelog: [General][Fixed] - Add `default:` case to avoid warnings/errors for targets that compile with `-Wswitch-enum` and `-Wswitch-default` enabled

Reviewed By: aary

Differential Revision: D77051152


