### PR TITLE
YGNodeFree: mark parent dirty when child is freed

### DIFF
--- a/tests/YGDirtyMarkingTest.cpp
+++ b/tests/YGDirtyMarkingTest.cpp
@@ -304,3 +304,38 @@ TEST(YogaTest, dirty_removed_child_nodes_when_removing_all) {
   YGNodeFree(child1);
   YGNodeFreeRecursive(root);
 }
+
+TEST(YogaTest, dirty_parent_when_child_freed) {
+  YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 100);
+
+  YGNodeRef child = YGNodeNew();
+  YGNodeStyleSetWidth(child, 50);
+  YGNodeStyleSetHeight(child, 50);
+  YGNodeInsertChild(root, child, 0);
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+  EXPECT_FALSE(YGNodeIsDirty(root));
+
+  YGNodeFree(child);
+
+  EXPECT_TRUE(YGNodeIsDirty(root));
+  YGNodeFree(root);
+}
+
+TEST(YogaTest, dirty_parent_when_subtree_freed_recursive) {
+  YGNodeRef root = YGNodeNew();
+  YGNodeRef child = YGNodeNew();
+  YGNodeRef grandchild = YGNodeNew();
+  YGNodeInsertChild(root, child, 0);
+  YGNodeInsertChild(child, grandchild, 0);
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+  EXPECT_FALSE(YGNodeIsDirty(root));
+
+  YGNodeFreeRecursive(child);
+
+  EXPECT_TRUE(YGNodeIsDirty(root));
+  YGNodeFree(root);
+}

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -44,6 +44,7 @@ void YGNodeFree(const YGNodeRef nodeRef) {
   if (auto owner = node->getOwner()) {
     owner->removeChild(node);
     node->setOwner(nullptr);
+    owner->markDirtyAndPropagate();
   }
 
   const size_t childCount = node->getChildCount();


### PR DESCRIPTION
fixes #1659.

**problem:** `YGNodeFree` called `owner->removeChild(node)` to detach the node from its
parent, but never called `owner->markDirtyAndPropagate()`. the parent's layout stayed
stale after the free, so a subsequent `YGNodeCalculateLayout` wouldn't recompute it.
`YGNodeRemoveChild` has always called `markDirtyAndPropagate` — `YGNodeFree` was just
missing the same call.

`YGNodeFreeRecursive` was already correct for its recursive child removals (it calls
`YGNodeRemoveChild` internally), but the terminal `YGNodeFree(root)` inherited the bug.

**fix:** added `owner->markDirtyAndPropagate()` after `node->setOwner(nullptr)` in
`YGNodeFree`.

regression tests: `dirty_parent_when_child_freed` and `dirty_parent_when_subtree_freed_recursive`
in `YGDirtyMarkingTest.cpp`.
