### PR TITLE
Fix incorrect code examples in documentation

### DIFF
--- a/website/docs/advanced/external-layout-systems.mdx
+++ b/website/docs/advanced/external-layout-systems.mdx
@@ -23,7 +23,7 @@ Measure functions in the C/C++ APIs are represented as C function pointers and d
 ```cpp
 Widget widget{};
 
-YGNodeSetContext(node, &w);
+YGNodeSetContext(node, &widget);
 YGNodeSetMeasureFunc(node, &measureWidget);
 ```
 

--- a/website/docs/advanced/incremental-layout.mdx
+++ b/website/docs/advanced/incremental-layout.mdx
@@ -60,7 +60,7 @@ void applyLayout(YogaNode node) {
 <TabItem value="js" label="JavaScript">
 
 ```javascript
-void applyLayout(node) {
+function applyLayout(node) {
   if (!node.hasNewLayout()) {
     return;
   }


### PR DESCRIPTION
Two small fixes to code examples in the documentation:

- **`external-layout-systems.mdx`:** The C/C++ tab declares `Widget widget{};` on line 24 but then references `&w` on line 26. Fixed to `&widget` to match the declared variable. The Java tab already uses the correct name (`widget`).

- **`incremental-layout.mdx`:** The JavaScript tab uses `void applyLayout(node) {` which is not valid JavaScript syntax. Fixed to `function applyLayout(node) {`. This appears to have been introduced in #1631 when the JS example was added by adapting the Java tab — other language-specific syntax was updated (`int` → `let`, type annotations removed) but the `void` return type was not changed to `function`. The code block is tagged as ` ```javascript ` and all other lines use valid JS syntax, confirming this was a copy-paste oversight rather than intentional pseudocode.