### PR TITLE
Update javascript CMakeLists.txt to add SUPPORT_BIG_ENDIAN

### DIFF
--- a/javascript/CMakeLists.txt
+++ b/javascript/CMakeLists.txt
@@ -45,6 +45,7 @@ add_link_options(
     "SHELL:-s EXPORT_ES6=1"
     "SHELL:-s WASM=1"
     "SHELL:-s TEXTDECODER=0"
+    "SHELL:-s SUPPORT_BIG_ENDIAN=1"
     # SINGLE_FILE=1 combined with ENVIRONMENT='web' creates code that works on
     # both bundlders and Node.
     "SHELL:-s SINGLE_FILE=1"


### PR DESCRIPTION
Add support for Big Endian in Yoga WASM so that it works on big endian platforms like Linux on Z, z/OS, AIX and others.

SUPPORT_BIG_ENDIAN - This makes generated JavaScript run on BE as well as LE machines: https://github.com/emscripten-core/emscripten/blob/6b8bba1add53b1f039717998fb784b7bdf5d510b/site/source/docs/tools_reference/settings_reference.rst#support_big_endian