### PR TITLE
Fix testLoggerLeak by replacing Kotlin SAM lambda with anonymous object

### DIFF
--- a/java/tests/com/facebook/yoga/YogaLoggerTest.kt
+++ b/java/tests/com/facebook/yoga/YogaLoggerTest.kt
@@ -55,7 +55,11 @@ class YogaLoggerTest {
   @Throws(Exception::class)
   fun testLoggerLeak() {
     val config = YogaConfigFactory.create()
-    var logger: YogaLogger? = YogaLogger { level, message -> }
+    @Suppress("ObjectLiteralToLambda")
+    var logger: YogaLogger? =
+        object : YogaLogger {
+          override fun log(level: YogaLogLevel, message: String) {}
+        }
     config.setLogger(logger)
     config.setLogger(null)
     val ref = WeakReference<Any>(logger)


### PR DESCRIPTION
Summary:
Yoga test is failing after migration from java to kotlin due to the `testLoggerLeak` failing. The test creates a no-op `YogaLogger`, sets+unsets it on a config, drops all references, then asserts that a `WeakReference` to the logger gets cleared by GC. The Kotlin SAM lambda form (`YogaLogger { level, message -> }`) ends up with an implicit `this$0` capture of the enclosing test instance, so the logger never becomes weakly reachable and the test fails after 50 GC attempts.

Fix:
Replacing the SAM lambda with an explicit anonymous object expression to match what the Java version was doing.

Reviewed By: cortinico

Differential Revision: D108765169


