### PR TITLE
Bump tmp to 0.2.6 in yoga to fix GHSA-ph9p-34f9-6g65

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10693,9 +10693,9 @@ tinyglobby@^0.2.11:
     picomatch "^4.0.3"
 
 tmp@^0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
-  integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.6.tgz#0dfac10fd09a9319288eb0e8f0ed524604e183b4"
+  integrity sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Summary:
Resolves the GitHub security alert for the `tmp` npm package in the facebook/yoga project (T273208322).

`tmp` < 0.2.6 is affected by GHSA-ph9p-34f9-6g65 / CVE-2026-44705 (high severity). It is a transitive dependency pulled in via `selenium-webdriver` in the `gentest` workspace.

This bumps the `tmp@^0.2.5` entry in `xplat/yoga/yarn.lock` from 0.2.5 to the fixed 0.2.6, updating the resolved URL and integrity hash. The `^0.2.5` range already satisfies 0.2.6, and tmp@0.2.6 has no dependencies, so no other lockfile entries change.

Differential Revision: D110195946


