### PR TITLE
validate child index in YGNodeSwapChild and YGNodeInsertChild

### DIFF
--- a/tests/YGNodeChildTest.cpp
+++ b/tests/YGNodeChildTest.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <stdexcept>
+
 #include <gtest/gtest.h>
 #include <yoga/Yoga.h>
 
@@ -64,5 +66,45 @@ TEST(YogaTest, removed_child_can_be_reused_with_valid_layout) {
   ASSERT_EQ(100, YGNodeLayoutGetHeight(child));
   ASSERT_FALSE(YGNodeIsDirty(child));
 
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, swap_child_with_out_of_bounds_index_is_rejected) {
+  YGNodeRef root = YGNodeNew();
+  YGNodeRef child = YGNodeNew();
+  YGNodeInsertChild(root, child, 0);
+
+  // Replacing an existing index works.
+  YGNodeRef replacement = YGNodeNew();
+  YGNodeSwapChild(root, replacement, 0);
+  ASSERT_EQ(replacement, YGNodeGetChild(root, 0));
+
+  // An index past the last child is rejected rather than reading and writing
+  // out of bounds on the underlying children vector.
+  YGNodeRef stray = YGNodeNew();
+  ASSERT_THROW(YGNodeSwapChild(root, stray, 1), std::logic_error);
+
+  YGNodeFree(stray);
+  YGNodeFree(child);
+  YGNodeFreeRecursive(root);
+}
+
+TEST(YogaTest, insert_child_with_out_of_bounds_index_is_rejected) {
+  YGNodeRef root = YGNodeNew();
+
+  YGNodeRef first = YGNodeNew();
+  YGNodeInsertChild(root, first, 0);
+
+  // Appending at the end (index == child count) is allowed.
+  YGNodeRef second = YGNodeNew();
+  YGNodeInsertChild(root, second, 1);
+  ASSERT_EQ(2u, YGNodeGetChildCount(root));
+
+  // An index beyond the end is rejected rather than constructing an invalid
+  // iterator into the children vector.
+  YGNodeRef stray = YGNodeNew();
+  ASSERT_THROW(YGNodeInsertChild(root, stray, 5), std::logic_error);
+
+  YGNodeFree(stray);
   YGNodeFreeRecursive(root);
 }

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -142,6 +142,11 @@ void YGNodeInsertChild(
       !owner->hasMeasureFunc(),
       "Cannot add child: Nodes with measure functions cannot have children.");
 
+  yoga::assertFatalWithNode(
+      owner,
+      index <= owner->getChildCount(),
+      "Cannot insert child: index out of bounds.");
+
   owner->insertChild(child, index);
   child->setOwner(owner);
   owner->markDirtyAndPropagate();
@@ -153,6 +158,11 @@ void YGNodeSwapChild(
     const size_t index) {
   auto owner = resolveRef(ownerRef);
   auto child = resolveRef(childRef);
+
+  yoga::assertFatalWithNode(
+      owner,
+      index < owner->getChildCount(),
+      "Cannot swap child: index out of bounds.");
 
   owner->replaceChild(child, index);
   child->setOwner(owner);


### PR DESCRIPTION
YGNodeSwapChild forwards its index straight to Node::replaceChild, which reads and writes children_[index] with no bounds check, so calling it with an index past the last child reads and writes a Node* outside the children vector. YGNodeInsertChild has the same gap, where an index greater than the child count builds an invalid insertion iterator and is undefined behavior. Both now validate the index up front the same way YGNodeGetChild already does, rejecting out-of-range values before the vector is touched.