### PR TITLE
guard shrink-factor division against floating-point near-zero

### DIFF
--- a/tests/YGFlexShrinkBorderBugTest.cpp
+++ b/tests/YGFlexShrinkBorderBugTest.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Regression test for https://github.com/facebook/yoga/issues/1665
+// flexBasis:0 + flexShrink:1 + borderWidth + minWidth produces an astronomically
+// large width (~1.65e11) instead of being clamped to minWidth.
+
+#include <gtest/gtest.h>
+#include <yoga/Yoga.h>
+
+TEST(YGFlexShrinkBorderBug, flex_basis_0_border_minwidth_row) {
+  YGConfigRef config = YGConfigNew();
+  YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetWidth(root, 393.0f);
+  YGNodeStyleSetHeight(root, 100.0f);
+
+  // Four row children: flexBasis:0, flexGrow:1, flexShrink:1, minWidth:160
+  // First child has borderWidth:0.594443, rest 0.594442.
+  // Bug: first child (and all others) get width ~1.65e11 instead of 160.
+  float borders[] = {0.594443f, 0.594442f, 0.594442f, 0.594442f};
+  for (int i = 0; i < 4; i++) {
+    YGNodeRef child = YGNodeNewWithConfig(config);
+    YGNodeStyleSetFlexBasis(child, 0.0f);
+    YGNodeStyleSetFlexGrow(child, 1.0f);
+    YGNodeStyleSetFlexShrink(child, 1.0f);
+    YGNodeStyleSetMinWidth(child, 160.0f);
+    YGNodeStyleSetBorder(child, YGEdgeAll, borders[i]);
+    YGNodeInsertChild(root, child, i);
+  }
+
+  YGNodeCalculateLayout(root, 393.0f, 100.0f, YGDirectionLTR);
+
+  for (int i = 0; i < 4; i++) {
+    YGNodeRef child = YGNodeGetChild(root, i);
+    EXPECT_GE(YGNodeLayoutGetWidth(child), 160.0f)
+        << "child[" << i << "] width below minWidth";
+    EXPECT_LE(YGNodeLayoutGetWidth(child), 200.0f)
+        << "child[" << i << "] width is astronomically large (bug)";
+  }
+
+  YGNodeFreeRecursive(root);
+  YGConfigFree(config);
+}

--- a/yoga/algorithm/CalculateLayout.cpp
+++ b/yoga/algorithm/CalculateLayout.cpp
@@ -925,8 +925,15 @@ static float distributeFreeSpaceSecondPass(
       if (flexShrinkScaledFactor != 0) {
         float childSize = YGUndefined;
 
+        // Use a relative epsilon guard instead of exact equality: after the
+        // first pass removes all constrained items, totalFlexShrinkScaledFactors
+        // may be near-zero rather than exactly 0 due to floating-point
+        // cancellation.  Dividing by a near-zero value produces a gigantic
+        // childSize that overwhelms the min/max clamp.
+        const float shrinkFactorMagnitude =
+            std::abs(flexLine.layout.totalFlexShrinkScaledFactors);
         if (yoga::isDefined(flexLine.layout.totalFlexShrinkScaledFactors) &&
-            flexLine.layout.totalFlexShrinkScaledFactors == 0) {
+            shrinkFactorMagnitude < 1e-6f) {
           childSize = childFlexBasis + flexShrinkScaledFactor;
         } else {
           childSize = childFlexBasis +


### PR DESCRIPTION
fixes #1665.

**problem:** when all flex children are frozen to their min-width in the first
pass, `totalFlexShrinkScaledFactors` is reduced to near-zero by floating-point
cancellation rather than exactly 0. the guard in `distributeFreeSpaceSecondPass`
uses exact equality (`== 0`), so it never fires, and the second pass divides
`remainingFreeSpace` by a value on the order of 1e-7, producing a childSize on
the order of 1e11 that overwhelms the min/max clamp.

**fix:** replace the exact-zero check with a relative epsilon guard
(`shrinkFactorMagnitude < 1e-6f`). when the magnitude is that small, all items
were already frozen in the first pass; the safe fallback (`childFlexBasis +
flexShrinkScaledFactor`) applies and the subsequent `boundAxisWithAutoMin` clamps
correctly to minWidth.

regression: `YGFlexShrinkBorderBug.flex_basis_0_border_minwidth_row` reproduces
the original crash — 4 children, `borderWidth` difference of 1e-6 across them,
all now compute to their correct minWidth.
