### PR TITLE
Bump ws to 8.20.1 in yoga yarn.lock (CVE-2026-45736) (#1982)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11415,9 +11415,9 @@ ws@^7.3.1:
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 ws@^8.13.0, ws@^8.19.0:
-  version "8.19.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.19.0.tgz#ddc2bdfa5b9ad860204f5a72a4863a8895fd8c8b"
-  integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
 
 xdg-basedir@^5.0.1, xdg-basedir@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
Summary:

Remediates a medium-severity security vulnerability in the `ws` npm package reported for the `facebook/yoga` repository (GHSA-58qx-3vcg-4xpx / CVE-2026-45736), which affects `ws >= 8.0.0, < 8.20.1`.

Updates the `ws@^8.13.0, ws@^8.19.0` entry in `xplat/yoga/yarn.lock` from `8.19.0` to the fixed `8.20.1`, including the new `resolved` URL and `integrity` hash from the npm registry. Both existing semver ranges are satisfied by `8.20.1`, so no `package.json` change is needed. `ws` is a transitive dependency.

The separate `ws@^7.3.1` (7.5.10) entry is below 8.0.0 and is not affected, so it is left unchanged.

Reviewed By: javache

Differential Revision: D108618638


