### PR TITLE
validate grid track index in grid template and auto setters

### DIFF
--- a/tests/YGGridTrackIndexTest.cpp
+++ b/tests/YGGridTrackIndexTest.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <yoga/Yoga.h>
+
+TEST(YogaTest, grid_template_column_index_in_range) {
+  YGNodeRef const node = YGNodeNew();
+  YGNodeStyleSetGridTemplateColumnsCount(node, 2);
+
+  YGNodeStyleSetGridTemplateColumn(node, 1, YGGridTrackTypePoints, 50.0f);
+  YGNodeStyleSetGridTemplateColumnMinMax(
+      node, 0, YGGridTrackTypePoints, 10.0f, YGGridTrackTypeFr, 1.0f);
+
+  YGNodeFree(node);
+}
+
+TEST(YogaTest, grid_template_column_index_out_of_range_throws) {
+  YGNodeRef const node = YGNodeNew();
+  YGNodeStyleSetGridTemplateColumnsCount(node, 1);
+
+  ASSERT_THROW(
+      YGNodeStyleSetGridTemplateColumn(node, 1, YGGridTrackTypePoints, 50.0f),
+      std::logic_error);
+  ASSERT_THROW(
+      YGNodeStyleSetGridTemplateColumnMinMax(
+          node, 4, YGGridTrackTypePoints, 10.0f, YGGridTrackTypeFr, 1.0f),
+      std::logic_error);
+
+  YGNodeFree(node);
+}
+
+TEST(YogaTest, grid_template_row_index_out_of_range_throws) {
+  YGNodeRef const node = YGNodeNew();
+  YGNodeStyleSetGridTemplateRowsCount(node, 1);
+
+  ASSERT_THROW(
+      YGNodeStyleSetGridTemplateRow(node, 2, YGGridTrackTypePoints, 50.0f),
+      std::logic_error);
+  ASSERT_THROW(
+      YGNodeStyleSetGridTemplateRowMinMax(
+          node, 9, YGGridTrackTypePoints, 10.0f, YGGridTrackTypeFr, 1.0f),
+      std::logic_error);
+
+  YGNodeFree(node);
+}
+
+TEST(YogaTest, grid_auto_column_index_out_of_range_throws) {
+  YGNodeRef const node = YGNodeNew();
+  YGNodeStyleSetGridAutoColumnsCount(node, 1);
+
+  ASSERT_THROW(
+      YGNodeStyleSetGridAutoColumn(node, 3, YGGridTrackTypePoints, 50.0f),
+      std::logic_error);
+  ASSERT_THROW(
+      YGNodeStyleSetGridAutoColumnMinMax(
+          node, 7, YGGridTrackTypePoints, 10.0f, YGGridTrackTypeFr, 1.0f),
+      std::logic_error);
+
+  YGNodeFree(node);
+}
+
+TEST(YogaTest, grid_auto_row_index_out_of_range_throws) {
+  YGNodeRef const node = YGNodeNew();
+  YGNodeStyleSetGridAutoRowsCount(node, 1);
+
+  ASSERT_THROW(
+      YGNodeStyleSetGridAutoRow(node, 5, YGGridTrackTypePoints, 50.0f),
+      std::logic_error);
+  ASSERT_THROW(
+      YGNodeStyleSetGridAutoRowMinMax(
+          node, 6, YGGridTrackTypePoints, 10.0f, YGGridTrackTypeFr, 1.0f),
+      std::logic_error);
+
+  YGNodeFree(node);
+}

--- a/yoga/YGNodeStyle.cpp
+++ b/yoga/YGNodeStyle.cpp
@@ -657,9 +657,14 @@ void YGNodeStyleSetGridTemplateColumn(
     size_t index,
     YGGridTrackType type,
     float value) {
-  resolveRef(node)->style().setGridTemplateColumnAt(
+  auto resolvedNode = resolveRef(node);
+  yoga::assertFatalWithNode(
+      resolvedNode,
+      index < resolvedNode->style().gridTemplateColumns().size(),
+      "Grid template column index is out of range");
+  resolvedNode->style().setGridTemplateColumnAt(
       index, gridTrackSizeFromTypeAndValue(type, value));
-  resolveRef(node)->markDirtyAndPropagate();
+  resolvedNode->markDirtyAndPropagate();
 }
 
 void YGNodeStyleSetGridTemplateColumnMinMax(
@@ -669,12 +674,17 @@ void YGNodeStyleSetGridTemplateColumnMinMax(
     float minValue,
     YGGridTrackType maxType,
     float maxValue) {
-  resolveRef(node)->style().setGridTemplateColumnAt(
+  auto resolvedNode = resolveRef(node);
+  yoga::assertFatalWithNode(
+      resolvedNode,
+      index < resolvedNode->style().gridTemplateColumns().size(),
+      "Grid template column index is out of range");
+  resolvedNode->style().setGridTemplateColumnAt(
       index,
       GridTrackSize::minmax(
           styleSizeLengthFromTypeAndValue(minType, minValue),
           styleSizeLengthFromTypeAndValue(maxType, maxValue)));
-  resolveRef(node)->markDirtyAndPropagate();
+  resolvedNode->markDirtyAndPropagate();
 }
 
 // GridTemplateRows
@@ -689,9 +699,14 @@ void YGNodeStyleSetGridTemplateRow(
     size_t index,
     YGGridTrackType type,
     float value) {
-  resolveRef(node)->style().setGridTemplateRowAt(
+  auto resolvedNode = resolveRef(node);
+  yoga::assertFatalWithNode(
+      resolvedNode,
+      index < resolvedNode->style().gridTemplateRows().size(),
+      "Grid template row index is out of range");
+  resolvedNode->style().setGridTemplateRowAt(
       index, gridTrackSizeFromTypeAndValue(type, value));
-  resolveRef(node)->markDirtyAndPropagate();
+  resolvedNode->markDirtyAndPropagate();
 }
 
 void YGNodeStyleSetGridTemplateRowMinMax(
@@ -701,12 +716,17 @@ void YGNodeStyleSetGridTemplateRowMinMax(
     float minValue,
     YGGridTrackType maxType,
     float maxValue) {
-  resolveRef(node)->style().setGridTemplateRowAt(
+  auto resolvedNode = resolveRef(node);
+  yoga::assertFatalWithNode(
+      resolvedNode,
+      index < resolvedNode->style().gridTemplateRows().size(),
+      "Grid template row index is out of range");
+  resolvedNode->style().setGridTemplateRowAt(
       index,
       GridTrackSize::minmax(
           styleSizeLengthFromTypeAndValue(minType, minValue),
           styleSizeLengthFromTypeAndValue(maxType, maxValue)));
-  resolveRef(node)->markDirtyAndPropagate();
+  resolvedNode->markDirtyAndPropagate();
 }
 
 // GridAutoColumns
@@ -721,9 +741,14 @@ void YGNodeStyleSetGridAutoColumn(
     size_t index,
     YGGridTrackType type,
     float value) {
-  resolveRef(node)->style().setGridAutoColumnAt(
+  auto resolvedNode = resolveRef(node);
+  yoga::assertFatalWithNode(
+      resolvedNode,
+      index < resolvedNode->style().gridAutoColumns().size(),
+      "Grid auto column index is out of range");
+  resolvedNode->style().setGridAutoColumnAt(
       index, gridTrackSizeFromTypeAndValue(type, value));
-  resolveRef(node)->markDirtyAndPropagate();
+  resolvedNode->markDirtyAndPropagate();
 }
 
 void YGNodeStyleSetGridAutoColumnMinMax(
@@ -733,12 +758,17 @@ void YGNodeStyleSetGridAutoColumnMinMax(
     float minValue,
     YGGridTrackType maxType,
     float maxValue) {
-  resolveRef(node)->style().setGridAutoColumnAt(
+  auto resolvedNode = resolveRef(node);
+  yoga::assertFatalWithNode(
+      resolvedNode,
+      index < resolvedNode->style().gridAutoColumns().size(),
+      "Grid auto column index is out of range");
+  resolvedNode->style().setGridAutoColumnAt(
       index,
       GridTrackSize::minmax(
           styleSizeLengthFromTypeAndValue(minType, minValue),
           styleSizeLengthFromTypeAndValue(maxType, maxValue)));
-  resolveRef(node)->markDirtyAndPropagate();
+  resolvedNode->markDirtyAndPropagate();
 }
 
 // GridAutoRows
@@ -753,9 +783,14 @@ void YGNodeStyleSetGridAutoRow(
     size_t index,
     YGGridTrackType type,
     float value) {
-  resolveRef(node)->style().setGridAutoRowAt(
+  auto resolvedNode = resolveRef(node);
+  yoga::assertFatalWithNode(
+      resolvedNode,
+      index < resolvedNode->style().gridAutoRows().size(),
+      "Grid auto row index is out of range");
+  resolvedNode->style().setGridAutoRowAt(
       index, gridTrackSizeFromTypeAndValue(type, value));
-  resolveRef(node)->markDirtyAndPropagate();
+  resolvedNode->markDirtyAndPropagate();
 }
 
 void YGNodeStyleSetGridAutoRowMinMax(
@@ -765,10 +800,15 @@ void YGNodeStyleSetGridAutoRowMinMax(
     float minValue,
     YGGridTrackType maxType,
     float maxValue) {
-  resolveRef(node)->style().setGridAutoRowAt(
+  auto resolvedNode = resolveRef(node);
+  yoga::assertFatalWithNode(
+      resolvedNode,
+      index < resolvedNode->style().gridAutoRows().size(),
+      "Grid auto row index is out of range");
+  resolvedNode->style().setGridAutoRowAt(
       index,
       GridTrackSize::minmax(
           styleSizeLengthFromTypeAndValue(minType, minValue),
           styleSizeLengthFromTypeAndValue(maxType, maxValue)));
-  resolveRef(node)->markDirtyAndPropagate();
+  resolvedNode->markDirtyAndPropagate();
 }


### PR DESCRIPTION
1. The exported grid track setters (`YGNodeStyleSetGridTemplateColumn`/`Row`, their `MinMax` variants, and the `GridAuto` equivalents) pass the caller's `index` straight into `Style::setGrid*At`, which writes the backing `GridTrackList` vector through `operator[]`.
2. An index past the current track count (the count set by the matching `...Count` resize call) is an out-of-bounds heap write rather than a rejected argument; ASan reports a heap-buffer-overflow write in `Style::setGridTemplateColumnAt`.
3. Each of the eight indexed setters now checks `index < <list>.size()` with `assertFatalWithNode` before forwarding, so an out-of-range index is rejected the same way other public index APIs already are.

Validated with a unit test that fails on the unpatched tree (OOB write under ASan) and passes after, covering the in-range path plus an out-of-range call for all four track lists.
