### PR TITLE
Update Yoga Babel SystemJS transform dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typescript": "5.0.4"
   },
   "resolutions": {
-    "cliui/wrap-ansi": "7.0.0"
+    "cliui/wrap-ansi": "7.0.0",
+    "@babel/plugin-transform-modules-systemjs": "7.29.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,10 +882,10 @@
     "@babel/helper-module-transforms" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"
 
-"@babel/plugin-transform-modules-systemjs@^7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz#e458a95a17807c415924106a3ff188a3b8dee964"
-  integrity sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==
+"@babel/plugin-transform-modules-systemjs@7.29.4", "@babel/plugin-transform-modules-systemjs@^7.29.0":
+  version "7.29.4"
+  resolved "https://registry.facebook.net/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz#f621105da99919c15cf4bde6fcc7346ef95e7b20"
+  integrity sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==
   dependencies:
     "@babel/helper-module-transforms" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/yoga/pull/1937

Pin Yoga's transitive `babel/plugin-transform-modules-systemjs` dependency to 7.29.4 via Yarn resolutions and regenerate `yarn.lock` to remediate GHSA-fv7c-fp4j-7gwp / CVE-2026-44728.

Differential Revision: D104695545


