### PR TITLE
Bump qs to 6.15.2 in yoga (CVE-2026-8723)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typescript": "5.0.4"
   },
   "resolutions": {
-    "cliui/wrap-ansi": "7.0.0"
+    "cliui/wrap-ansi": "7.0.0",
+    "qs": "6.15.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9243,10 +9243,10 @@ pure-rand@^6.0.0:
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
   integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
 
-qs@~6.14.0:
-  version "6.14.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.2.tgz#b5634cf9d9ad9898e31fba3504e866e8efb6798c"
-  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
+qs@6.15.2, qs@~6.14.0:
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 


### PR DESCRIPTION
Summary:
Remediates GitHub security alert GHSA-q8mj-m7cp-5q26 / CVE-2026-8723 (medium severity) flagged on `facebook/yoga`.

`qs` is a transitive dependency (via `body-parser` and `express`) pinned to `6.14.2` through the `~6.14.0` range, which does not permit the fixed `6.15.2`. A plain lockfile bump is therefore insufficient, so a Yarn `resolutions` override is used to force `qs` to `6.15.2` across all dependents.

Changes:
- Add `"qs": "6.15.2"` to `resolutions` in `xplat/yoga/package.json`.
- Regenerate `xplat/yoga/yarn.lock` via `yarn install`, keeping the `registry.yarnpkg.com` host for open-source lockfile consistency.

Differential Revision: D110207476


