### PR TITLE
ci: declare workflow-level `contents: read` on 6 workflows

### DIFF
--- a/.github/workflows/validate-android.yml
+++ b/.github/workflows/validate-android.yml
@@ -8,6 +8,9 @@ on:
       - 'release-*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build [${{ matrix.os }}][${{ matrix.mode }}]

--- a/.github/workflows/validate-cpp.yml
+++ b/.github/workflows/validate-cpp.yml
@@ -11,6 +11,9 @@ on:
 env:
   GTEST_COLOR: 1
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Build and Test [${{ matrix.toolchain }}][${{ matrix.mode }}]

--- a/.github/workflows/validate-js.yml
+++ b/.github/workflows/validate-js.yml
@@ -11,6 +11,9 @@ on:
 env:
   FORCE_COLOR: 3
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     name: Benchmark [${{ matrix.os }}]

--- a/.github/workflows/validate-swiftpm.yml
+++ b/.github/workflows/validate-swiftpm.yml
@@ -8,6 +8,9 @@ on:
       - 'release-*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Build

--- a/.github/workflows/validate-tests.yml
+++ b/.github/workflows/validate-tests.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate

--- a/.github/workflows/validate-website.yml
+++ b/.github/workflows/validate-website.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build_next:
     name: Build


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 6 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.