### PR TITLE
Bump @babel/plugin-transform-modules-systemjs to 7.29.4 (CVE-2026-44728) (#1984)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -883,9 +883,9 @@
     "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-modules-systemjs@^7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz#e458a95a17807c415924106a3ff188a3b8dee964"
-  integrity sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==
+  version "7.29.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz#f621105da99919c15cf4bde6fcc7346ef95e7b20"
+  integrity sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==
   dependencies:
     "@babel/helper-module-transforms" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"


### PR DESCRIPTION
Summary:

Remediates HIGH-severity advisory GHSA-fv7c-fp4j-7gwp / CVE-2026-44728 in `babel/plugin-transform-modules-systemjs` (affected `>= 7.12.0, <= 7.29.3`; fixed in `7.29.4`).

This is a transitive dependency pulled in via `babel/preset-env`. The existing semver selector `^7.29.0` already permits `7.29.4`, so this is a minimal lockfile-only edit in `xplat/yoga/yarn.lock`: bump `version`, `resolved`, and `integrity` for the single resolved entry. The `dependencies` block and the `registry.yarnpkg.com` host are unchanged, keeping the open-source lockfile consistent and avoiding an internal-registry rewrite.

Reviewed By: javache

Differential Revision: D110064496


