### PR TITLE
Fix typos in doc comment and benchmark runner

### DIFF
--- a/javascript/tests/bin/run-bench.ts
+++ b/javascript/tests/bin/run-bench.ts
@@ -42,7 +42,7 @@ for (const type of ['wasm']) {
 }
 
 console.log(
-  `Note: those tests are independants; there is no time relation to be expected between them`,
+  `Note: those tests are independent; there is no time relation to be expected between them`,
 );
 
 for (const [name, results] of testResults) {

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -257,7 +257,7 @@ YG_EXPORT bool YGNodeIsReferenceBaseline(YGNodeConstRef node);
 YG_EXPORT void YGNodeSetNodeType(YGNodeRef node, YGNodeType nodeType);
 
 /**
- * Wwhether a leaf node's layout results may be truncated during layout
+ * Whether a leaf node's layout results may be truncated during layout
  * rounding.
  */
 YG_EXPORT YGNodeType YGNodeGetNodeType(YGNodeConstRef node);


### PR DESCRIPTION
- "Wwhether" -> "Whether" in YGNode.h
- "independants" -> "independent" in run-bench.ts