### PR TITLE
Pin Yoga fast-uri to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typescript": "5.0.4"
   },
   "resolutions": {
-    "cliui/wrap-ansi": "7.0.0"
+    "cliui/wrap-ansi": "7.0.0",
+    "fast-uri": "3.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5357,10 +5357,10 @@ fast-levenshtein@^3.0.0:
   dependencies:
     fastest-levenshtein "^1.0.7"
 
-fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+fast-uri@3.1.1, fast-uri@^3.0.1:
+  version "3.1.1"
+  resolved "https://registry.facebook.net/fast-uri/-/fast-uri-3.1.1.tgz#dd085fec2494a2a33bac6e61277374669e1dd774"
+  integrity sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==
 
 fastest-levenshtein@^1.0.7:
   version "1.0.16"


### PR DESCRIPTION
Summary: Add a Yarn resolution for fast-uri 3.1.1 and update the lockfile so the ajv transitive dependency resolves to the fixed version for GHSA-q3j6-qgpj-74h6 / CVE-2026-6321.

Differential Revision: D104695401


