### PR TITLE
Update fast-uri to 3.1.1 to fix CVE-2026-6321 (#1981)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5358,9 +5358,9 @@ fast-levenshtein@^3.0.0:
     fastest-levenshtein "^1.0.7"
 
 fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.1.tgz#dd085fec2494a2a33bac6e61277374669e1dd774"
+  integrity sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==
 
 fastest-levenshtein@^1.0.7:
   version "1.0.16"


### PR DESCRIPTION
Summary:

Update the fast-uri transitive dependency from 3.1.0 to 3.1.1 in the yoga yarn.lock to remediate a high-severity security vulnerability (CVE-2026-6321, GHSA-q3j6-qgpj-74h6). fast-uri is a transitive dependency pulled in through ajv@8.18.0. The vulnerability affects versions <= 3.1.0 and is fixed in 3.1.1. Only the yarn.lock entry is changed — the version, resolved URL, and integrity hash are updated to match the published 3.1.1 package on npm.

Reviewed By: javache

Differential Revision: D104695957


